### PR TITLE
Switch most of rpm over to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(rpm
 	VERSION 5.99.90
 	DESCRIPTION "The RPM Package Manager"
 	HOMEPAGE_URL "http://rpm.org"
-	LANGUAGES C
+	LANGUAGES C CXX
 )
 
 # user configurable stuff
@@ -41,6 +41,8 @@ option(WITH_LIBELF "Build with libelf support" ON)
 option(WITH_LIBLZMA "Build with liblzma support" ON)
 option(WITH_DOXYGEN "Build API docs with doxygen" OFF)
 
+option(WITH_CXX "Build with C++" OFF)
+
 set(RPM_CONFIGDIR "${CMAKE_INSTALL_PREFIX}/lib/rpm" CACHE PATH "rpm home")
 set(RPM_MACROSDIR "${RPM_CONFIGDIR}/macros.d")
 set(RPM_VENDOR "vendor" CACHE STRING "rpm vendor string")
@@ -57,6 +59,10 @@ set(RPM_LIBVERSION ${RPM_SOVERSION}.0.0)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# extensions needed for typeof() hacks during transition
+set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_SHARED_MODULE_PREFIX "")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -394,9 +400,15 @@ configure_file(config.h.in config.h)
 
 add_compile_definitions(HAVE_CONFIG_H)
 
-add_compile_options(-Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wempty-body)
+add_compile_options(-Wall -Wpointer-arith -Wempty-body)
 if (ENABLE_WERROR)
 	add_compile_options(-Werror)
+endif()
+
+if (WITH_CXX)
+	set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -Wno-c++20-compat -Wno-sign-compare")
+else()
+	set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-prototypes -Wstrict-prototypes")
 endif()
 
 if (ENABLE_ASAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,6 @@ option(WITH_LIBELF "Build with libelf support" ON)
 option(WITH_LIBLZMA "Build with liblzma support" ON)
 option(WITH_DOXYGEN "Build API docs with doxygen" OFF)
 
-option(WITH_CXX "Build with C++" ON)
-
 set(RPM_CONFIGDIR "${CMAKE_INSTALL_PREFIX}/lib/rpm" CACHE PATH "rpm home")
 set(RPM_MACROSDIR "${RPM_CONFIGDIR}/macros.d")
 set(RPM_VENDOR "vendor" CACHE STRING "rpm vendor string")
@@ -405,11 +403,8 @@ if (ENABLE_WERROR)
 	add_compile_options(-Werror)
 endif()
 
-if (WITH_CXX)
-	set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -Wno-c++20-compat -Wno-sign-compare")
-else()
-	set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-prototypes -Wstrict-prototypes")
-endif()
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -Wno-c++20-compat -Wno-sign-compare")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-prototypes -Wstrict-prototypes")
 
 if (ENABLE_ASAN)
 	add_compile_options(-fsanitize=address)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ option(WITH_LIBELF "Build with libelf support" ON)
 option(WITH_LIBLZMA "Build with liblzma support" ON)
 option(WITH_DOXYGEN "Build API docs with doxygen" OFF)
 
-option(WITH_CXX "Build with C++" OFF)
+option(WITH_CXX "Build with C++" ON)
 
 set(RPM_CONFIGDIR "${CMAKE_INSTALL_PREFIX}/lib/rpm" CACHE PATH "rpm home")
 set(RPM_MACROSDIR "${RPM_CONFIGDIR}/macros.d")

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -49,7 +49,6 @@ if(OpenMP_C_FOUND)
 	target_link_libraries(librpmbuild PRIVATE OpenMP::OpenMP_C)
 endif()
 
-if (WITH_CXX)
 set (cxx_sources
 	build.c files.c misc.c pack.c
 	parseChangelog.c parseDescription.c parseFiles.c parseList.c
@@ -61,7 +60,6 @@ set (cxx_sources
 set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
 if (OpenMP_C_FOUND)
 	target_link_libraries(librpmbuild PRIVATE OpenMP::OpenMP_CXX)
-endif()
 endif()
 
 install(TARGETS librpmbuild EXPORT rpm-targets)

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -49,5 +49,19 @@ if(OpenMP_C_FOUND)
 	target_link_libraries(librpmbuild PRIVATE OpenMP::OpenMP_C)
 endif()
 
+if (WITH_CXX)
+set (cxx_sources
+	build.c files.c misc.c pack.c
+	parseChangelog.c parseDescription.c parseFiles.c parseList.c
+	parsePolicies.c parsePreamble.c parsePrep.c parseReq.c
+	parseScript.c parseSimpleScript.c parseSpec.c
+	policies.c reqprov.c rpmfc.c
+	spec.c speclua.c
+)
+set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
+if (OpenMP_C_FOUND)
+	target_link_libraries(librpmbuild PRIVATE OpenMP::OpenMP_CXX)
+endif()
+endif()
 
 install(TARGETS librpmbuild EXPORT rpm-targets)

--- a/build/build.c
+++ b/build/build.c
@@ -67,7 +67,7 @@ static char * buildHost(void)
     if (strcmp(bhMacro, "") != 0) {
         rasprintf(&hostname, "%s", bhMacro);
     } else {
-	hostname = rcalloc(NI_MAXHOST + 1, sizeof(*hostname));
+	hostname = (char *)rcalloc(NI_MAXHOST + 1, sizeof(*hostname));
 	if (gethostname(hostname, NI_MAXHOST) == 0) {
 	    struct addrinfo *ai, hints;
 	    memset(&hints, 0, sizeof(hints));

--- a/build/files.c
+++ b/build/files.c
@@ -360,7 +360,7 @@ static rpmRC parseForVerify(char * buf, int def, FileEntry entry)
     }
 
     /* Localize. Erase parsed string */
-    q = xmalloc((pe-p) + 1);
+    q = (char *)xmalloc((pe-p) + 1);
     rstrlcpy(q, p, (pe-p) + 1);
     while (p <= pe)
 	*p++ = ' ';
@@ -437,10 +437,10 @@ static rpmRC parseForDev(char * buf, FileEntry cur)
     }
 
     /* Localize. Erase parsed string */
-    q = xmalloc((pe-p) + 1);
+    q = (char *)xmalloc((pe-p) + 1);
     rstrlcpy(q, p, (pe-p) + 1);
 
-    attr_parameters = xmalloc((pe-p) + 1);
+    attr_parameters = (char *)xmalloc((pe-p) + 1);
     rstrlcpy(attr_parameters, p, (pe-p) + 1);
 
     while (p <= pe)
@@ -552,10 +552,10 @@ static rpmRC parseForAttr(rpmstrPool pool, char * buf, int def, FileEntry entry)
     }
 
     /* Localize. Erase parsed string */
-    q = xmalloc((pe-p) + 1);
+    q = (char *)xmalloc((pe-p) + 1);
     rstrlcpy(q, p, (pe-p) + 1);
 
-    attr_parameters = xmalloc((pe-p) + 1);
+    attr_parameters = (char *)xmalloc((pe-p) + 1);
     rstrlcpy(attr_parameters, p, (pe-p) + 1);
 
     while (p <= pe)
@@ -677,7 +677,7 @@ static rpmRC parseForConfig(char * buf, FileEntry cur)
     }
 
     /* Localize. Erase parsed string. */
-    q = xmalloc((pe-p) + 1);
+    q = (char *)xmalloc((pe-p) + 1);
     rstrlcpy(q, p, (pe-p) + 1);
     while (p <= pe)
 	*p++ = ' ';
@@ -765,7 +765,7 @@ static rpmRC parseForLang(char * buf, FileEntry cur)
     }
 
     /* Localize. Erase parsed string. */
-    q = xmalloc((pe-p) + 1);
+    q = (char *)xmalloc((pe-p) + 1);
     rstrlcpy(q, p, (pe-p) + 1);
     while (p <= pe)
 	*p++ = ' ';
@@ -826,7 +826,7 @@ static rpmRC parseForCaps(char * buf, FileEntry cur)
     }
 
     /* Localize. Erase parsed string. */
-    q = xmalloc((pe-p) + 1);
+    q = (char *)xmalloc((pe-p) + 1);
     rstrlcpy(q, p, (pe-p) + 1);
     while (p <= pe)
 	*p++ = ' ';
@@ -1121,7 +1121,7 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
 	      sizeof(*(fl->files.recs)), compareFileListRecs);
     }
     
-    pkg->dpaths = xmalloc((fl->files.used + 1) * sizeof(*pkg->dpaths));
+    pkg->dpaths = (char **)xmalloc((fl->files.used + 1) * sizeof(*pkg->dpaths));
 
     /* Generate the header. */
     for (i = 0, flp = fl->files.recs; i < fl->files.used; i++, flp++) {
@@ -1946,7 +1946,7 @@ static int generateBuildIDs(FileList fl, ARGV_t *files)
 			    addid = 1;
 			}
 			if (addid) {
-			    const unsigned char *p = build_id;
+			    const unsigned char *p = (const unsigned char *)build_id;
 			    const unsigned char *end = p + len;
 			    char *id_str;
 			    if (allocated <= nr_ids) {
@@ -1958,7 +1958,7 @@ static int generateBuildIDs(FileList fl, ARGV_t *files)
 			    }
 
 			    paths[nr_ids] = xstrdup(flp->cpioPath);
-			    id_str = ids[nr_ids] = xmalloc(2 * len + 1);
+			    id_str = ids[nr_ids] = (char *)xmalloc(2 * len + 1);
 			    while (p < end)
 				id_str += sprintf(id_str, "%02x",
 						  (unsigned)*p++);
@@ -2359,11 +2359,11 @@ static char * getSpecialDocDir(Header h, rpmFlags sdtype)
 
 static specialDir specialDirNew(Header h, rpmFlags sdtype)
 {
-    specialDir sd = xcalloc(1, sizeof(*sd));
+    specialDir sd = (specialDir)xcalloc(1, sizeof(*sd));
 
     sd->entriesCount = 0;
     sd->entriesAlloced = 10;
-    sd->entries = xcalloc(sd->entriesAlloced, sizeof(sd->entries[0]));
+    sd->entries = (struct FileEntries_s *)xcalloc(sd->entriesAlloced, sizeof(*(sd->entries)));
 
     sd->dirname = getSpecialDocDir(h, sdtype);
     sd->sdtype = sdtype;
@@ -2412,7 +2412,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     StringBuf docScript = newStringBuf();
     int count = sd->entriesCount;
     char *basepath = rpmGenPath(spec->rootDir, "%{builddir}", "%{?buildsubdir}");
-    ARGV_t *files = xmalloc(sizeof(*files) * count);
+    ARGV_t *files = (ARGV_t *)xmalloc(sizeof(*files) * count);
     int i, j;
 
     /* Glob and copy file entries from builddir to buildroot */
@@ -2732,7 +2732,7 @@ rpmRC processSourceFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags)
 	free(a);
     }
     fl.files.alloced = spec->numSources + 1;
