### PR TITLE
Add the "issuer fingerprint" subpacket type

### DIFF
--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -192,6 +192,7 @@ typedef enum pgpSubType_e {
     PGPSUBTYPE_REVOKE_REASON	=  29, /*!< reason for revocation */
     PGPSUBTYPE_FEATURES		=  30, /*!< feature flags (gpg) */
     PGPSUBTYPE_EMBEDDED_SIG	=  32, /*!< embedded signature (gpg) */
+    PGPSUBTYPE_ISSUER_FINGERPRINT= 33, /*!< issuer fingerprint */
 
     PGPSUBTYPE_INTERNAL_100	= 100, /*!< internal or user-defined */
     PGPSUBTYPE_INTERNAL_101	= 101, /*!< internal or user-defined */

--- a/rpmio/rpmpgpval.h
+++ b/rpmio/rpmpgpval.h
@@ -106,6 +106,7 @@ static struct pgpValTbl_s const pgpSubTypeTbl[] = {
     { PGPSUBTYPE_REVOKE_REASON,	"reason for revocation" },
     { PGPSUBTYPE_FEATURES,	"features" },
     { PGPSUBTYPE_EMBEDDED_SIG,	"embedded signature" },
+    { PGPSUBTYPE_ISSUER_FINGERPRINT,"issuer fingerprint" },
 
     { PGPSUBTYPE_INTERNAL_100,	"internal subpkt type 100" },
     { PGPSUBTYPE_INTERNAL_101,	"internal subpkt type 101" },


### PR DESCRIPTION
This subpacket is an alternative to the "issuer keyid" subpacket. It contains the pubkey version plus the complete fingerprint.

I would prefer to drop all the subpacket definitions from the rpm code, as rpm has no business dealing with subpackets. Unfortunately `pgpValString(PGPVAL_SUBTYPE, val)` is in the public API...