-    fl.files.recs = xcalloc(fl.files.alloced, sizeof(*fl.files.recs));
+    fl.files.recs = (FileListRec)xcalloc(fl.files.alloced, sizeof(*fl.files.recs));
     fl.pkgFlags = pkgFlags;
 
     for (ARGV_const_t fp = files; *fp != NULL; fp++) {

--- a/build/misc.c
+++ b/build/misc.c
@@ -20,10 +20,10 @@ struct StringBufRec {
 
 StringBuf newStringBuf(void)
 {
-    StringBuf sb = xmalloc(sizeof(*sb));
+    StringBuf sb = (StringBuf)xmalloc(sizeof(*sb));
 
     sb->free = sb->allocated = BUF_CHUNK;
-    sb->buf = xcalloc(sb->allocated, sizeof(*sb->buf));
+    sb->buf = (char *)xcalloc(sb->allocated, sizeof(*sb->buf));
     sb->buf[0] = '\0';
     sb->tail = sb->buf;
     

--- a/build/pack.c
+++ b/build/pack.c
@@ -225,7 +225,7 @@ struct charInDepData {
 static rpmRC charInDepCb(void *cbdata, rpmrichParseType type,
 		const char *n, int nl, const char *e, int el, rpmsenseFlags sense,
 		rpmrichOp op, char **emsg) {
-    struct charInDepData *data = cbdata;
+    struct charInDepData *data = (struct charInDepData *)cbdata;
     if (e && data && memchr(e, data->c, el))
 	data->present = 1;
 
@@ -479,8 +479,8 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
     if (pkg->rpmver >= 6)
 	headerPutUint32(pkg->header, RPMTAG_RPMFORMAT, &(pkg->rpmver), 1);
 
-    /* Create a dummy payload digests + size to get the header size right */
-    pld = nullDigest(pld_algo, 1);
+    /* Create a dummy payload digests to get the header size right */
+    pld = (char *)nullDigest(pld_algo, 1);
     headerPutUint32(pkg->header, RPMTAG_PAYLOADDIGESTALGO, &pld_algo, 1);
     headerPutString(pkg->header, RPMTAG_PAYLOADDIGEST, pld);
     headerPutString(pkg->header, RPMTAG_PAYLOADDIGESTALT, pld);
@@ -513,10 +513,10 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
 
     /* Generate and write a placeholder signature header */
     if (pkg->rpmver < 6) {
-	SHA1 = nullDigest(RPM_HASH_SHA1, 1);
-	MD5 = nullDigest(RPM_HASH_MD5, 0);
+	SHA1 = (char *)nullDigest(RPM_HASH_SHA1, 1);
+	MD5 = (uint8_t *)nullDigest(RPM_HASH_MD5, 0);
     }
-    SHA256 = nullDigest(RPM_HASH_SHA256, 1);
+    SHA256 = (char *)nullDigest(RPM_HASH_SHA256, 1);
     if (rpmGenerateSignature(SHA256, SHA1, MD5, 0, 0, fd, pkg->rpmver))
 	goto exit;
     SHA1 = _free(SHA1);
@@ -778,7 +778,7 @@ rpmRC packageBinaries(rpmSpec spec, const char *cookie, int cheating)
 
     for (pkg = spec->packages; pkg != NULL; pkg = pkg->next)
         npkgs++;
-    tasks = xcalloc(npkgs, sizeof(Package));
+    tasks = (Package *)xcalloc(npkgs, sizeof(Package));
 
     pkg = spec->packages;
     for (int i = 0; i < npkgs; i++) {

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -135,7 +135,7 @@ static inline int parseYesNo(const char * s)
 
 static struct Source *newSource(uint32_t num, const char *path, int flags)
 {
-    struct Source *p = xmalloc(sizeof(*p));
+    struct Source *p = (struct Source *)xmalloc(sizeof(*p));
     p->num = num;
     p->fullSource = xstrdup(path);
     p->flags = flags;
@@ -632,7 +632,7 @@ static rpmRC addIcon(Package pkg, const char * file)
 	goto exit;
     }
 
-    icon = xmalloc(iconsize + 1);
+    icon = (uint8_t *)xmalloc(iconsize + 1);
     *icon = '\0';
 
     nb = Fread(icon, sizeof(icon[0]), iconsize, fd);

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -157,7 +157,7 @@ exit:
  */
 void doSetupMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed)
 {
-    rpmSpec spec = rpmMacroEntryPriv(me);
+    rpmSpec spec = (rpmSpec)rpmMacroEntryPriv(me);
     char *line = argvJoin(margs, " ");
     char *buf = NULL;
     StringBuf before = newStringBuf();
@@ -321,7 +321,7 @@ exit:
  */
 void doPatchMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed)
 {
-    rpmSpec spec = rpmMacroEntryPriv(me);
+    rpmSpec spec = (rpmSpec)rpmMacroEntryPriv(me);
     char *line = argvJoin(margs, " ");
     char *opt_b, *opt_d, *opt_o;
     int opt_p, opt_R, opt_E, opt_F, opt_Z;

--- a/build/parseReqs.c
+++ b/build/parseReqs.c
@@ -89,13 +89,13 @@ static rpmRC parseRCPOTRichCB(void *cbdata, rpmrichParseType type,
     } else if (type == RPMRICH_PARSE_LEAVE) {
 	appendStringBuf(sb, ")");
     } else if (type == RPMRICH_PARSE_SIMPLE) {
-	char *N = xmalloc(nl + 1);
+	char *N = (char *)xmalloc(nl + 1);
 	char *EVR = NULL;
 	rstrlcpy(N, n, nl + 1);
 	appendStringBuf(sb, N);
 	if (el) {
 	    char rel[6], *rp = rel;
-	    EVR = xmalloc(el + 1);
+	    EVR = (char *)xmalloc(el + 1);
 	    rstrlcpy(EVR, e, el + 1);
 	    *rp++ = ' ';
 	    if (sense & RPMSENSE_LESS)
@@ -240,7 +240,7 @@ rpmRC parseRCPOT(rpmSpec spec, Package pkg, const char *field, rpmTagVal tagN,
 
 	re = r;
 	SKIPNONWHITE(re);
-	N = xmalloc((re-r) + 1);
+	N = (char *)xmalloc((re-r) + 1);
 	rstrlcpy(N, r, (re-r) + 1);
 
 	/* Parse EVR */
@@ -267,7 +267,7 @@ rpmRC parseRCPOT(rpmSpec spec, Package pkg, const char *field, rpmTagVal tagN,
 		    rasprintf(&emsg, _("Version required"));
 		    goto exit;
 		}
-		EVR = xmalloc((ve-v) + 1);
+		EVR = (char *)xmalloc((ve-v) + 1);
 		rstrlcpy(EVR, v, (ve-v) + 1);
 		re = ve;	/* ==> next token after EVR string starts here */
 	    }

--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -47,7 +47,7 @@ static int addTriggerIndex(Package pkg, const char *file,
     if (last)
 	index = last->index + 1;
 
-    tfe = xcalloc(1, sizeof(*tfe));
+    tfe = (struct TriggerFileEntry *)xcalloc(1, sizeof(*tfe));
 
     tfe->fileName = (file) ? xstrdup(file) : NULL;
     tfe->script = (script && *script != '\0') ? xstrdup(script) : NULL;

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -149,7 +149,7 @@ int handleComments(char *s)
 static void ofilineMacro(rpmMacroBuf mb,
 			rpmMacroEntry me, ARGV_t margs, size_t *parsed)
 {
-    OFI_t *ofi = rpmMacroEntryPriv(me);
+    OFI_t *ofi = (OFI_t *)rpmMacroEntryPriv(me);
     if (ofi) {
 	char lnobuf[16];
 	snprintf(lnobuf, sizeof(lnobuf), "%d", ofi->lineNum);
@@ -160,13 +160,13 @@ static void ofilineMacro(rpmMacroBuf mb,
 /* Push a file to spec's file stack, return the newly pushed entry */
 static OFI_t * pushOFI(rpmSpec spec, const char *fn)
 {
-    OFI_t *ofi = xcalloc(1, sizeof(*ofi));
+    OFI_t *ofi = (OFI_t *)xcalloc(1, sizeof(*ofi));
 
     ofi->fp = NULL;
     ofi->fileName = xstrdup(fn);
     ofi->lineNum = 0;
     ofi->readBufLen = BUFSIZ;
-    ofi->readBuf = xmalloc(ofi->readBufLen);
+    ofi->readBuf = (char *)xmalloc(ofi->readBufLen);
     ofi->readBuf[0] = '\0';
     ofi->readPtr = NULL;
     ofi->next = spec->fileStack;
@@ -309,7 +309,7 @@ static int copyNextLineFromOFI(rpmSpec spec, OFI_t *ofi, int strip)
 
 	    if (spec->lbufOff >= spec->lbufSize) {
 		spec->lbufSize += BUFSIZ;
-		spec->lbuf = realloc(spec->lbuf, spec->lbufSize);
+		spec->lbuf = xrealloc(spec->lbuf, spec->lbufSize);
 	    }
 	}
 	spec->lbuf[spec->lbufOff] = '\0';
@@ -569,7 +569,7 @@ retry:
     }
 
     if (lineType->id & LINE_IFANY) {
-	rl = xmalloc(sizeof(*rl));
+	rl = (struct ReadLevelEntry *)xmalloc(sizeof(*rl));
 	rl->reading = spec->readStack->reading && match;
 	rl->next = spec->readStack;
 	rl->lineNum = ofi->lineNum;
@@ -1183,7 +1183,7 @@ static rpmRC parseSpecSection(rpmSpec *specptr, enum parseStages stage)
 
 	    closeSpec(spec);
 
-	    spec->BASpecs = xcalloc(spec->BACount, sizeof(*spec->BASpecs));
+	    spec->BASpecs = (rpmSpec *)xcalloc(spec->BACount, sizeof(*spec->BASpecs));
 	    index = 0;
 	    if (spec->BANames != NULL)
 	    for (x = 0; x < spec->BACount; x++) {

--- a/build/policies.c
+++ b/build/policies.c
@@ -162,7 +162,7 @@ static ModuleRec newModule(const char *path, const char *name,
 	return NULL;
     }
 
-    mod = xcalloc(1, sizeof(*mod));
+    mod = (ModuleRec)xcalloc(1, sizeof(*mod));
 
     mod->path = rpmGenPath(buildDir, NULL, path);
 

--- a/build/reqprov.c
+++ b/build/reqprov.c
@@ -44,7 +44,7 @@ rpmRC addReqProvPkg(void *cbdata, rpmTagVal tagN,
 		    const char * N, const char *EVR, rpmsenseFlags Flags,
 		    int index)
 {
-    Package pkg = cbdata;
+    Package pkg = (Package)cbdata;
     return addReqProv(pkg, tagN, N, EVR, Flags, index) ? RPMRC_FAIL : RPMRC_OK;
 }
 

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -144,7 +144,7 @@ static char *rpmfcAttrMacroV(const char *arg, va_list args)
     }
     blen += sizeof("}") - 1;
 
-    buf = xmalloc(blen + 1);
+    buf = (char *)xmalloc(blen + 1);
 
     pe = buf;
     pe = stpcpy(pe, "%{?_");
@@ -183,7 +183,7 @@ static regex_t *rpmfcAttrReg(const char *arg, ...)
     pattern = rpmfcAttrMacroV(arg, args);
     va_end(args);
     if (pattern) {
-	reg = xcalloc(1, sizeof(*reg));
+	reg = (regex_t *)xcalloc(1, sizeof(*reg));
 	if (regcomp(reg, pattern, REG_EXTENDED) != 0) { 
 	    rpmlog(RPMLOG_WARNING, _("Ignoring invalid regex %s\n"), pattern);
 	    reg = _free(reg);
@@ -195,7 +195,7 @@ static regex_t *rpmfcAttrReg(const char *arg, ...)
 
 static rpmfcAttr rpmfcAttrNew(const char *name)
 {
-    rpmfcAttr attr = xcalloc(1, sizeof(*attr));
+    rpmfcAttr attr = (rpmfcAttr)xcalloc(1, sizeof(*attr));
     struct matchRule *rules[] = { &attr->incl, &attr->excl, NULL };
 
     attr->name = xstrdup(name);
@@ -602,7 +602,7 @@ static rpmRC addReqProvFc(void *cbdata, rpmTagVal tagN,
 			  const char * N, const char * EVR, rpmsenseFlags Flags,
 			  int index)
 {
-    struct addReqProvDataFc *data = cbdata;
+    struct addReqProvDataFc *data = (struct addReqProvDataFc *)cbdata;
     rpmfc fc = data->fc;
     const char *namespc = data->namespc;
     regex_t *exclude = data->exclude;
@@ -686,8 +686,8 @@ static int rpmfcHelper(rpmfc fc, int *ixs, int n, const char *proto,
 		       const char *namespc, const char *mname)
 {
     int rc = 0;
-    const char **paths = xcalloc(n + 1, sizeof(*paths));
-    int *fnx = xmalloc(n * sizeof(*fnx));
+    const char **paths = (const char **)xcalloc(n + 1, sizeof(*paths));
+    int *fnx = (int *)xmalloc(n * sizeof(*fnx));
     int nfn = 0;
 
     for (int i = 0; i < n; i++) {
@@ -945,15 +945,15 @@ rpmfc rpmfcFree(rpmfc fc)
 
 rpmfc rpmfcCreate(const char *buildRoot, rpmFlags flags)
 {
-    rpmfc fc = xcalloc(1, sizeof(*fc));
+    rpmfc fc = (rpmfc)xcalloc(1, sizeof(*fc));
     if (buildRoot) {
 	fc->buildRoot = xstrdup(buildRoot);
 	fc->brlen = strlen(buildRoot);
     }
     fc->pool = rpmstrPoolCreate();
-    fc->pkg = xcalloc(1, sizeof(*fc->pkg));
+    fc->pkg = (Package)xcalloc(1, sizeof(*fc->pkg));
     fc->fileDeps.alloced = 10;
-    fc->fileDeps.data = xmalloc(fc->fileDeps.alloced *
+    fc->fileDeps.data = (rpmfcFileDep *)xmalloc(fc->fileDeps.alloced *
 	sizeof(fc->fileDeps.data[0]));
     return fc;
 }
@@ -1040,7 +1040,7 @@ static int cmpIndexDeps(const void *a, const void *b)
 static void rpmfcNormalizeFDeps(rpmfc fc)
 {
     rpmstrPool versionedDeps = rpmstrPoolCreate();
-    rpmfcFileDep *normalizedFDeps = xmalloc(fc->fileDeps.size *
+    rpmfcFileDep *normalizedFDeps = (rpmfcFileDep *)xmalloc(fc->fileDeps.size *
 	sizeof(normalizedFDeps[0]));
     int ix = 0;
     char *depStr;
@@ -1219,7 +1219,7 @@ static int initAttrs(rpmfc fc)
 
     /* Initialize attr objects */
     nattrs = argvCount(all_attrs);
-    fc->atypes = xcalloc(nattrs + 1, sizeof(*fc->atypes));
+    fc->atypes = (rpmfcAttr*)xcalloc(nattrs + 1, sizeof(*fc->atypes));
 
     for (int i = 0; i < nattrs; i++) {
 	fc->atypes[i] = rpmfcAttrNew(all_attrs[i]);
@@ -1306,11 +1306,11 @@ rpmRC rpmfcClassify(rpmfc fc, ARGV_t argv, rpm_mode_t * fmode)
     }
 
     fc->nfiles = argvCount(argv);
-    fc->fn = xcalloc(fc->nfiles, sizeof(*fc->fn));
-    fc->ftype = xcalloc(fc->nfiles, sizeof(*fc->ftype));
-    fc->fattrs = xcalloc(fc->nfiles, sizeof(*fc->fattrs));
-    fc->fcolor = xcalloc(fc->nfiles, sizeof(*fc->fcolor));
-    fc->fcdictx = xcalloc(fc->nfiles, sizeof(*fc->fcdictx));
+    fc->fn = (char **)xcalloc(fc->nfiles, sizeof(*fc->fn));
+    fc->ftype = (char **)xcalloc(fc->nfiles, sizeof(*fc->ftype));
+    fc->fattrs = (ARGV_t *)xcalloc(fc->nfiles, sizeof(*fc->fattrs));
+    fc->fcolor = (rpm_color_t *)xcalloc(fc->nfiles, sizeof(*fc->fcolor));
+    fc->fcdictx = (rpmsid *)xcalloc(fc->nfiles, sizeof(*fc->fcdictx));
     fc->fahash = fattrHashCreate(fc->nfiles / 3, intId, intCmp, NULL, NULL);
 
     /* Initialize the per-file dictionary indices. */
@@ -1701,7 +1701,7 @@ rpmRC rpmfcGenerateDepends(const rpmSpec spec, Package pkg)
 	goto exit;
 
     /* Extract absolute file paths in argv format. */
-    fmode = xcalloc(ac+1, sizeof(*fmode));
+    fmode = (rpm_mode_t *)xcalloc(ac+1, sizeof(*fmode));
 
     fc = rpmfcCreate(spec->buildRoot, 0);
     freePackage(fc->pkg);

--- a/build/spec.c
+++ b/build/spec.c
@@ -102,7 +102,7 @@ rpmRC lookupPackage(rpmSpec spec, const char *name, int flag,Package *pkg)
 
 Package newPackage(const char *name, rpmstrPool pool, Package *pkglist)
 {
-    Package p = xcalloc(1, sizeof(*p));
+    Package p = (Package)xcalloc(1, sizeof(*p));
     p->header = headerNew();
     p->autoProv = 1;
     p->autoReq = 1;
@@ -203,19 +203,19 @@ rpmds * packageDependencies(Package pkg, rpmTagVal tag)
 
 rpmSpec newSpec(void)
 {
-    rpmSpec spec = xcalloc(1, sizeof(*spec));
+    rpmSpec spec = (rpmSpec)xcalloc(1, sizeof(*spec));
     
     spec->specFile = NULL;
 
     spec->fileStack = NULL;
     spec->lbufSize = BUFSIZ * 10;
-    spec->lbuf = xmalloc(spec->lbufSize);
+    spec->lbuf = (char *)xmalloc(spec->lbufSize);
     spec->lbuf[0] = '\0';
     spec->line = spec->lbuf;
     spec->nextline = NULL;
     spec->nextpeekc = '\0';
     spec->lineNum = 0;
-    spec->readStack = xcalloc(1, sizeof(*spec->readStack));
+    spec->readStack = (struct ReadLevelEntry*)xcalloc(1, sizeof(*spec->readStack));
     spec->readStack->next = NULL;
     spec->readStack->reading = 1;
     spec->readStack->lastConditional = lineTypes;
@@ -342,7 +342,7 @@ struct rpmSpecIter_s {
 #define SPEC_LISTITER_INIT(_itertype, _iteritem)	\
     _itertype iter = NULL;				\
     if (spec) {						\
-	iter = xcalloc(1, sizeof(*iter));		\
+	iter = (_itertype)xcalloc(1, sizeof(*iter));		\
 	iter->next = spec->_iteritem;			\
     }							\
     return iter
@@ -350,7 +350,7 @@ struct rpmSpecIter_s {
 #define SPEC_LISTITER_NEXT(_valuetype)			\
     _valuetype item = NULL;				\
     if (iter) {						\
-	item = iter->next;				\
+	item = (_valuetype)iter->next;				\
 	iter->next = (item) ? item->next : NULL;	\
     }							\
     return item

--- a/build/speclua.c
+++ b/build/speclua.c
@@ -12,7 +12,7 @@ static const char * luavars[] = { "patches", "sources",
 void * specLuaInit(rpmSpec spec)
 {
     rpmlua lua = rpmluaGetGlobalState();
-    lua_State *L = rpmluaGetLua(lua);
+    lua_State *L = (lua_State *)rpmluaGetLua(lua);
     for (const char **vp = luavars; vp && *vp; vp++) {
 	lua_newtable(L);
 	lua_setglobal(L, *vp);
@@ -24,7 +24,7 @@ void * specLuaInit(rpmSpec spec)
 void * specLuaFini(rpmSpec spec)
 {
     rpmlua lua = rpmluaGetGlobalState();
-    lua_State *L = rpmluaGetLua(lua);
+    lua_State *L = (lua_State *)rpmluaGetLua(lua);
     for (const char **vp = luavars; vp && *vp; vp++) {
 	lua_pushnil(L);
 	lua_setglobal(L, *vp);
@@ -35,7 +35,7 @@ void * specLuaFini(rpmSpec spec)
 void addLuaSource(const struct Source *p)
 {
     rpmlua lua = rpmluaGetGlobalState();
-    lua_State *L = rpmluaGetLua(lua);
+    lua_State *L = (lua_State *)rpmluaGetLua(lua);
     const char * what = (p->flags & RPMBUILD_ISPATCH) ? "patches" : "sources";
 
     lua_getglobal(L, what);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,7 +57,6 @@ if(ENABLE_NDB)
 	)
 endif()
 
-if (WITH_CXX)
 # sources converted to c++ so far (avoid having to do everything at once)
 set (cxx_sources
 	cpio.c depends.c formats.c fprint.c fsm.c header.c
@@ -73,7 +72,6 @@ set (cxx_sources
 	backend/dummydb.c backend/sqlite.c backend/ndb/glue.c
 )
 set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
-endif()
 
 if(ENABLE_BDB_RO)
 	target_sources(librpm PRIVATE backend/bdb_ro.c)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,6 +57,24 @@ if(ENABLE_NDB)
 	)
 endif()
 
+if (WITH_CXX)
+# sources converted to c++ so far (avoid having to do everything at once)
+set (cxx_sources
+	cpio.c depends.c formats.c fprint.c fsm.c header.c
+	headerfmt.c headerutil.c manifest.c order.c package.c
+	poptALL.c poptI.c poptQV.c psm.c
+	query.c relocation.c rpmal.c rpmchecksig.c rpmchroot.c
+	rpmdb.c rpmds.c rpmfi.c rpmfs.c rpmgi.c rpminstall.c
+	rpmlead.c rpmlock.c rpmplugins.c rpmprob.c rpmps.c
+	rpmrc.c rpmscript.c rpmtd.c rpmte.c rpmtriggers.c
+	rpmts.c rpmug.c rpmvs.c signature.c tagexts.c tagname.c
+	transaction.c verify.c
+	backend/dbi.c backend/dbiset.c backend/bdb_ro.c
+	backend/dummydb.c backend/sqlite.c backend/ndb/glue.c
+)
+set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
+endif()
+
 if(ENABLE_BDB_RO)
 	target_sources(librpm PRIVATE backend/bdb_ro.c)
 endif()

--- a/lib/backend/dbi.c
+++ b/lib/backend/dbi.c
@@ -37,7 +37,7 @@ dbiIndex dbiFree(dbiIndex dbi)
 
 dbiIndex dbiNew(rpmdb rdb, rpmDbiTagVal rpmtag)
 {
-    dbiIndex dbi = xcalloc(1, sizeof(*dbi));
+    dbiIndex dbi = (dbiIndex)xcalloc(1, sizeof(*dbi));
     /* FIX: figger lib/dbi refcounts */
     dbi->dbi_rpmdb = rdb;
     dbi->dbi_file = rpmTagGetName(rpmtag);

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -6,7 +6,7 @@
 
 dbiIndexSet dbiIndexSetNew(unsigned int sizehint)
 {
-    dbiIndexSet set = xcalloc(1, sizeof(*set));
+    dbiIndexSet set = (dbiIndexSet)xcalloc(1, sizeof(*set));
     if (sizehint > 0)
 	dbiIndexSetGrow(set, sizehint);
     return set;
@@ -33,7 +33,8 @@ void dbiIndexSetGrow(dbiIndexSet set, unsigned int nrecs)
 
 static int hdrNumCmp(const void * one, const void * two)
 {
-    const struct dbiIndexItem_s *a = one, *b = two;
+    const struct dbiIndexItem_s *a = (const struct dbiIndexItem_s *)one;
+    const struct dbiIndexItem_s *b = (const struct dbiIndexItem_s *)two;
     if (a->hdrNum - b->hdrNum != 0)
 	return a->hdrNum - b->hdrNum;
     return a->tagNum - b->tagNum;

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -36,8 +36,8 @@ static void rpm_match3(sqlite3_context *sctx, int argc, sqlite3_value **argv)
 	int b2len = sqlite3_value_bytes(argv[1]);
 	int n = sqlite3_value_int(argv[2]);
 	if (b1len >= n && b2len >= n) {
-	    const char *b1 = sqlite3_value_blob(argv[0]);
-	    const char *b2 = sqlite3_value_blob(argv[1]);
+	    const void *b1 = sqlite3_value_blob(argv[0]);
+	    const void *b2 = sqlite3_value_blob(argv[1]);
 	    match = (memcmp(b1, b2, n) == 0);
 	}
     }
@@ -100,7 +100,7 @@ static rpmRC dbiCursorBindPkg(dbiCursor dbc, unsigned int hnum,
     return dbiCursorResult(dbc);
 }
 
-static rpmRC dbiCursorBindIdx(dbiCursor dbc, const void *key, int keylen,
+static rpmRC dbiCursorBindIdx(dbiCursor dbc, const char *key, int keylen,
 				dbiIndexItem rec)
 {
     int rc;
@@ -189,7 +189,7 @@ static int sqlite_fini(rpmdb rdb)
 {
     int rc = 0;
     if (rdb) {
-	sqlite3 *sdb = rdb->db_dbenv;
+	sqlite3 *sdb = (sqlite3 *)rdb->db_dbenv;
 	if (rdb->db_opens > 1) {
 	    rdb->db_opens--;
 	} else {
@@ -237,7 +237,7 @@ static int dbiExists(dbiIndex dbi)
 {
     const char *col = (dbi->dbi_type == DBI_PRIMARY) ? "hnum" : "key";
     const char *tbl = dbi->dbi_file;
-    int rc = sqlite3_table_column_metadata(dbi->dbi_db, NULL, tbl, col,
+    int rc = sqlite3_table_column_metadata((sqlite3 *)dbi->dbi_db, NULL, tbl, col,
 					   NULL, NULL, NULL, NULL, NULL);
     return (rc == 0);
 }
@@ -250,7 +250,7 @@ static int init_table(dbiIndex dbi, rpmTagVal tag)
 	return 0;
 
     if (dbi->dbi_type == DBI_PRIMARY) {
-	rc = sqlexec(dbi->dbi_db,
+	rc = sqlexec((sqlite3 *)dbi->dbi_db,
 			"CREATE TABLE IF NOT EXISTS '%q' ("
 			    "hnum INTEGER PRIMARY KEY AUTOINCREMENT,"
 			    "blob BLOB NOT NULL"
@@ -259,7 +259,7 @@ static int init_table(dbiIndex dbi, rpmTagVal tag)
     } else {
 	const char *keytype = (rpmTagGetClass(tag) == RPM_STRING_CLASS) ?
 				"TEXT" : "BLOB";
-	rc = sqlexec(dbi->dbi_db,
+	rc = sqlexec((sqlite3 *)dbi->dbi_db,
 			"CREATE TABLE IF NOT EXISTS '%q' ("
 			    "key '%q' NOT NULL, "
 			    "hnum INTEGER NOT NULL, "
@@ -286,16 +286,16 @@ static int init_index(dbiIndex dbi, rpmTagVal tag)
     int rc = 0;
 
     /* Can't create on readonly database, but things will still work */
-    if (sqlite3_db_readonly(dbi->dbi_db, NULL) == 1)
+    if (sqlite3_db_readonly((sqlite3 *)dbi->dbi_db, NULL) == 1)
 	return 0;
 
     if (dbi->dbi_type == DBI_SECONDARY) {
 	int string = (rpmTagGetClass(tag) == RPM_STRING_CLASS);
 	int array = (rpmTagGetReturnType(tag) == RPM_ARRAY_RETURN_TYPE);
 	if (!rc && string)
-	    rc = create_index(dbi->dbi_db, dbi->dbi_file, "key");
+	    rc = create_index((sqlite3 *)dbi->dbi_db, dbi->dbi_file, "key");
 	if (!rc && array)
-	    rc = create_index(dbi->dbi_db, dbi->dbi_file, "hnum");
+	    rc = create_index((sqlite3 *)dbi->dbi_db, dbi->dbi_file, "hnum");
     }
     return rc;
 }
@@ -343,7 +343,7 @@ static int sqlite_Verify(dbiIndex dbi, unsigned int flags)
     if (dbi->dbi_type == DBI_SECONDARY)
 	return RPMRC_OK;
 
-    if (sqlite3_prepare_v2(dbi->dbi_db, cmd, -1, &s, NULL) == SQLITE_OK) {
+    if (sqlite3_prepare_v2((sqlite3 *)dbi->dbi_db, cmd, -1, &s, NULL) == SQLITE_OK) {
 	errors = 0;
 	while (sqlite3_step(s) == SQLITE_ROW) {
 	    const char *txt = (const char *)sqlite3_column_text(s, 0);
@@ -354,7 +354,7 @@ static int sqlite_Verify(dbiIndex dbi, unsigned int flags)
 	}
 	sqlite3_finalize(s);
     } else {
-	rpmlog(RPMLOG_ERR, "%s: %s\n", cmd, sqlite3_errmsg(dbi->dbi_db));
+	rpmlog(RPMLOG_ERR, "%s: %s\n", cmd, sqlite3_errmsg((sqlite3 *)dbi->dbi_db));
     }
 
     /* No point checking higher-level errors if low-level errors exist */
@@ -362,7 +362,7 @@ static int sqlite_Verify(dbiIndex dbi, unsigned int flags)
 	goto exit;
 
     cmd = "PRAGMA foreign_key_check";
-    if (sqlite3_prepare_v2(dbi->dbi_db, cmd, -1, &s, NULL) == SQLITE_OK) {
+    if (sqlite3_prepare_v2((sqlite3 *)dbi->dbi_db, cmd, -1, &s, NULL) == SQLITE_OK) {
 	key_errors = 0;
 	while (sqlite3_step(s) == SQLITE_ROW) {
 	    key_errors++;
@@ -372,7 +372,7 @@ static int sqlite_Verify(dbiIndex dbi, unsigned int flags)
 	}
 	sqlite3_finalize(s);
     } else {
-	rpmlog(RPMLOG_ERR, "%s: %s\n", cmd, sqlite3_errmsg(dbi->dbi_db));
+	rpmlog(RPMLOG_ERR, "%s: %s\n", cmd, sqlite3_errmsg((sqlite3 *)dbi->dbi_db));
     }
 
 exit:
@@ -382,7 +382,7 @@ exit:
 
 static void sqlite_SetFSync(rpmdb rdb, int enable)
 {
-    sqlexec(rdb->db_dbenv,
+    sqlexec((sqlite3 *)rdb->db_dbenv,
 	    "PRAGMA synchronous = %s", enable ? "FULL" : "OFF");
 }
 
@@ -392,10 +392,10 @@ static int sqlite_Ctrl(rpmdb rdb, dbCtrlOp ctrl)
 
     switch (ctrl) {
     case DB_CTRL_LOCK_RW:
-	rc = sqlexec(rdb->db_dbenv, "SAVEPOINT 'rwlock'");
+	rc = sqlexec((sqlite3 *)rdb->db_dbenv, "SAVEPOINT 'rwlock'");
 	break;
     case DB_CTRL_UNLOCK_RW:
-	rc = sqlexec(rdb->db_dbenv, "RELEASE 'rwlock'");
+	rc = sqlexec((sqlite3 *)rdb->db_dbenv, "RELEASE 'rwlock'");
 	break;
     default:
 	break;
@@ -406,8 +406,8 @@ static int sqlite_Ctrl(rpmdb rdb, dbCtrlOp ctrl)
 
 static dbiCursor sqlite_CursorInit(dbiIndex dbi, unsigned int flags)
 {
-    dbiCursor dbc = xcalloc(1, sizeof(*dbc));
-    dbc->sdb = dbi->dbi_db;
+    dbiCursor dbc = (dbiCursor)xcalloc(1, sizeof(*dbc));
+    dbc->sdb = (sqlite3 *)dbi->dbi_db;
     dbc->flags = flags;
     dbc->tag = rpmTagGetValue(dbi->dbi_file);
     if (rpmTagGetClass(dbc->tag) == RPM_STRING_CLASS) {
@@ -491,7 +491,7 @@ static rpmRC sqlite_stepPkg(dbiCursor dbc, unsigned char **hdrBlob, unsigned int
 	if (hdrLen)
 	    *hdrLen = sqlite3_column_bytes(dbc->stmt, 1);
 	if (hdrBlob)
-	    *hdrBlob = (void *) sqlite3_column_blob(dbc->stmt, 1);
+	    *hdrBlob = (unsigned char *) sqlite3_column_blob(dbc->stmt, 1);
     }
 
     return (rc == SQLITE_DONE) ? RPMRC_NOTFOUND : dbiCursorResult(dbc);
@@ -605,7 +605,8 @@ static rpmRC sqlite_idxdbIter(dbiIndex dbi, dbiCursor dbc, dbiIndexSet *set)
 	    }
 	    dbc->keylen = sqlite3_column_bytes(dbc->stmt, 0);
 	    if (dbc->subc) {
-		rc = sqlite_idxdbByKey(dbi, dbc->subc, dbc->key, dbc->keylen,
+		rc = sqlite_idxdbByKey(dbi, dbc->subc,
+					(const char *)dbc->key, dbc->keylen,
 					DBC_NORMAL_SEARCH, set);
 	    } else {
 		rc = RPMRC_OK;

--- a/lib/cpio.c
+++ b/lib/cpio.c
@@ -83,7 +83,7 @@ rpmcpio_t rpmcpioOpen(FD_t fd, char mode)
         (mode & O_ACCMODE) != O_WRONLY)
         return NULL;
 
-    rpmcpio_t cpio = xcalloc(1, sizeof(*cpio));
+    rpmcpio_t cpio = (rpmcpio_t)xcalloc(1, sizeof(*cpio));
     cpio->fd = fdLink(fd);
     cpio->mode = mode;
     cpio->offset = 0;

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -852,7 +852,7 @@ static void checkInstDeps(rpmts ts, depCache dcache, rpmte te,
     if (depds)
 	dep = rpmdsN(depds);
     if (neg) {
-	ndep = rmalloc(strlen(dep) + 2);
+	ndep = (char *)xmalloc(strlen(dep) + 2);
 	ndep[0] = '!';
 	strcpy(ndep + 1, dep);
 	dep = ndep;

--- a/lib/formats.c
+++ b/lib/formats.c
@@ -61,7 +61,7 @@ static char * stringFormat(rpmtd td, char **emsg)
 	    break;
 	}
 	case RPM_BINARY_CLASS:
-	    val = rpmhex(td->data, td->count);
+	    val = rpmhex((uint8_t *)td->data, td->count);
 	    break;
 	default:
 	    *emsg = xstrdup("(unknown type)");
@@ -230,7 +230,7 @@ static char * armorFormat(rpmtd td, char **emsg)
 
     switch (rpmtdType(td)) {
     case RPM_BIN_TYPE:
-	s = td->data;
+	s = (const unsigned char *)td->data;
 	/* XXX HACK ALERT: element field abused as no. bytes of binary data. */
 	ns = td->count;
 	atype = PGPARMOR_SIGNATURE;	/* XXX check pkt for signature */
@@ -418,7 +418,7 @@ static char * pgpsigFormat(rpmtd td, char **emsg)
     char * val = NULL;
     pgpDigParams sigp = NULL;
 
-    if (pgpPrtParams(td->data, td->count, PGPTAG_SIGNATURE, &sigp)) {
+    if (pgpPrtParams((uint8_t*)td->data, td->count, PGPTAG_SIGNATURE, &sigp)) {
 	*emsg = xstrdup(_("(not an OpenPGP signature)"));
     } else {
 	char dbuf[BUFSIZ];
@@ -450,7 +450,7 @@ static char * depflagsFormat(rpmtd td, char **emsg)
 {
     char * val = NULL;
     uint64_t anint = rpmtdGetNumber(td);
-    val = xcalloc(4, 1);
+    val = (char *)xcalloc(4, 1);
 
     if (anint & RPMSENSE_LESS)
 	strcat(val, "<");
@@ -475,7 +475,7 @@ static char * fstateFormat(rpmtd td, char **emsg)
 {
     char * val = NULL;
     const char * str;
-    rpmfileState fstate = rpmtdGetNumber(td);
+    rpmfileState fstate = (rpmfileState)rpmtdGetNumber(td);
     switch (fstate) {
     case RPMFILE_STATE_NORMAL:
 	str = _("normal");

--- a/lib/fprint.c
+++ b/lib/fprint.c
@@ -92,7 +92,7 @@ fingerPrintCache fpCacheCreate(int sizeHint, rpmstrPool pool)
 {
     fingerPrintCache fpc;
 
-    fpc = xcalloc(1, sizeof(*fpc));
+    fpc = (fingerPrintCache)xcalloc(1, sizeof(*fpc));
     fpc->ht = rpmFpEntryHashCreate(sizeHint, sidHash, sidCmp,
 				   NULL, (rpmFpEntryHashFreeData)free);
     fpc->pool = (pool != NULL) ? rpmstrPoolLink(pool) : rpmstrPoolCreate();
@@ -179,7 +179,8 @@ static int doLookupId(fingerPrintCache cache,
 	if (cacheHit != NULL) {
 	    fp->entry = cacheHit;
 	} else if (!stat(rpmstrPoolStr(cache->pool, fpId), &sb)) {
-	    struct fprintCacheEntry_s * newEntry = xmalloc(sizeof(* newEntry));
+	    struct fprintCacheEntry_s * newEntry =
+		(struct fprintCacheEntry_s *)xmalloc(sizeof(* newEntry));
 
 	    newEntry->ino = sb.st_ino;
 	    newEntry->dev = sb.st_dev;
@@ -231,7 +232,7 @@ int fpLookup(fingerPrintCache cache,
              fingerPrint **fp)
 {
     if (*fp == NULL)
-	*fp = xcalloc(1, sizeof(**fp));
+	*fp = (fingerPrint *)xcalloc(1, sizeof(**fp));
     return doLookup(cache, dirName, baseName, *fp);
 }
 
@@ -240,7 +241,7 @@ int fpLookupId(fingerPrintCache cache,
                fingerPrint **fp)
 {
     if (*fp == NULL)
-	*fp = xcalloc(1, sizeof(**fp));
+	*fp = (fingerPrint *)xcalloc(1, sizeof(**fp));
     return doLookupId(cache, dirNameId, baseNameId, *fp);
 }
 
@@ -311,7 +312,7 @@ fingerPrint * fpLookupList(fingerPrintCache cache, rpmstrPool pool,
 		  const uint32_t * dirIndexes, 
 		  int fileCount)
 {
-    fingerPrint * fps = xmalloc(fileCount * sizeof(*fps));
+    fingerPrint * fps = (fingerPrint *)xmalloc(fileCount * sizeof(*fps));
     int i;
 
     /*

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -844,7 +844,7 @@ struct diriter_s {
 
 static int onChdir(rpmfi fi, void *data)
 {
-    struct diriter_s *di = data;
+    struct diriter_s *di = (struct diriter_s *)data;
 
     fsmClose(&(di->dirfd));
     return 0;
@@ -883,7 +883,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
     int nofcaps = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOCAPS) ? 1 : 0;
     int firstlinkfile = -1;
     char *tid = NULL;
-    struct filedata_s *fdata = xcalloc(fc, sizeof(*fdata));
+    struct filedata_s *fdata = (struct filedata_s *)xcalloc(fc, sizeof(*fdata));
     struct filedata_s *firstlink = NULL;
     struct diriter_s di = { -1, -1 };
 
@@ -1122,7 +1122,7 @@ int rpmPackageFilesRemove(rpmts ts, rpmte te, rpmfiles files,
     rpmPlugins plugins = rpmtsPlugins(ts);
     int fc = rpmfilesFC(files);
     int fx = -1;
-    struct filedata_s *fdata = xcalloc(fc, sizeof(*fdata));
+    struct filedata_s *fdata = (struct filedata_s *)xcalloc(fc, sizeof(*fdata));
     int rc = 0;
 
     while (!rc && (fx = rpmfiNext(fi)) >= 0) {

--- a/lib/headerfmt.c
+++ b/lib/headerfmt.c
@@ -434,7 +434,7 @@ static int parseFormat(headerSprintfArgs hsa, char * str,
 	if (*chptr == '%' || *chptr == '[') numTokens++;
     numTokens = numTokens * 2 + 1;
 
-    format = xcalloc(numTokens, sizeof(*format));
+    format = (sprintfToken)xcalloc(numTokens, sizeof(*format));
     if (endPtr) *endPtr = NULL;
 
     dst = start = str;

--- a/lib/headerutil.c
+++ b/lib/headerutil.c
@@ -200,8 +200,8 @@ int headerPutBin(Header h, rpmTagVal tag, const uint8_t *val, rpm_count_t size)
 
 static int dncmp(const void * a, const void * b)
 {
-    const char *const * first = a;
-    const char *const * second = b;
+    const char *const * first = (const char *const *)a;
+    const char *const * second = (const char *const *)b;
     return strcmp(*first, *second);
 }
 
@@ -232,9 +232,9 @@ static void compressFilelist(Header h)
     if (count < 1) 
 	return;
 
-    dirNames = xmalloc(sizeof(*dirNames) * count);	/* worst case */
-    baseNames = xmalloc(sizeof(*dirNames) * count);
-    dirIndexes = xmalloc(sizeof(*dirIndexes) * count);
+    dirNames = (char **)xmalloc(sizeof(*dirNames) * count);	/* worst case */
+    baseNames = (const char **)xmalloc(sizeof(*dirNames) * count);
+    dirIndexes = (uint32_t *)xmalloc(sizeof(*dirIndexes) * count);
 
     /* HACK. Source RPM, so just do things differently */
     {	const char *fn = rpmtdGetString(&fileNames);
@@ -276,8 +276,8 @@ static void compressFilelist(Header h)
 	savechar = *baseName;
 	*baseName = '\0';
 	if (dirIndex < 0 ||
-	    (needle = bsearch(&filename, dirNames, dirIndex + 1, sizeof(dirNames[0]), dncmp)) == NULL) {
-	    char *s = xmalloc(len + 1);
+	    (needle = (char **)bsearch(&filename, dirNames, dirIndex + 1, sizeof(dirNames[0]), dncmp)) == NULL) {
+	    char *s = (char *)xmalloc(len + 1);
 	    rstrlcpy(s, filename, len + 1);
 	    dirIndexes[realCount] = ++dirIndex;
 	    dirNames[dirIndex] = s;

--- a/lib/manifest.c
+++ b/lib/manifest.c
@@ -154,7 +154,7 @@ rpmRC rpmReadPackageManifest(FD_t fd, int * argcPtr, char *** argvPtr)
     /* Copy old arg list, inserting manifest before argv[next]. */
     if (argv != NULL) {
 	int nac = npre + ac;
-	char ** nav = xcalloc((nac + 1), sizeof(*nav));
+	char ** nav = (char **)xcalloc((nac + 1), sizeof(*nav));
 
 	for (i = 0, j = 0; i < next; i++) {
 	    if (argv[i] != NULL)

--- a/lib/order.c
+++ b/lib/order.c
@@ -156,7 +156,7 @@ static inline int addSingleRelation(rpmte p,
     /* bump p predecessor count */
     tsi_p->tsi_count++;
 
-    rel = xcalloc(1, sizeof(*rel));
+    rel = (relation)xcalloc(1, sizeof(*rel));
     rel->rel_suc = tsi_p;
     rel->rel_flags = flags;
 
@@ -167,7 +167,7 @@ static inline int addSingleRelation(rpmte p,
     /* bump q successor count */
     tsi_q->tsi_qcnt++;
 
-    rel = xcalloc(1, sizeof(*rel));
+    rel = (relation)xcalloc(1, sizeof(*rel));
     rel->rel_suc = tsi_q;
     rel->rel_flags = flags;
 
@@ -350,7 +350,8 @@ static void tarjan(sccData sd, tsortInfo tsi)
 	    } while (tsi_q != tsi);
 	    sd->SCCs[sd->sccCnt].size = sd->stackcnt - stackIdx;
 	    /* copy members */
-	    sd->SCCs[sd->sccCnt].members = xcalloc(sd->SCCs[sd->sccCnt].size,
+	    sd->SCCs[sd->sccCnt].members =
+				(tsortInfo *)xcalloc(sd->SCCs[sd->sccCnt].size,
 					   sizeof(tsortInfo));
 	    memcpy(sd->SCCs[sd->sccCnt].members, sd->stack + stackIdx,
 		   sd->SCCs[sd->sccCnt].size * sizeof(tsortInfo));
@@ -364,8 +365,8 @@ static void tarjan(sccData sd, tsortInfo tsi)
 static scc detectSCCs(tsortInfo orderInfo, int nelem, int debugloops)
 {
     /* Set up data structures needed for the tarjan algorithm */
-    scc SCCs = xcalloc(nelem+3, sizeof(*SCCs));
-    tsortInfo *stack = xcalloc(nelem, sizeof(*stack));
+    scc SCCs = (scc)xcalloc(nelem+3, sizeof(*SCCs));
+    tsortInfo *stack = (tsortInfo *)xcalloc(nelem, sizeof(*stack));
     struct sccData_s sd = { 0, stack, 0, SCCs, 2 };
 
     for (int i = 0; i < nelem; i++) {
@@ -468,7 +469,7 @@ static void dijkstra(const struct scc_s *SCC, int sccNr)
     relation rel;
 
     /* can use a simple queue as edge weights are always 1 */
-    tsortInfo * queue = xmalloc((SCC->size+1) * sizeof(*queue));
+    tsortInfo * queue = (tsortInfo *)xmalloc((SCC->size+1) * sizeof(*queue));
 
     /*
      * Find packages that are prerequired and use them as
@@ -583,7 +584,7 @@ int rpmtsOrder(rpmts ts)
     rpmal erasedPackages;
     scc SCCs;
     int nelem = rpmtsNElements(ts);
-    tsortInfo sortInfo = xcalloc(nelem, sizeof(struct tsortInfo_s));
+    tsortInfo sortInfo = (tsortInfo)xcalloc(nelem, sizeof(struct tsortInfo_s));
 
     (void) rpmswEnter(rpmtsOp(ts, RPMTS_OP_ORDER), 0);
 
@@ -620,7 +621,7 @@ int rpmtsOrder(rpmts ts)
 
     rpmtsiFree(pi);
 
-    newOrder = xcalloc(tsmem->orderCount, sizeof(*newOrder));
+    newOrder = (rpmte*)xcalloc(tsmem->orderCount, sizeof(*newOrder));
     SCCs = detectSCCs(sortInfo, nelem, (rpmtsFlags(ts) & RPMTRANS_FLAG_DEPLOOPS));
 
     rpmlog(RPMLOG_DEBUG, "========== tsorting packages (order, #predecessors, #succesors, depth)\n");

--- a/lib/package.c
+++ b/lib/package.c
@@ -155,7 +155,7 @@ exit:
 
 static int handleHdrVS(struct rpmsinfo_s *sinfo, void *cbdata)
 {
-    struct pkgdata_s *pkgdata = cbdata;
+    struct pkgdata_s *pkgdata = (struct pkgdata_s *)cbdata;
 
     if (pkgdata->msgfunc) {
 	char *vsmsg = rpmsinfoMsg(sinfo);

--- a/lib/poptALL.c
+++ b/lib/poptALL.c
@@ -200,7 +200,7 @@ static void rpmcliAllArgCallback( poptContext con,
 struct poptOption rpmcliAllPoptTable[] = {
 /* FIX: cast? */
  { NULL, '\0', POPT_ARG_CALLBACK | POPT_CBFLAG_INC_DATA | POPT_CBFLAG_CONTINUE,
-        rpmcliAllArgCallback, 0, NULL, NULL },
+        (void *)rpmcliAllArgCallback, 0, NULL, NULL },
 
  { "debug", 'd', POPT_ARG_VAL|POPT_ARGFLAG_DOC_HIDDEN, &_debug, -1,
         NULL, NULL },

--- a/lib/poptI.c
+++ b/lib/poptI.c
@@ -113,7 +113,7 @@ static void installArgCallback( poptContext con,
 struct poptOption rpmInstallPoptTable[] = {
 /* FIX: cast? */
  { NULL, '\0', POPT_ARG_CALLBACK | POPT_CBFLAG_INC_DATA | POPT_CBFLAG_CONTINUE,
-	installArgCallback, 0, NULL, NULL },
+	(void *)installArgCallback, 0, NULL, NULL },
 
  { "allfiles", '\0', POPT_BIT_SET,
 	&rpmIArgs.transFlags, RPMTRANS_FLAG_ALLFILES,

--- a/lib/poptQV.c
+++ b/lib/poptQV.c
@@ -78,7 +78,7 @@ static void rpmQVSourceArgCallback( poptContext con,
 struct poptOption rpmQVSourcePoptTable[] = {
 /* FIX: cast? */
  { NULL, '\0', POPT_ARG_CALLBACK | POPT_CBFLAG_INC_DATA, 
-	rpmQVSourceArgCallback, 0, NULL, NULL },
+	(void *)rpmQVSourceArgCallback, 0, NULL, NULL },
  { "all", 'a', 0, 0, 'a',
 	N_("query/verify all packages"), NULL },
  { "checksig", 'K', POPT_ARGFLAG_DOC_HIDDEN, NULL, 'K',
@@ -224,7 +224,7 @@ struct poptOption rpmQVFilePoptTable[] = {
  */
 struct poptOption rpmQueryPoptTable[] = {
  { NULL, '\0', POPT_ARG_CALLBACK | POPT_CBFLAG_INC_DATA | POPT_CBFLAG_CONTINUE,
-	queryArgCallback, 0, NULL, NULL },
+	(void *)queryArgCallback, 0, NULL, NULL },
  { "dump", '\0', 0, 0, POPT_DUMP,
 	N_("dump basic file information"), NULL },
  { NULL, 'i', POPT_ARGFLAG_DOC_HIDDEN, 0, 'i',
@@ -246,7 +246,7 @@ struct poptOption rpmQueryPoptTable[] = {
 struct poptOption rpmVerifyPoptTable[] = {
 /* FIX: cast? */
  { NULL, '\0', POPT_ARG_CALLBACK | POPT_CBFLAG_INC_DATA | POPT_CBFLAG_CONTINUE, 
-	queryArgCallback, 0, NULL, NULL },
+	(void *)queryArgCallback, 0, NULL, NULL },
 
  { "nofiledigest", '\0', 0, NULL, RPMCLI_POPT_NOFILEDIGEST,
 	N_("don't verify digest of files"), NULL },

--- a/lib/rpmal.c
+++ b/lib/rpmal.c
@@ -96,13 +96,13 @@ static void rpmalFreeIndex(rpmal al)
 
 rpmal rpmalCreate(rpmts ts, int delta)
 {
-    rpmal al = xcalloc(1, sizeof(*al));
+    rpmal al = (rpmal)xcalloc(1, sizeof(*al));
 
     al->pool = rpmstrPoolLink(rpmtsPool(ts));
     al->delta = delta;
     al->size = 0;
     al->alloced = al->delta;
-    al->list = xmalloc(sizeof(*al->list) * al->alloced);
+    al->list = (availablePackage)xmalloc(sizeof(*al->list) * al->alloced);
 
     al->providesHash = NULL;
     al->obsoletesHash = NULL;
@@ -348,7 +348,7 @@ rpmte * rpmalAllObsoletes(rpmal al, rpmds ds)
 	availablePackage alp;
 	int rc, found = 0;
 
-	ret = xmalloc((resultCnt+1) * sizeof(*ret));
+	ret = (rpmte *)xmalloc((resultCnt+1) * sizeof(*ret));
 
 	for (int i = 0; i < resultCnt; i++) {
 	    alp = al->list + result[i].pkgNum;
@@ -400,7 +400,7 @@ static rpmte * rpmalAllFileSatisfiesDepend(const rpmal al, const char *fileName,
 
 	if (resultCnt > 0) {
 	    int i, found;
-	    ret = xmalloc((resultCnt+1) * sizeof(*ret));
+	    ret = (rpmte *)xmalloc((resultCnt+1) * sizeof(*ret));
 	    fingerPrint * fp = NULL;
 	    rpmsid dirName = rpmstrPoolIdn(al->pool, fileName, bnStart, 1);
 
@@ -473,7 +473,7 @@ rpmte * rpmalAllSatisfiesDepend(const rpmal al, const rpmds ds)
 
     if (resultCnt==0) return NULL;
 
-    ret = xmalloc((resultCnt+1) * sizeof(*ret));
+    ret = (rpmte *)xmalloc((resultCnt+1) * sizeof(*ret));
 
     for (found=i=0; i<resultCnt; i++) {
 	alp = al->list + result[i].pkgNum;

--- a/lib/rpmchecksig.c
+++ b/lib/rpmchecksig.c
@@ -126,7 +126,7 @@ struct vfydata_s {
 
 static int vfyCb(struct rpmsinfo_s *sinfo, void *cbdata)
 {
-    struct vfydata_s *vd = cbdata;
+    struct vfydata_s *vd = (struct vfydata_s *)cbdata;
     vd->seen |= sinfo->type;
     if (sinfo->rc != RPMRC_OK)
 	vd->bad |= sinfo->type;

--- a/lib/rpmdb_internal.h
+++ b/lib/rpmdb_internal.h
@@ -114,7 +114,7 @@ const char *rpmdbHome(rpmdb db);
  * @return		0 on success
  */
 int rpmdbExtendIterator(rpmdbMatchIterator mi,
-			const void * keyp, size_t keylen);
+			const char * keyp, size_t keylen);
 
 /** \ingroup rpmdb
  * sort the iterator by (recnum, filenum)
@@ -171,7 +171,7 @@ rpmdbMatchIterator rpmdbNewIterator(rpmdb db, rpmDbiTagVal dbitag);
  */
 RPM_GNUC_INTERNAL
 rpmdbMatchIterator rpmdbInitPrefixIterator(rpmdb db, rpmDbiTagVal rpmtag,
-					const void * pfx, size_t plen);
+					const char* pfx, size_t plen);
 /** \ingroup rpmdb
  * Get package offsets of entries
  * @param ii		index iterator

--- a/lib/rpmfs.c
+++ b/lib/rpmfs.c
@@ -18,11 +18,11 @@ struct rpmfs_s {
 
 rpmfs rpmfsNew(rpm_count_t fc, int initState)
 {
-    rpmfs fs = xcalloc(1, sizeof(*fs));
+    rpmfs fs = (rpmfs)xcalloc(1, sizeof(*fs));
     fs->fc = fc;
-    fs->actions = xcalloc(fs->fc, sizeof(*fs->actions));
+    fs->actions = (rpmFileAction *)xcalloc(fs->fc, sizeof(*fs->actions));
     if (initState) {
-	fs->states = xmalloc(sizeof(*fs->states) * fs->fc);
+	fs->states = (rpm_fstate_t *)xmalloc(sizeof(*fs->states) * fs->fc);
 	memset(fs->states, RPMFILE_STATE_NORMAL, fs->fc);
     }
     return fs;
@@ -49,7 +49,7 @@ void rpmfsAddReplaced(rpmfs fs, int pkgFileNum, char rstate,
 			int otherPkg, int otherFileNum)
 {
     if (!fs->replaced) {
-	fs->replaced = xcalloc(3, sizeof(*fs->replaced));
+	fs->replaced = (sharedFileInfo)xcalloc(3, sizeof(*fs->replaced));
 	fs->allocatedReplaced = 3;
     }
     if (fs->numReplaced>=fs->allocatedReplaced) {

--- a/lib/rpmgi.c
+++ b/lib/rpmgi.c
@@ -205,7 +205,7 @@ rpmgi rpmgiFree(rpmgi gi)
 
 rpmgi rpmgiNew(rpmts ts, rpmgiFlags flags, ARGV_const_t argv)
 {
-    rpmgi gi = xcalloc(1, sizeof(*gi));
+    rpmgi gi = (rpmgi)xcalloc(1, sizeof(*gi));
 
     gi->ts = rpmtsLink(ts);
 

--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -417,7 +417,7 @@ static int rpmNoGlob(const char *fn, int *argcPtr, ARGV_t * argvPtr)
 /** @todo Generalize --freshen policies. */
 int rpmInstall(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_t fileArgv)
 {
-    struct rpmEIU * eiu = xcalloc(1, sizeof(*eiu));
+    struct rpmEIU * eiu = (struct rpmEIU *)xcalloc(1, sizeof(*eiu));
     rpmRelocation * relocations;
     char * fileURL = NULL;
     rpmVSFlags vsflags, ovsflags;

--- a/lib/rpmplugins.c
+++ b/lib/rpmplugins.c
@@ -49,7 +49,7 @@ int rpmpluginsPluginAdded(rpmPlugins plugins, const char *name)
 
 rpmPlugins rpmpluginsNew(rpmts ts)
 {
-    rpmPlugins plugins = xcalloc(1, sizeof(*plugins));
+    rpmPlugins plugins = (rpmPlugins)xcalloc(1, sizeof(*plugins));
     plugins->ts = ts;
     return plugins;
 }
@@ -80,13 +80,13 @@ static rpmPlugin rpmPluginNew(const char *name, const char *path,
     hooks_name = rstrscat(NULL, name, "_hooks", NULL);
     /* clear out any old errors that weren't fetched */
     dlerror();
-    hooks = dlsym(handle, hooks_name);
+    hooks = (rpmPluginHooks)dlsym(handle, hooks_name);
     if ((error = dlerror()) != NULL) {
 	rpmlog(RPMLOG_ERR, _("Failed to resolve symbol %s: %s\n"),
 	       hooks_name, error);
 	mydlclose(handle);
     } else {
-	plugin = xcalloc(1, sizeof(*plugin));
+	plugin = (rpmPlugin)xcalloc(1, sizeof(*plugin));
 	plugin->name = xstrdup(name);
 	plugin->handle = handle;
 	plugin->hooks = hooks;

--- a/lib/rpmprob.c
+++ b/lib/rpmprob.c
@@ -29,7 +29,7 @@ rpmProblem rpmProblemCreate(rpmProblemType type,
                             const char * altNEVR,
                             const char * str, uint64_t number)
 {
-    rpmProblem p = xcalloc(1, sizeof(*p));
+    rpmProblem p = (rpmProblem)xcalloc(1, sizeof(*p));
 
     p->type = type;
     p->key = key;

--- a/lib/rpmps.c
+++ b/lib/rpmps.c
@@ -53,7 +53,7 @@ rpmpsi rpmpsInitIterator(rpmps ps)
 {
     rpmpsi psi = NULL;
     if (ps != NULL && ps->numProblems > 0) {
-	psi = xcalloc(1, sizeof(*psi));
+	psi = (rpmpsi)xcalloc(1, sizeof(*psi));
 	psi->ps = rpmpsLink(ps);
 	psi->ix = -1;
     }
@@ -99,7 +99,7 @@ rpmProblem rpmpsGetProblem(rpmpsi psi)
 
 rpmps rpmpsCreate(void)
 {
-    rpmps ps = xcalloc(1, sizeof(*ps));
+    rpmps ps = (rpmps)xcalloc(1, sizeof(*ps));
     return rpmpsLink(ps);
 }
 

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -265,7 +265,7 @@ static int machCompatCacheAdd(char * name, const char * fn, int linenum,
 	    entry->equivs = xrealloc(entry->equivs, sizeof(*entry->equivs)
 					* (entry->count + 1));
 	else
-	    entry->equivs = xmalloc(sizeof(*entry->equivs));
+	    entry->equivs = (char **)xmalloc(sizeof(*entry->equivs));
 
 	entry->equivs[entry->count] = xstrdup(chptr);
 	entry->count++;
@@ -297,7 +297,7 @@ static void machAddEquiv(machEquivTable table, const char * name,
 	    table->list = xrealloc(table->list, (table->count + 1)
 				    * sizeof(*table->list));
 	else
-	    table->list = xmalloc(sizeof(*table->list));
+	    table->list = (machEquivInfo)xmalloc(sizeof(*table->list));
 
 	table->list[table->count].name = xstrdup(name);
 	table->list[table->count++].score = distance;
@@ -557,8 +557,8 @@ static rpmRC doReadRC(rpmrcCtx ctx, const char * urlfn)
 
 	/* Find keyword in table */
 	searchOption.name = s;
-	option = bsearch(&searchOption, optionTable, optionTableSize,
-			 sizeof(optionTable[0]), optionCompare);
+	option = (struct rpmOption *)bsearch(&searchOption, optionTable,
+			optionTableSize, sizeof(optionTable[0]), optionCompare);
 
 	if (option) {	/* For configuration variables  ... */
 	    const char *arch, *val;
@@ -609,7 +609,7 @@ static rpmRC doReadRC(rpmrcCtx ctx, const char * urlfn)
 	    if (option->macroize &&
 	      (arch == NULL || rstreq(arch, ctx->current[ARCH]))) {
 		char *n, *name;
-		n = name = xmalloc(strlen(option->name)+2);
+		n = name = (char *)xmalloc(strlen(option->name)+2);
 		if (option->localize)
 		    *n++ = '_';
 		strcpy(n, option->name);
@@ -1509,7 +1509,7 @@ static void rpmSetVarArch(rpmrcCtx ctx,
 	    next->value = _free(next->value);
 	    next->arch = _free(next->arch);
 	} else if (next->arch || arch) {
-	    next->next = xmalloc(sizeof(*next->next));
+	    next->next = (struct rpmvarValue *)xmalloc(sizeof(*next->next));
 	    next = next->next;
 	    next->value = NULL;
 	    next->arch = NULL;

--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -108,7 +108,7 @@ static const struct scriptInfo_s * findTag(rpmTagVal tag)
 
 static int next_file(lua_State *L)
 {
-    scriptNextFileFunc nff = lua_touserdata(L, lua_upvalueindex(1));
+    scriptNextFileFunc nff = (scriptNextFileFunc)lua_touserdata(L, lua_upvalueindex(1));
     lua_pushstring(L, nff->func(nff->param));
     return 1;
 }
@@ -139,7 +139,7 @@ static rpmRC runLuaScript(rpmPlugins plugins, ARGV_const_t prefixes,
     char *scriptbuf = NULL;
     rpmRC rc = RPMRC_FAIL;
     rpmlua lua = rpmluaGetGlobalState();
-    lua_State *L = rpmluaGetLua(lua);
+    lua_State *L = (lua_State *)rpmluaGetLua(lua);
     int cwd = -1;
 
     rpmlog(RPMLOG_DEBUG, "%s: running <lua> scriptlet.\n", sname);
@@ -525,7 +525,7 @@ static rpmScript rpmScriptNew(Header h, rpmTagVal tag, const char *body,
 			      rpmscriptFlags flags, const char *prefix)
 {
     char *nevra = headerGetAsString(h, RPMTAG_NEVRA);
-    rpmScript script = xcalloc(1, sizeof(*script));
+    rpmScript script = (rpmScript)xcalloc(1, sizeof(*script));
     script->tag = tag;
     script->type = getScriptType(tag);
     script->flags = getDefFlags(tag) | flags;
@@ -553,7 +553,7 @@ static rpmScript rpmScriptNew(Header h, rpmTagVal tag, const char *body,
 void rpmScriptSetNextFileFunc(rpmScript script, nextfilefunc func,
 			    void *param)
 {
-    script->nextFileFunc = xmalloc(sizeof(*script->nextFileFunc));
+    script->nextFileFunc = (struct scriptNextFileFunc_s *)xmalloc(sizeof(*script->nextFileFunc));
     script->nextFileFunc->func = func;
     script->nextFileFunc->param = param;
 }
@@ -655,7 +655,7 @@ rpmScript rpmScriptFromTriggerTag(Header h, rpmTagVal triggerTag,
 				rpmtdGetString(&tscripts), sflags, prefix);
 
 	/* hack up a hge-style NULL-terminated array */
-	script->args = xmalloc(2 * sizeof(*script->args) + strlen(prog) + 1);
+	script->args = (char **)xmalloc(2 * sizeof(*script->args) + strlen(prog) + 1);
 	script->args[0] = (char *)(script->args + 2);
 	script->args[1] = NULL;
 	strcpy(script->args[0], prog);
@@ -694,7 +694,7 @@ rpmScript rpmScriptFromTag(Header h, rpmTagVal scriptTag)
 			      headerGetNumber(h, getFlagTag(scriptTag)), "");
 
 	if (headerGet(h, progTag, &prog, (HEADERGET_ALLOC|HEADERGET_ARGV))) {
-	    script->args = prog.data;
+	    script->args = (char **)prog.data;
 	}
     }
     return script;

--- a/lib/rpmtd.c
+++ b/lib/rpmtd.c
@@ -9,7 +9,7 @@
 
 rpmtd rpmtdNew(void)
 {
-    rpmtd td = xmalloc(sizeof(*td));
+    rpmtd td = (rpmtd)xmalloc(sizeof(*td));
     rpmtdReset(td);
     return td;
 }
@@ -36,7 +36,7 @@ void rpmtdFreeData(rpmtd td)
 {
     if (td && td->data && td->flags & RPMTD_ALLOCED) {
 	if (td->flags & RPMTD_PTR_ALLOCED) {
-	    char **data = td->data;
+	    char **data = (char **)td->data;
 	    for (int i = 0; i < td->count; i++) {
 		free(data[i]);
 	    }
@@ -431,7 +431,7 @@ rpmtd rpmtdDup(rpmtd td)
     newtd->flags &= ~(RPMTD_IMMUTABLE);
 
     newtd->flags |= (RPMTD_ALLOCED | RPMTD_PTR_ALLOCED);
-    newtd->data = data = xmalloc(td->count * sizeof(*data));
+    newtd->data = data = (char **)xmalloc(td->count * sizeof(*data));
     while ((i = rpmtdNext(td)) >= 0) {
 	data[i] = xstrdup(rpmtdGetString(td));
     }
@@ -444,11 +444,11 @@ rpmsid * rpmtdToPool(rpmtd td, rpmstrPool pool)
     rpmsid *sids = NULL;
 
     if (pool && td) {
-	const char **strings = td->data;
+	const char **strings = (const char **)td->data;
 	switch (td->type) {
 	case RPM_STRING_ARRAY_TYPE:
 	case RPM_I18NSTRING_TYPE:
-	    sids = xmalloc(td->count * sizeof(*sids));
+	    sids = (rpmsid *)xmalloc(td->count * sizeof(*sids));
 	    for (rpm_count_t i = 0; i < td->count; i++)
 		sids[i] = rpmstrPoolId(pool, strings[i], 1);
 	    break;

--- a/lib/rpmte.c
+++ b/lib/rpmte.c
@@ -265,7 +265,7 @@ rpmte rpmteFree(rpmte te)
 rpmte rpmteNew(rpmts ts, Header h, rpmElementType type, fnpyKey key,
 	       rpmRelocation * relocs, int addop)
 {
-    rpmte p = xcalloc(1, sizeof(*p));
+    rpmte p = (rpmte)xcalloc(1, sizeof(*p));
     p->ts = ts;
     p->type = type;
     p->addop = addop;
@@ -307,8 +307,7 @@ Header rpmteSetHeader(rpmte te, Header h)
 
 rpmElementType rpmteType(rpmte te)
 {
-    /* XXX returning negative for unsigned type */
-    return (te != NULL ? te->type : -1);
+    return te->type;
 }
 
 const char * rpmteN(rpmte te)
@@ -502,7 +501,7 @@ static void rpmteColorDS(rpmte te, rpmTag tag)
     if (!(te && deptype && (Count = rpmdsCount(ds)) > 0 && rpmfilesFC(te->files) > 0))
 	return;
 
-    colors = xcalloc(Count, sizeof(*colors));
+    colors = (rpm_color_t *)xcalloc(Count, sizeof(*colors));
 
     /* Calculate dependency color. */
     fi = rpmfilesIter(te->files, RPMFI_ITER_FWD);
@@ -550,7 +549,7 @@ static Header rpmteDBHeader(rpmte te)
 static Header rpmteFDHeader(rpmte te)
 {
     Header h = NULL;
-    te->fd = rpmtsNotify(te->ts, te, RPMCALLBACK_INST_OPEN_FILE, 0, 0);
+    te->fd = (FD_t)rpmtsNotify(te->ts, te, RPMCALLBACK_INST_OPEN_FILE, 0, 0);
     if (te->fd != NULL) {
 	rpmVSFlags ovsflags;
 	rpmRC pkgrc;

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -190,14 +190,15 @@ rpmdbMatchIterator rpmtsInitIterator(const rpmts ts, rpmDbiTagVal rpmtag,
 	loadKeyring(ts);
 
     /* Parse out "N(EVR)" tokens from a label key if present */
-    if (rpmtag == RPMDBI_LABEL && keyp != NULL && strchr(keyp, '(')) {
-	const char *se, *s = keyp;
+    const char *s = (const char *)keyp;
+    if (rpmtag == RPMDBI_LABEL && keyp != NULL && strchr(s, '(')) {
+	const char *se;
 	char *t;
 	size_t slen = strlen(s);
 	int level = 0;
 	int c;
 
-	tmp = xmalloc(slen+1);
+	tmp = (char *)xmalloc(slen+1);
 	keyp = t = tmp;
 	while ((c = *s++) != '\0') {
 	    switch (c) {
@@ -1189,11 +1190,10 @@ static int vfylevel_init(void)
 
 rpmts rpmtsCreate(void)
 {
-    rpmts ts;
+    rpmts ts = (rpmts)xcalloc(1, sizeof(*ts));
     tsMembers tsmem;
     char *source_date_epoch = NULL;
 
-    ts = xcalloc(1, sizeof(*ts));
     memset(&ts->ops, 0, sizeof(ts->ops));
     (void) rpmswEnter(rpmtsOp(ts, RPMTS_OP_TOTAL), -1);
     ts->dsi = NULL;
@@ -1241,7 +1241,7 @@ rpmts rpmtsCreate(void)
 	free(tmp);
     }
 
-    tsmem = xcalloc(1, sizeof(*ts->members));
+    tsmem = (tsMembers)xcalloc(1, sizeof(*ts->members));
     tsmem->pool = NULL;
     tsmem->delta = 5;
     tsmem->addedPackages = NULL;
@@ -1297,7 +1297,7 @@ rpmtsi rpmtsiInit(rpmts ts)
 {
     rpmtsi tsi = NULL;
 
-    tsi = xcalloc(1, sizeof(*tsi));
+    tsi = (rpmtsi)xcalloc(1, sizeof(*tsi));
     tsi->ts = rpmtsLink(ts);
     tsi->oc = 0;
     return tsi;
@@ -1364,7 +1364,7 @@ rpmtxn rpmtxnBegin(rpmts ts, rpmtxnFlags flags)
 	ts->lock = rpmlockNew(ts->lockPath, _("transaction"));
 
     if (rpmlockAcquire(ts->lock)) {
-	txn = xcalloc(1, sizeof(*txn));
+	txn = (rpmtxn)xcalloc(1, sizeof(*txn));
 	txn->lock = ts->lock;
 	txn->flags = flags;
 	txn->ts = rpmtsLink(ts);

--- a/lib/rpmug.c
+++ b/lib/rpmug.c
@@ -130,7 +130,7 @@ static int lookup_str(const char *path, long val, int vcol, int rcol,
 static void rpmugInit(void)
 {
     if (rpmug == NULL)
-	rpmug = xcalloc(1, sizeof(*rpmug));
+	rpmug = (struct rpmug_s *)xcalloc(1, sizeof(*rpmug));
 }
 
 /* 

--- a/lib/signature.c
+++ b/lib/signature.c
@@ -116,7 +116,7 @@ rpmRC rpmGenerateSignature(char *SHA256, char *SHA1, uint8_t *MD5,
     Header sig = headerNew();
     struct rpmtd_s td;
     rpmRC rc = RPMRC_OK;
-    char *reservedSpace;
+    uint8_t *reservedSpace;
     int spaceSize = 32; /* always reserve a bit of space */
     int gpgSize = rpmExpandNumeric("%{__gpg_reserved_space}");
     rpm_off_t size32 = size;
@@ -206,7 +206,7 @@ reserve:
 	spaceSize += gpgSize;
 
     if (spaceSize > 0) {
-	reservedSpace = xcalloc(spaceSize, sizeof(char));
+	reservedSpace = (uint8_t *)xcalloc(spaceSize, sizeof(char));
 	rpmtdReset(&td);
 	td.tag = reserveTag;
 	td.count = spaceSize;

--- a/lib/tagname.c
+++ b/lib/tagname.c
@@ -239,7 +239,7 @@ int rpmTagGetNames(rpmtd tagnames, int fullname)
 
     rpmtdReset(tagnames);
     tagnames->count = rpmTagTableSize;
-    tagnames->data = names = xmalloc(tagnames->count * sizeof(*names));
+    tagnames->data = names = (const char **)xmalloc(tagnames->count * sizeof(*names));
     tagnames->type = RPM_STRING_ARRAY_TYPE;
     tagnames->flags = RPMTD_ALLOCED | RPMTD_IMMUTABLE;
 

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -126,7 +126,7 @@ static int getRotational(const char *dirName, dev_t dev)
 static int rpmtsInitDSI(const rpmts ts)
 {
     ts->dsi = _free(ts->dsi);
-    ts->dsi = xcalloc(1, sizeof(*ts->dsi));
+    ts->dsi = (rpmDiskSpaceInfo)xcalloc(1, sizeof(*ts->dsi));
     return 0;
 }
 
@@ -837,7 +837,7 @@ static void skipInstallFiles(const rpmts ts, rpmfiles files, rpmfs fs)
     int noDocs = (rpmtsFlags(ts) & RPMTRANS_FLAG_NODOCS);
     int noArtifacts = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOARTIFACTS);
     int * drc;
-    char * dff;
+    uint8_t * dff;
     int dc;
     int i, j, ix;
     rpmfi fi = rpmfilesIter(files, RPMFI_ITER_FWD);
@@ -847,8 +847,8 @@ static void skipInstallFiles(const rpmts ts, rpmfiles files, rpmfs fs)
 
     /* Compute directory refcount, skip directory if now empty. */
     dc = rpmfiDC(fi);
-    drc = xcalloc(dc, sizeof(*drc));
-    dff = xcalloc(dc, sizeof(*dff));
+    drc = (int *)xcalloc(dc, sizeof(*drc));
+    dff = (uint8_t *)xcalloc(dc, sizeof(*dff));
 
     fi = rpmfiInit(fi, 0);
     while ((i = rpmfiNext(fi)) >= 0) {
@@ -1233,7 +1233,7 @@ struct vfydata_s {
 
 static int vfyCb(struct rpmsinfo_s *sinfo, void *cbdata)
 {
-    struct vfydata_s *vd = cbdata;
+    struct vfydata_s *vd = (struct vfydata_s *)cbdata;
 
     if (sinfo->type & RPMSIG_VERIFIABLE_TYPE && sinfo->rc != RPMRC_NOTFOUND) {
 	int res = (sinfo->rc != RPMRC_OK);
@@ -1291,7 +1291,7 @@ static int verifyPackageFiles(rpmts ts, rpm_loff_t total)
 	int prc = RPMRC_FAIL;
 
 	rpmtsNotify(ts, p, RPMCALLBACK_VERIFY_PROGRESS, oc++, total);
-	FD_t fd = rpmtsNotify(ts, p, RPMCALLBACK_INST_OPEN_FILE, 0, 0);
+	FD_t fd = (FD_t)rpmtsNotify(ts, p, RPMCALLBACK_INST_OPEN_FILE, 0, 0);
 	if (fd != NULL) {
 	    prc = rpmpkgRead(vs, fd, NULL, NULL, &vd.msg);
 	    rpmtsNotify(ts, p, RPMCALLBACK_INST_CLOSE_FILE, 0, 0);
@@ -1634,7 +1634,7 @@ static int rpmtsProcess(rpmts ts)
 	rpmlog(RPMLOG_DEBUG, "========== +++ %s %s-%s 0x%x\n",
 		rpmteNEVR(p), rpmteA(p), rpmteO(p), rpmteColor(p));
 
-	failed = rpmteProcess(p, rpmteType(p), i++);
+	failed = rpmteProcess(p, (pkgGoal)rpmteType(p), i++);
 	if (failed) {
 	    rpmlog(RPMLOG_ERR, "%s: %s %s\n", rpmteNEVRA(p),
 		   rpmteTypeString(p), failed > 1 ? _("skipped") : _("failed"));
@@ -1709,7 +1709,7 @@ rpmRC runScript(rpmts ts, rpmte te, Header h, ARGV_const_t prefixes,
 	rpmteSetHeader(te, h);
     }
 
-    sfd = rpmtsNotify(ts, te, RPMCALLBACK_SCRIPT_START, stag, 0);
+    sfd = (FD_t)rpmtsNotify(ts, te, RPMCALLBACK_SCRIPT_START, stag, 0);
     if (sfd == NULL)
 	sfd = rpmtsScriptFd(ts);
 

--- a/lib/verify.c
+++ b/lib/verify.c
@@ -276,7 +276,7 @@ char * rpmVerifyString(uint32_t verifyResult, const char *pad)
 char * rpmFFlagsString(uint32_t fflags)
 {
     char *fmt, *p;
-    fmt = p = xmalloc(10);
+    fmt = p = (char *)xmalloc(10);
     if ((fflags & RPMFILE_DOC))
         *p++ = 'd';
     if ((fflags & RPMFILE_CONFIG))

--- a/misc/rpmhash.C
+++ b/misc/rpmhash.C
@@ -68,9 +68,9 @@ HASHTYPE HASHPREFIX(Create)(int numBuckets,
 {
     HASHTYPE ht;
 
-    ht = xmalloc(sizeof(*ht));
+    ht = (HASHTYPE)xmalloc(sizeof(*ht));
     ht->numBuckets = numBuckets > 11 ? numBuckets : 11;
-    ht->buckets = xcalloc(ht->numBuckets, sizeof(*ht->buckets));
+    ht->buckets = (Bucket *)xcalloc(ht->numBuckets, sizeof(*ht->buckets));
     ht->freeKey = freeKey;
 #ifdef HTDATATYPE
     ht->freeData = freeData;
@@ -83,7 +83,7 @@ HASHTYPE HASHPREFIX(Create)(int numBuckets,
 }
 
 static void HASHPREFIX(Resize)(HASHTYPE ht, int numBuckets) {
-    Bucket * buckets = xcalloc(numBuckets, sizeof(*ht->buckets));
+    Bucket * buckets = (Bucket *)xcalloc(numBuckets, sizeof(*ht->buckets));
 
     for (int i=0; i<ht->numBuckets; i++) {
 	Bucket b = ht->buckets[i];
@@ -131,7 +131,7 @@ void HASHPREFIX(AddHEntry)(HASHTYPE ht, HTKEYTYPE key, unsigned int keyHash
 
     if (b == NULL) {
 	ht->keyCount += 1;
-	b = xmalloc(sizeof(*b));
+	b = (Bucket)xmalloc(sizeof(*b));
 	b->key = key;
 #ifdef HTDATATYPE
 	b->dataCount = 1;

--- a/misc/system.h
+++ b/misc/system.h
@@ -29,10 +29,12 @@ extern char ** environ;
 #endif
 #endif
 
+#ifndef __cplusplus
 #if defined(HAVE_SECURE_GETENV)
 #define	getenv(_s)	secure_getenv(_s)
 #elif defined(HAVE___SECURE_GETENV)
 #define	getenv(_s)	__secure_getenv(_s)
+#endif
 #endif
 
 #ifdef HAVE_LIMITS_H
@@ -58,10 +60,16 @@ extern int fdatasync(int fildes);
 #define xmalloc(_size) rmalloc((_size))
 #define xmallocn(_nmemb, _size) rreallocn(NULL, (_nmemb), (_size))
 #define xcalloc(_nmemb, _size) rcalloc((_nmemb), (_size))
+#define xstrdup(_str) rstrdup((_str))
+#ifdef __cplusplus
+#define xrealloc(_ptr, _size) (typeof((_ptr))) rrealloc((_ptr), (_size))
+#define xreallocn(_ptr, _nmemb, _size) (typeof((_ptr))) rreallocn((_ptr), (_nmemb), (_size))
+#define _free(_ptr) (typeof((_ptr))) rfree((_ptr))
+#else
 #define xrealloc(_ptr, _size) rrealloc((_ptr), (_size))
 #define xreallocn(_ptr, _nmemb, _size) rreallocn((_ptr), (_nmemb), (_size))
-#define xstrdup(_str) rstrdup((_str))
 #define _free(_ptr) rfree((_ptr))
+#endif
 
 /* To extract program's name: use calls (reimplemented or shipped with system):
    - void setprogname(const char *pn)

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -38,6 +38,18 @@ else()
 	endif()
 endif()
 
+if (WITH_CXX)
+set (cxx_sources
+	argv.c base64.c digest.c expression.c lposix.c macro.c
+	digest_libgcrypt.c digest_openssl.c
+	rgetopt.c rpmfileutil.c rpmglob.c rpmhook.c rpmio.c
+	rpmkeyring.c rpmlog.c rpmlua.c rpmpgp.c rpm_sequoia.c rpmsq.c
+	rpmsw.c rpmstring.c rpmstrpool.c
+	rpmver.c rpmvercmp.c url.c
+)
+set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
+endif()
+
 set_target_properties(librpmio PROPERTIES
 	VERSION ${RPM_LIBVERSION}
 	SOVERSION ${RPM_SOVERSION}

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -38,7 +38,6 @@ else()
 	endif()
 endif()
 
-if (WITH_CXX)
 set (cxx_sources
 	argv.c base64.c digest.c expression.c lposix.c macro.c
 	digest_libgcrypt.c digest_openssl.c
@@ -48,7 +47,6 @@ set (cxx_sources
 	rpmver.c rpmvercmp.c url.c
 )
 set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
-endif()
 
 set_target_properties(librpmio PROPERTIES
 	VERSION ${RPM_LIBVERSION}

--- a/rpmio/argv.c
+++ b/rpmio/argv.c
@@ -27,7 +27,7 @@ void argvPrint(const char * msg, ARGV_const_t argv, FILE * fp)
 
 ARGV_t argvNew(void)
 {
-    ARGV_t argv = xcalloc(1, sizeof(*argv));
+    ARGV_t argv = (ARGV_t)xcalloc(1, sizeof(*argv));
     return argv;
 }
 
@@ -104,7 +104,7 @@ ARGV_t argvSearch(ARGV_const_t argv, const char *val,
 	return NULL;
     if (compar == NULL)
 	compar = argvCmp;
-    return bsearch(&val, argv, argvCount(argv), sizeof(*argv), compar);
+    return (ARGV_t)bsearch(&val, argv, argvCount(argv), sizeof(*argv), compar);
 }
 
 int argiAdd(ARGI_t * argip, int ix, int val)
@@ -114,7 +114,7 @@ int argiAdd(ARGI_t * argip, int ix, int val)
     if (argip == NULL)
 	return -1;
     if (*argip == NULL)
-	*argip = xcalloc(1, sizeof(**argip));
+	*argip = (ARGI_t)xcalloc(1, sizeof(**argip));
     argi = *argip;
     if (ix < 0)
 	ix = argi->nvals;
@@ -186,7 +186,7 @@ ARGV_t argvSplitString(const char * str, const char * seps, argvFlags flags)
     if (str == NULL || seps == NULL)
 	return NULL;
 
-    dest = xmalloc(strlen(str) + 1);
+    dest = (char *)xmalloc(strlen(str) + 1);
     for (argc = 1, s = str, t = dest; (c = *s); s++, t++) {
 	if (strchr(seps, c)) {
 	    argc++;
@@ -196,7 +196,7 @@ ARGV_t argvSplitString(const char * str, const char * seps, argvFlags flags)
     }
     *t = '\0';
 
-    argv = xmalloc( (argc + 1) * sizeof(*argv));
+    argv = (ARGV_t)xmalloc( (argc + 1) * sizeof(*argv));
 
     for (c = 0, s = dest; s < t; s+= strlen(s) + 1) {
 	if (*s == '\0' && (flags & ARGV_SKIPEMPTY))
@@ -235,7 +235,7 @@ char *argvJoin(ARGV_const_t argv, const char *sep)
 	size_t seplen = (sep != NULL) ? strlen(sep) : 0;
 	char *p;
 
-	dest = xmalloc(argvlen + (seplen * (argc - 1)) + 1);
+	dest = (char *)xmalloc(argvlen + (seplen * (argc - 1)) + 1);
 
 	p = stpcpy(dest, argv[0]);
 	for (int i = 1; i < argc; i++) {

--- a/rpmio/base64.c
+++ b/rpmio/base64.c
@@ -61,7 +61,7 @@ static char *base64_encode_block(const char *plaintext_in, int length_in, char *
 char *rpmBase64Encode(const void *data, size_t len, int linelen)
 {
 	size_t encodedlen;
-	const char *dataptr = data;
+	const char *dataptr = (const char *)data;
 	char *output;
 	char *outptr;
 	
@@ -78,7 +78,7 @@ char *rpmBase64Encode(const void *data, size_t len, int linelen)
 	}
 	++encodedlen; /* for zero termination */
 
-	output = malloc(encodedlen);
+	output = (char *)malloc(encodedlen);
 	if (output == NULL)
 		return NULL;
 		
@@ -189,12 +189,12 @@ int rpmBase64Decode(const char *in, void **out, size_t *outlen)
 	
 	outcnt = (outcnt / 4) * 3;
 	
-	*out = malloc(outcnt + 1); /* base64_decode_block can write one extra character */
+	*out = (char *)malloc(outcnt + 1); /* base64_decode_block can write one extra character */
 	
 	if (*out == NULL)
 		return 4;
 	
-	*outlen = base64_decode_block(in, inptr - in, *out);
+	*outlen = base64_decode_block(in, inptr - in, (char *)*out);
 
 	return 0;
 }

--- a/rpmio/digest.c
+++ b/rpmio/digest.c
@@ -34,7 +34,7 @@ static int findID(rpmDigestBundle bundle, int id)
 
 rpmDigestBundle rpmDigestBundleNew(void)
 {
-    rpmDigestBundle bundle = xcalloc(1, sizeof(*bundle));
+    rpmDigestBundle bundle = (rpmDigestBundle)xcalloc(1, sizeof(*bundle));
     return bundle;
 }
 

--- a/rpmio/digest_libgcrypt.c
+++ b/rpmio/digest_libgcrypt.c
@@ -80,7 +80,7 @@ DIGEST_CTX rpmDigestInit(int hashalgo, rpmDigestFlags flags)
     if (!gcryalgo || gcry_md_open(&h, gcryalgo, 0) != 0)
 	return NULL;
 
-    ctx = xcalloc(1, sizeof(*ctx));
+    ctx = (DIGEST_CTX)xcalloc(1, sizeof(*ctx));
     ctx->flags = flags;
     ctx->algo = hashalgo;
     ctx->h = h;
@@ -129,7 +129,7 @@ DIGEST_CTX rpmDigestDup(DIGEST_CTX octx)
         gcry_md_hd_t h;
 	if (gcry_md_copy(&h, octx->h))
 	    return NULL;
-	nctx = memcpy(xcalloc(1, sizeof(*nctx)), octx, sizeof(*nctx));
+	nctx = (DIGEST_CTX)memcpy(xcalloc(1, sizeof(*nctx)), octx, sizeof(*nctx));
 	nctx->h = h;
     }
     return nctx;

--- a/rpmio/digest_openssl.c
+++ b/rpmio/digest_openssl.c
@@ -31,7 +31,7 @@ DIGEST_CTX rpmDigestDup(DIGEST_CTX octx)
     if (!octx) return NULL;
 
     DIGEST_CTX nctx = NULL;
-    nctx = xcalloc(1, sizeof(*nctx));
+    nctx = (DIGEST_CTX)xcalloc(1, sizeof(*nctx));
 
     nctx->flags = octx->flags;
     nctx->algo = octx->algo;
@@ -83,7 +83,7 @@ size_t rpmDigestLength(int hashalgo)
 
 DIGEST_CTX rpmDigestInit(int hashalgo, rpmDigestFlags flags)
 {
-    DIGEST_CTX ctx = xcalloc(1, sizeof(*ctx));
+    DIGEST_CTX ctx = (DIGEST_CTX)xcalloc(1, sizeof(*ctx));
 
     ctx->md_ctx = EVP_MD_CTX_new();
     if (!ctx->md_ctx) {
@@ -121,13 +121,13 @@ int rpmDigestUpdate(DIGEST_CTX ctx, const void *data, size_t len)
 int rpmDigestFinal(DIGEST_CTX ctx, void ** datap, size_t *lenp, int asAscii)
 {
     int ret;
-    unsigned char *digest = NULL;
+    uint8_t *digest = NULL;
     unsigned int digestlen;
 
     if (ctx == NULL) return -1;
 
     digestlen = EVP_MD_CTX_size(ctx->md_ctx);
-    digest = xcalloc(digestlen, sizeof(*digest));
+    digest = (uint8_t *)xcalloc(digestlen, sizeof(*digest));
 
     ret = EVP_DigestFinal_ex(ctx->md_ctx, digest, &digestlen);
     if (ret != 1) goto done;

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -281,7 +281,7 @@ static char *getValuebuf(ParseState state, const char *p, size_t size)
     char *temp;
     if ((state->flags & RPMEXPR_DISCARD) != 0)
 	size = 0;
-    temp = xmalloc(size + 1);
+    temp = (char *)xmalloc(size + 1);
     memcpy(temp, p, size);
     temp[size] = '\0';
     if (size && (state->flags & RPMEXPR_EXPAND) != 0) {
@@ -531,7 +531,7 @@ static Value doLuaFunction(ParseState state, const char *name, int argc, Value *
     if (state->flags & RPMEXPR_DISCARD)
 	return valueMakeString(xstrdup(""));
     args = rpmhookArgsNew(argc);
-    argt = xmalloc(argc + 1);
+    argt = (char *)xmalloc(argc + 1);
     for (i = 0; i < argc; i++) {
 	switch (argv[i]->type) {
 	    case VALUE_TYPE_INTEGER:
@@ -796,7 +796,7 @@ static Value doAddSubtract(ParseState state)
         goto err;
       }
 
-      copy = xmalloc(strlen(v1->data.s) + strlen(v2->data.s) + 1);
+      copy = (char *)xmalloc(strlen(v1->data.s) + strlen(v2->data.s) + 1);
       (void) stpcpy( stpcpy(copy, v1->data.s), v2->data.s);
 
       valueSetString(v1, copy);

--- a/rpmio/lposix.c
+++ b/rpmio/lposix.c
@@ -200,7 +200,7 @@ static int Pdir(lua_State *L)			/** dir([path]) */
 
 static int aux_files(lua_State *L)
 {
-	DIR *d = lua_touserdata(L, lua_upvalueindex(1));
+	DIR *d = (DIR *)lua_touserdata(L, lua_upvalueindex(1));
 	struct dirent *entry;
 	if (d == NULL) return luaL_error(L, "attempt to use closed dir");
 	entry = readdir(d);
@@ -346,7 +346,7 @@ static int Pexec(lua_State *L)			/** exec(path,[args]) */
 
 	rpmSetCloseOnExec();
 
-	argv = malloc((n+1)*sizeof(char*));
+	argv = (char **)malloc((n+1)*sizeof(char*));
 	if (argv==NULL) return luaL_error(L,"not enough memory");
 	argv[0] = (char*)path;
 	for (i=1; i<n; i++) argv[i] = (char*)luaL_checkstring(L, i+1);
@@ -399,8 +399,8 @@ static int Pputenv(lua_State *L)		/** putenv(string) */
 #ifdef HAVE_PUTENV
 	size_t l;
 	const char *s=luaL_checklstring(L, 1, &l);
-	char *e=malloc(++l);
-	return pushresult(L, (e==NULL) ? -1 : putenv(memcpy(e,s,l)), s);
+	char *e=(char *)malloc(++l);
+	return pushresult(L, (e==NULL) ? -1 : putenv((char *)memcpy(e,s,l)), s);
 #else
 	return -1;
 #endif
@@ -563,7 +563,7 @@ static int Pgetlogin(lua_State *L)		/** getlogin() */
 
 static int Fgetpasswd(lua_State *L, int i, const void *data)
 {
-	const struct passwd *p=data;
+	const struct passwd *p= (const struct passwd *)data;
 	switch (i)
 	{
 		case 0: lua_pushstring(L, p->pw_name); break;
@@ -648,7 +648,7 @@ struct mytimes
 
 static int Ftimes(lua_State *L, int i, const void *data)
 {
-	const struct mytimes *t=data;
+	const struct mytimes *t=(const struct mytimes *)data;
 	switch (i)
 	{
 		case 0: pushtime(L, t->t.tms_utime); break;
@@ -684,7 +684,7 @@ struct mystat
 
 static int Fstat(lua_State *L, int i, const void *data)
 {
-	const struct mystat *s=data;
+	const struct mystat *s=(const struct mystat *)data;
 	switch (i)
 	{
 		case 0: lua_pushstring(L, s->mode); break;
@@ -755,7 +755,7 @@ static const int Kpathconf[] =
 
 static int Fpathconf(lua_State *L, int i, const void *data)
 {
-	const char *path=data;
+	const char *path=(const char *)data;
 	lua_pushnumber(L, pathconf(path, Kpathconf[i]));
 	return 1;
 }

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -463,7 +463,7 @@ expandThis(rpmMacroBuf mb, const char * src, size_t slen, char **target, int *fl
 
 static rpmMacroBuf mbCreate(rpmMacroContext mc, int flags)
 {
-    rpmMacroBuf mb = xcalloc(1, sizeof(*mb));
+    rpmMacroBuf mb = (rpmMacroBuf)xcalloc(1, sizeof(*mb));
     mb->buf = NULL;
     mb->depth = mc->depth;
     mb->level = mc->level;
@@ -477,7 +477,7 @@ static rpmMacroBuf mbCreate(rpmMacroContext mc, int flags)
 static void mbAllocBuf(rpmMacroBuf mb, size_t slen)
 {
     size_t blen = MACROBUFSIZ + slen;
-    mb->buf = xmalloc(blen + 1);
+    mb->buf = (char *)xmalloc(blen + 1);
     mb->buf[0] = '\0';
     mb->tpos = 0;
     mb->nb = blen;
@@ -684,7 +684,7 @@ doDefine(rpmMacroBuf mb, const char * se, int level, int expandbody, size_t *par
 {
     const char *start = se;
     const char *s = se;
-    char *buf = xmalloc(strlen(s) + 3); /* Some leeway for termination issues... */
+    char *buf = (char *)xmalloc(strlen(s) + 3); /* Some leeway for termination issues... */
     char *n = buf, *ne = n;
     char *o = NULL, *oe;
     char *b, *be, *ebody = NULL;
@@ -859,7 +859,7 @@ static void doDump(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed
 
 static int mbopt(int c, const char *oarg, int oint, void *data)
 {
-    rpmMacroBuf mb = data;
+    rpmMacroBuf mb = (rpmMacroBuf)data;
     char *name = NULL, *body = NULL;
 
     /* Define option macros. */
@@ -1028,7 +1028,7 @@ char *unsplitQuoted(ARGV_const_t av, const char *sep)
     seplen = av[1] ? strlen(sep) : 0;
     for (av2 = av; *av2; av2++)
 	len += strlen(*av2) + 2 + seplen;
-    b = buf = xmalloc(len + 1 - seplen);
+    b = buf = (char *)xmalloc(len + 1 - seplen);
     for (av2 = av; *av2; av2++) {
 	*b++ = qchar;
 	strcpy(b, *av2);
@@ -1848,7 +1848,7 @@ static void pushMacroAny(rpmMacroContext mc,
     rpmMacroEntry *mep = findEntry(mc, n, 0, &pos);
     if (mep) {
 	/* entry with shared name */
-	me = xmalloc(mesize);
+	me = (rpmMacroEntry)xmalloc(mesize);
 	p = me->arena;
 	/* set name */
 	me->name = (*mep)->name;
@@ -1857,7 +1857,7 @@ static void pushMacroAny(rpmMacroContext mc,
 	/* entry with new name */
 	mep = newEntry(mc, pos);
 	size_t nlen = strlen(n);
-	me = xmalloc(mesize + nlen + 1);
+	me = (rpmMacroEntry)xmalloc(mesize + nlen + 1);
 	p = me->arena;
 	/* copy name */
 	me->name = p;
@@ -1873,7 +1873,7 @@ static void pushMacroAny(rpmMacroContext mc,
     p += blen + 1;
     /* copy options */
     if (olen)
-	me->opts = memcpy(p, o, olen + 1);
+	me->opts = (char *)memcpy(p, o, olen + 1);
     else
 	me->opts = o ? "" : NULL;
     /* initialize */
@@ -1920,7 +1920,7 @@ static void popMacro(rpmMacroContext mc, const char * n)
 
 static int defineMacro(rpmMacroContext mc, const char * macro, int level)
 {
-    rpmMacroBuf mb = xcalloc(1, sizeof(*mb));
+    rpmMacroBuf mb = (rpmMacroBuf)xcalloc(1, sizeof(*mb));
     int rc;
     size_t parsed = 0;
 
@@ -1935,7 +1935,7 @@ static int defineMacro(rpmMacroContext mc, const char * macro, int level)
 static void linenoMacro(rpmMacroBuf mb,
 		    rpmMacroEntry me, ARGV_t margs, size_t *parsed)
 {
-    int *lineno = rpmMacroEntryPriv(me);
+    int *lineno = (int *)rpmMacroEntryPriv(me);
     if (lineno) {
 	char lnobuf[16];
 	snprintf(lnobuf, sizeof(lnobuf), "%d", *lineno);
@@ -1947,7 +1947,7 @@ static int loadMacroFile(rpmMacroContext mc, const char * fn)
 {
     FILE *fd = fopen(fn, "r");
     size_t blen = MACROBUFSIZ;
-    char *buf = xmalloc(blen);
+    char *buf = (char *)xmalloc(blen);
     int rc = -1;
     int nfailed = 0;
     int lineno = 0;
@@ -2241,7 +2241,7 @@ rpmExpand(const char *arg, ...)
 	blen += strlen(s);
     va_end(ap);
 
-    buf = xmalloc(blen + 1);
+    buf = (char *)xmalloc(blen + 1);
     buf[0] = '\0';
 
     va_start(ap, arg);

--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -25,7 +25,7 @@ int rpmDoDigest(int algo, const char * fn,int asAscii, unsigned char * digest)
 {
     unsigned char * dig = NULL;
     size_t diglen, buflen = 32 * BUFSIZ;
-    unsigned char *buf = xmalloc(buflen);
+    unsigned char *buf = (unsigned char *)xmalloc(buflen);
     int rc = 0;
 
     FD_t fd = Fopen(fn, "r.ufdio");
@@ -394,7 +394,7 @@ static char * rpmEscapeChars(const char *s, const char *accept, int (*fn)(int))
     }
     nb++;
 
-    t = te = xmalloc(nb);
+    t = te = (char *)xmalloc(nb);
     for (se = s; *se; se++) {
 	if ((accept && strchr(accept, *se)) || (fn && fn(*se)))
 	    *te++ = '\\';

--- a/rpmio/rpmhook.c
+++ b/rpmio/rpmhook.c
@@ -137,7 +137,7 @@ static void rpmhookTableAddItem(rpmhookTable *table, const char *name,
 	(*table)->used++;
     }
     while (*item) item = &(*item)->next;
-    *item = xcalloc(1, sizeof(**item));
+    *item = (rpmhookItem)xcalloc(1, sizeof(**item));
     (*item)->func = func;
     (*item)->data = data;
 }

--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -76,7 +76,7 @@ static void fdSetFdno(FD_t fd, int fdno)
 
 static void fdPush(FD_t fd, FDIO_t io, void * fp, int fdno)
 {
-    FDSTACK_t fps = xcalloc(1, sizeof(*fps));
+    FDSTACK_t fps = (FDSTACK_t) xcalloc(1, sizeof(*fps));
     fps->io = io;
     fps->fp = fp;
     fps->fdno = fdno;
@@ -335,12 +335,12 @@ FD_t fdFree( FD_t fd)
 
 static FD_t fdNew(int fdno, const char *descr)
 {
-    FD_t fd = xcalloc(1, sizeof(*fd));
+    FD_t fd = (FD_t)xcalloc(1, sizeof(*fd));
     fd->nrefs = 0;
     fd->flags = 0;
     fd->magic = FDMAGIC;
     fd->urlType = URL_IS_UNKNOWN;
-    fd->stats = xcalloc(1, sizeof(*fd->stats));
+    fd->stats = (FDSTAT_t)xcalloc(1, sizeof(*fd->stats));
     fd->digests = NULL;
     fd->descr = descr ? xstrdup(descr) : NULL;
 
@@ -771,7 +771,7 @@ static LZFILE *lzopen_internal(const char *mode, int fd, int xz)
     fp = fdopen(fd, encoding ? "w" : "r");
     if (!fp)
 	return NULL;
-    lzfile = calloc(1, sizeof(*lzfile));
+    lzfile = (LZFILE *)calloc(1, sizeof(*lzfile));
     lzfile->file = fp;
     lzfile->encoding = encoding;
     lzfile->eof = 0;
@@ -858,7 +858,7 @@ static ssize_t lzread(LZFILE *lzfile, void *buf, size_t len)
       return -1;
     if (lzfile->eof)
       return 0;
-    lzfile->strm.next_out = buf;
+    lzfile->strm.next_out = (uint8_t *)buf;
     lzfile->strm.avail_out = len;
     for (;;) {
 	if (!lzfile->strm.avail_in) {
@@ -889,7 +889,7 @@ static ssize_t lzwrite(LZFILE *lzfile, void *buf, size_t len)
 	return -1;
     if (!len)
 	return 0;
-    lzfile->strm.next_in = buf;
+    lzfile->strm.next_in = (uint8_t *)buf;
     lzfile->strm.avail_in = len;
     for (;;) {
 	lzfile->strm.next_out = lzfile->buf;
@@ -1131,7 +1131,7 @@ static rpmzstd rpmzstdNew(int fdno, const char *fmode)
     zstd->level = level;
     zstd->fp = fp;
     zstd->nb = nb;
-    zstd->b = xmalloc(nb);
+    zstd->b = (uint8_t *)xmalloc(nb);
 
     return zstd;
 
@@ -1700,7 +1700,7 @@ int rpmioSlurp(const char * fn, uint8_t ** bp, ssize_t * blenp)
     blen = (size >= 0 ? size : blenmax);
     if (blen) {
 	int nb;
-	b = xmalloc(blen+1);
+	b = (uint8_t *)xmalloc(blen+1);
 	b[0] = '\0';
 	nb = Fread(b, sizeof(*b), blen, fd);
 	if (Ferror(fd) || (size > 0 && nb != blen)) {

--- a/rpmio/rpmkeyring.c
+++ b/rpmio/rpmkeyring.c
@@ -39,7 +39,7 @@ static int keyidcmp(const void *k1, const void *k2)
 
 rpmKeyring rpmKeyringNew(void)
 {
-    rpmKeyring keyring = xcalloc(1, sizeof(*keyring));
+    rpmKeyring keyring = (rpmKeyring)xcalloc(1, sizeof(*keyring));
     keyring->keys = NULL;
     keyring->numkeys = 0;
     keyring->nrefs = 1;
@@ -73,7 +73,7 @@ static rpmPubkey rpmKeyringFindKeyid(rpmKeyring keyring, rpmPubkey key)
 {
     rpmPubkey *found = NULL;
     if (key && keyring->keys) {
-	found = bsearch(&key, keyring->keys, keyring->numkeys,
+	found = (rpmPubkey *)bsearch(&key, keyring->keys, keyring->numkeys,
 			sizeof(*keyring->keys), keyidcmp);
     }
     return found ? *found : NULL;
@@ -142,8 +142,8 @@ rpmPubkey rpmPubkeyNew(const uint8_t *pkt, size_t pktlen)
     if (pgpPrtParams(pkt, pktlen, PGPTAG_PUBLIC_KEY, &pgpkey))
 	goto exit;
 
-    key = xcalloc(1, sizeof(*key));
-    key->pkt = xmalloc(pktlen);
+    key = (rpmPubkey)xcalloc(1, sizeof(*key));
+    key->pkt = (uint8_t *)xmalloc(pktlen);
     key->pktlen = pktlen;
     key->pgpkey = pgpkey;
     key->nrefs = 1;
@@ -165,10 +165,10 @@ rpmPubkey *rpmGetSubkeys(rpmPubkey mainkey, int *count)
     if (mainkey && !pgpPrtParamsSubkeys(mainkey->pkt, mainkey->pktlen,
 			mainkey->pgpkey, &pgpsubkeys, &pgpsubkeysCount)) {
 
-	subkeys = xmalloc(pgpsubkeysCount * sizeof(*subkeys));
+	subkeys = (rpmPubkey *)xmalloc(pgpsubkeysCount * sizeof(*subkeys));
 
 	for (i = 0; i < pgpsubkeysCount; i++) {
-	    rpmPubkey subkey = xcalloc(1, sizeof(*subkey));
+	    rpmPubkey subkey = (rpmPubkey)xcalloc(1, sizeof(*subkey));
 	    subkeys[i] = subkey;
 
 	    /* Packets with all subkeys already stored in main key */

--- a/rpmio/rpmlog.c
+++ b/rpmio/rpmlog.c
@@ -445,14 +445,14 @@ void rpmlog (int code, const char *fmt, ...)
     if (n >= -1) {
 	struct rpmlogRec_s rec;
 	size_t nb = n + 1;
-	char *msg = xmalloc(nb);
+	char *msg = (char *)xmalloc(nb);
 
 	va_start(ap, fmt);
 	n = vsnprintf(msg, nb, fmt, ap);
 	va_end(ap);
 
 	rec.code = code;
-	rec.pri = pri;
+	rec.pri = (rpmlogLvl)pri;
 	rec.message = msg;
 
 	dolog(&rec, saverec);

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -181,7 +181,7 @@ void * rpmluaGetLua(rpmlua lua)
 void rpmluaPushPrintBuffer(rpmlua lua)
 {
     INITSTATE(lua);
-    rpmluapb prbuf = xcalloc(1, sizeof(*prbuf));
+    rpmluapb prbuf = (rpmluapb)xcalloc(1, sizeof(*prbuf));
     prbuf->buf = NULL;
     prbuf->alloced = 0;
     prbuf->used = 0;
@@ -224,7 +224,7 @@ int rpmluaCheckScript(rpmlua lua, const char *script, const char *name)
 
 static int luaopt(int c, const char *oarg, int oint, void *data)
 {
-    lua_State *L = data;
+    lua_State *L = (lua_State *)data;
     char key[2] = { (char)c, '\0' };
 
     lua_pushstring(L, oarg ? oarg : "");
@@ -527,7 +527,7 @@ static int rpm_b64decode(lua_State *L)
 	void *data = NULL;
 	size_t len = 0;
 	if (rpmBase64Decode(str, &data, &len) == 0) {
-	    lua_pushlstring(L, data, len);
+	    lua_pushlstring(L, (char *)data, len);
 	} else {
 	    lua_pushnil(L);
 	}
@@ -689,7 +689,7 @@ static int rpm_register(lua_State *L)
 	(void) luaL_argerror(L, 2, "function expected");
     } else {
 	rpmluaHookData hookdata =
-	    lua_newuserdata(L, sizeof(struct rpmluaHookData_s));
+	    (rpmluaHookData)lua_newuserdata(L, sizeof(struct rpmluaHookData_s));
 	lua_pushvalue(L, -1);
 	hookdata->dataRef = luaL_ref(L, LUA_REGISTRYINDEX);
 	lua_pushvalue(L, 2);
@@ -818,7 +818,7 @@ static int rpm_execute(lua_State *L)
     int status;
     pid_t pid;
 
-    char **argv = malloc((n + 1) * sizeof(char *));
+    char **argv = (char **)malloc((n + 1) * sizeof(char *));
     if (argv == NULL)
 	return luaL_error(L, "not enough memory");
     argv[0] = (char *)file;
@@ -903,8 +903,8 @@ static int rpm_glob(lua_State *L)
 static int newinstance(lua_State *L, const char *name, void *p)
 {
     if (p != NULL) {
-	intptr_t **pp = lua_newuserdata(L, sizeof(*pp));
-	*pp = p;
+	intptr_t **pp = (intptr_t **)lua_newuserdata(L, sizeof(*pp));
+	*pp = (intptr_t *)p;
 	luaL_getmetatable(L, name);
 	lua_setmetatable(L, -2);
     }
@@ -922,7 +922,7 @@ static int createclass(lua_State *L, const char *name, const luaL_Reg *methods)
 
 static rpmver * checkver(lua_State *L, int ix)
 {
-    rpmver *vp = lua_touserdata(L, ix);
+    rpmver *vp = (rpmver *)lua_touserdata(L, ix);
     luaL_checkudata(L, ix, "rpm.ver");
     return vp;
 }
@@ -1016,7 +1016,7 @@ static const luaL_Reg ver_m[] = {
 
 static FD_t * checkfd(lua_State *L, int ix)
 {
-    FD_t *fdp = lua_touserdata(L, ix);
+    FD_t *fdp = (FD_t *)lua_touserdata(L, ix);
     luaL_checkudata(L, ix, "rpm.fd");
     return fdp;
 }
@@ -1168,7 +1168,7 @@ static const luaL_Reg fd_m[] = {
 
 static rpmMacroContext *checkmc(lua_State *L, int ix)
 {
-    rpmMacroContext *mc = lua_touserdata(L, ix);
+    rpmMacroContext *mc = (rpmMacroContext *)lua_touserdata(L, ix);
     luaL_checkudata(L, ix, "rpm.mc");
     return mc;
 }

--- a/rpmio/rpmstring.c
+++ b/rpmio/rpmstring.c
@@ -13,7 +13,7 @@
 char *rpmhex(const uint8_t *p, size_t plen)
 {
     char *t, *str;
-    str = t = xmalloc(plen * 2 + 1);
+    str = t = (char *)xmalloc(plen * 2 + 1);
     static char const hex[] = "0123456789abcdef";
     while (plen-- > 0) {
 	size_t i;
@@ -81,7 +81,7 @@ int rvasprintf(char **strp, const char *fmt, va_list ap)
 
     if (n >= -1) {
 	size_t nb = n + 1;
-	p = xmalloc(nb);
+	p = (char *)xmalloc(nb);
 	va_copy(aq, ap);
         n = vsnprintf(p, nb, fmt, aq);
 	va_end(aq);

--- a/rpmio/rpmstrpool.c
+++ b/rpmio/rpmstrpool.c
@@ -124,9 +124,9 @@ static poolHash poolHashCreate(int numBuckets)
 {
     poolHash ht;
 
-    ht = xmalloc(sizeof(*ht));
+    ht = (poolHash)xmalloc(sizeof(*ht));
     ht->numBuckets = numBuckets;
-    ht->buckets = xcalloc(numBuckets, sizeof(*ht->buckets));
+    ht->buckets = (poolHashBucket *)xcalloc(numBuckets, sizeof(*ht->buckets));
     ht->keyCount = 0;
     return ht;
 }
@@ -134,7 +134,7 @@ static poolHash poolHashCreate(int numBuckets)
 static void poolHashResize(rpmstrPool pool, int numBuckets)
 {
     poolHash ht = pool->hash;
-    poolHashBucket * buckets = xcalloc(numBuckets, sizeof(*ht->buckets));
+    poolHashBucket * buckets = (poolHashBucket *)xcalloc(numBuckets, sizeof(*ht->buckets));
 
     for (int i=0; i<ht->numBuckets; i++) {
         if (!ht->buckets[i].keyid) continue;
@@ -244,16 +244,16 @@ static void rpmstrPoolRehash(rpmstrPool pool)
 
 rpmstrPool rpmstrPoolCreate(void)
 {
-    rpmstrPool pool = xcalloc(1, sizeof(*pool));
+    rpmstrPool pool = (rpmstrPool)xcalloc(1, sizeof(*pool));
 
     pool->offs_alloced = STROFFS_CHUNK;
-    pool->offs = xcalloc(pool->offs_alloced, sizeof(*pool->offs));
+    pool->offs = (const char **)xcalloc(pool->offs_alloced, sizeof(*pool->offs));
 
     pool->chunks_allocated = STRDATA_CHUNKS;
-    pool->chunks = xcalloc(pool->chunks_allocated, sizeof(*pool->chunks));
+    pool->chunks = (char **)xcalloc(pool->chunks_allocated, sizeof(*pool->chunks));
     pool->chunks_size = 1;
     pool->chunk_allocated = STRDATA_CHUNK;
-    pool->chunks[pool->chunks_size] = xcalloc(1, pool->chunk_allocated);
+    pool->chunks[pool->chunks_size] = (char *)xcalloc(1, pool->chunk_allocated);
     pool->offs[1] = pool->chunks[pool->chunks_size];
 
     rpmstrPoolRehash(pool);
@@ -353,12 +353,12 @@ static rpmsid rpmstrPoolPut(rpmstrPool pool, const char *s, size_t slen, unsigne
 	    pool->chunk_allocated = 2 * ssize;
 	}
 
-	pool->chunks[pool->chunks_size] = xcalloc(1, pool->chunk_allocated);
+	pool->chunks[pool->chunks_size] = (char *)xcalloc(1, pool->chunk_allocated);
 	pool->chunk_used = 0;
     }
 
     /* Copy the string into current chunk, ensure termination */
-    t = memcpy(pool->chunks[pool->chunks_size] + pool->chunk_used, s, slen);
+    t = (char *)memcpy(pool->chunks[pool->chunks_size] + pool->chunk_used, s, slen);
     t[slen] = '\0';
     pool->chunk_used += ssize;
 

--- a/rpmio/rpmver.c
+++ b/rpmio/rpmver.c
@@ -162,7 +162,7 @@ rpmver rpmverParse(const char *evr)
     rpmver rv = NULL;
     if (evr && *evr) {
 	size_t evrlen = strlen(evr) + 1;
-	rv = xmalloc(sizeof(*rv) + evrlen);
+	rv = (rpmver)xmalloc(sizeof(*rv) + evrlen);
 	memcpy(rv->arena, evr, evrlen);
 	parseEVR(rv->arena, &rv->e, &rv->v, &rv->r);
     }
@@ -177,7 +177,7 @@ rpmver rpmverNew(const char *e, const char *v, const char *r)
 	size_t nb = strlen(v) + 1;
 	nb += (e != NULL) ? strlen(e) + 1 : 0;
 	nb += (r != NULL) ? strlen(r) + 1 : 0;
-	rv = xmalloc(sizeof(*rv) + nb);
+	rv = (rpmver)xmalloc(sizeof(*rv) + nb);
 
 	rv->e = NULL;
 	rv->v = NULL;

--- a/sign/CMakeLists.txt
+++ b/sign/CMakeLists.txt
@@ -23,11 +23,9 @@ if (WITH_FSVERITY)
 	target_link_libraries(librpmsign PRIVATE PkgConfig::FSVERITY)
 endif()
 
-if (WITH_CXX)
 set (cxx_sources
 	rpmgensig.c rpmsignfiles.c rpmsignverity.c
 )
 set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
-endif()
 
 install(TARGETS librpmsign EXPORT rpm-targets)

--- a/sign/CMakeLists.txt
+++ b/sign/CMakeLists.txt
@@ -23,4 +23,11 @@ if (WITH_FSVERITY)
 	target_link_libraries(librpmsign PRIVATE PkgConfig::FSVERITY)
 endif()
 
+if (WITH_CXX)
+set (cxx_sources
+	rpmgensig.c rpmsignfiles.c rpmsignverity.c
+)
+set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
+endif()
+
 install(TARGETS librpmsign EXPORT rpm-targets)

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -320,7 +320,7 @@ static rpmtd makeGPGSignature(Header sigh, int ishdr, sigTarget sigt)
 
     pktlen = st.st_size;
     rpmlog(RPMLOG_DEBUG, "GPG sig size: %zd\n", pktlen);
-    pkt = xmalloc(pktlen);
+    pkt = (uint8_t *)xmalloc(pktlen);
 
     {	FD_t fd;
 
@@ -375,9 +375,9 @@ static int haveSignature(rpmtd sigtd, Header h)
     if (!headerGet(h, rpmtdTag(sigtd), &oldtd, HEADERGET_DEFAULT))
 	return rc;
 
-    pgpPrtParams(sigtd->data, sigtd->count, PGPTAG_SIGNATURE, &sig1);
+    pgpPrtParams((uint8_t *)sigtd->data, sigtd->count, PGPTAG_SIGNATURE, &sig1);
     while (rpmtdNext(&oldtd) >= 0 && rc == 0) {
-	pgpPrtParams(oldtd.data, oldtd.count, PGPTAG_SIGNATURE, &sig2);
+	pgpPrtParams((uint8_t *)oldtd.data, oldtd.count, PGPTAG_SIGNATURE, &sig2);
 	if (pgpDigParamsCmp(sig1, sig2) == 0)
 	    rc = 1;
 	sig2 = pgpDigParamsFree(sig2);
@@ -517,7 +517,7 @@ static rpmRC includeVeritySignatures(FD_t fd, Header *sigp, Header *hdrp)
 
 static int msgCb(struct rpmsinfo_s *sinfo, void *cbdata)
 {
-    char **msg = cbdata;
+    char **msg = (char **)cbdata;
     if (sinfo->rc && *msg == NULL)
 	*msg = rpmsinfoMsg(sinfo);
     return (sinfo->rc != RPMRC_FAIL);
@@ -665,7 +665,7 @@ static int rpmSign(const char *rpm, int deleting, int flags)
 	if (diff) {
 	    utd.count -= diff;
 	    if (utd.count > 0 && utd.count < origSigSize) {
-		char *zeros = xcalloc(utd.count, sizeof(*zeros));
+		uint8_t *zeros = (uint8_t *)xcalloc(utd.count, sizeof(*zeros));
 		utd.data = zeros;
 		headerMod(sigh, &utd);
 		insSig = 1;

--- a/sign/rpmsignverity.c
+++ b/sign/rpmsignverity.c
@@ -155,7 +155,7 @@ rpmRC rpmSignVerity(FD_t fd, Header sigh, Header h, char *key,
      * special files. Last we walk the array and populate the header.
      */
     nr_files = rpmfiFC(hfi);
-    signatures = xcalloc(nr_files, sizeof(char *));
+    signatures = (char **)xcalloc(nr_files, sizeof(char *));
 
     if (!algo)
 	    algo = FS_VERITY_HASH_ALG_SHA256;

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -16,6 +16,7 @@ RUN dnf -y install \
   doxygen \
   make \
   gcc \
+  gcc-c++ \
   git-core \
   glibc-gconv-extra \
   zlib-devel \

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -66,14 +66,12 @@ if (WITH_ARCHIVE)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rpm2cpio TYPE BIN)
 endif()
 
-if (WITH_CXX)
 set (cxx_sources
 	cliutils.c elfdeps.c rpm2archive.c rpmbuild.c rpm.c rpmdb.c
 	rpmdeps.c rpmdump.c rpmgraph.c rpmkeys.c rpmlua.c rpmsign.c
 	rpmsort.c rpmspec.c
 )
 set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
-endif()
 
 install(TARGETS
 	rpm rpmdb rpmkeys rpmsign rpmbuild rpmspec

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -66,6 +66,15 @@ if (WITH_ARCHIVE)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rpm2cpio TYPE BIN)
 endif()
 
+if (WITH_CXX)
+set (cxx_sources
+	cliutils.c elfdeps.c rpm2archive.c rpmbuild.c rpm.c rpmdb.c
+	rpmdeps.c rpmdump.c rpmgraph.c rpmkeys.c rpmlua.c rpmsign.c
+	rpmsort.c rpmspec.c
+)
+set_source_files_properties(${cxx_sources} PROPERTIES LANGUAGE CXX)
+endif()
+
 install(TARGETS
 	rpm rpmdb rpmkeys rpmsign rpmbuild rpmspec
 	rpmlua rpmgraph

--- a/tools/elfdeps.c
+++ b/tools/elfdeps.c
@@ -281,7 +281,7 @@ static int processFile(const char *fn, int dtype)
     int fdno;
     struct stat st;
     GElf_Ehdr *ehdr, ehdr_mem;
-    elfInfo *ei = rcalloc(1, sizeof(*ei));
+    elfInfo *ei = (elfInfo *)rcalloc(1, sizeof(*ei));
     ARGV_t dep = NULL;
 
     fdno = open(fn, O_RDONLY);

--- a/tools/rpm.c
+++ b/tools/rpm.c
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
 
 	/* we've already ensured !(!ia->prefix && !ia->relocations) */
 	if (ia->prefix) {
-	    ia->relocations = xmalloc(2 * sizeof(*ia->relocations));
+	    ia->relocations = (struct rpmRelocation_s *)xmalloc(2 * sizeof(*ia->relocations));
 	    ia->relocations[0].oldPath = NULL;   /* special case magic */
 	    ia->relocations[0].newPath = ia->prefix;
 	    ia->relocations[1].oldPath = NULL;

--- a/tools/rpm2archive.c
+++ b/tools/rpm2archive.c
@@ -230,7 +230,7 @@ static int process_package(rpmts ts, const char * filename)
 
     entry = archive_entry_new();
 
-    char * buf = xmalloc(BUFSIZE);
+    char * buf = (char *)xmalloc(BUFSIZE);
     char * hardlink = NULL;
 
     rpmfiles files = rpmfilesNew(NULL, h, 0, RPMFI_KEEPHEADER);

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -142,7 +142,7 @@ static void buildArgCallback( poptContext con,
 
 static struct poptOption rpmBuildPoptTable[] = {
  { NULL, '\0', POPT_ARG_CALLBACK | POPT_CBFLAG_INC_DATA | POPT_CBFLAG_CONTINUE,
-	buildArgCallback, 0, NULL, NULL },
+	(void *)buildArgCallback, 0, NULL, NULL },
 
  { "bp", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_BP,
 	N_("build through %prep (unpack sources and apply patches) from <specfile>"),

--- a/tools/rpmdump.c
+++ b/tools/rpmdump.c
@@ -129,7 +129,7 @@ static int readhdr(int fd, int sighdr, const char *msg)
     indexLen = numEntries * sizeof(*entry);
     headerLen = indexLen + numBytes;
 
-    blob = malloc(sizeof(numEntries) + sizeof(numBytes) + headerLen);
+    blob = (uint32_t *)malloc(sizeof(numEntries) + sizeof(numBytes) + headerLen);
     blob[0] = htonl(numEntries);
     blob[1] = htonl(numBytes);
 

--- a/tools/rpmsign.c
+++ b/tools/rpmsign.c
@@ -91,7 +91,7 @@ static char *get_fskpass(void)
 {
     struct termios flags, tmp_flags;
     int passlen = 64;
-    char *password = xmalloc(passlen);
+    char *password = (char *)xmalloc(passlen);
     char *pwd = NULL;
 
     tcgetattr(fileno(stdin), &flags);

--- a/tools/rpmsort.c
+++ b/tools/rpmsort.c
@@ -21,7 +21,7 @@ static size_t read_file(const char *input, char **ret)
     else
 	in = fopen(input, "r");
 
-    text = xmalloc(sz);
+    text = (char *)xmalloc(sz);
 
     if (!in) {
 	fprintf(stderr, "cannot open `%s'", input);
@@ -130,7 +130,7 @@ static void add_input(const char *filename, char ***package_names,
     size_t n_names = *n_package_names;
 
     if (!*package_names)
-	new_names = names = xmalloc(sizeof(char *) * 2);
+	new_names = names = (char **)xmalloc(sizeof(char *) * 2);
 
     if (read_file(filename, &orig_input_buffer) < 2) {
 	if (new_names)


### PR DESCRIPTION
As per https://github.com/rpm-software-management/rpm/discussions/2983, here goes.

More details in commits, but to summarize: add necessary casts to most of the codebase to make it buildable with a c++ compiler, and then switch over to c++. Exempt from this conversion are 
- Python bindings: there are no big benefits from converting it right now, and it'll serve as a C API canary as well
- plugins: some of these may want to move to their real upstream repository now that the plugin API is public, we don't want to for language changes for them just now
- the low-level ndb engine is left up to maintainer (@mlschroe ) discretion, there's no *need* to convert it