### PR TITLE
Fix an ancient memleak on %caps() parsing, add tests

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -228,6 +228,7 @@ static void copyFileEntry(FileEntry src, FileEntry dest)
 static void FileEntryFree(FileEntry entry)
 {
     argvFree(entry->langs);
+    free(entry->caps);
     memset(entry, 0, sizeof(*entry));
 }
 

--- a/tests/data/SPECS/caps.spec
+++ b/tests/data/SPECS/caps.spec
@@ -1,0 +1,25 @@
+Name: caps
+Version: 1.0
+Release: 1
+Summary: Test %caps
+License: Public domain
+
+%description
+%{summary}
+
+%prep
+cat << EOF > test.c
+int main(int argc, char *argv[])
+{
+	return 0;
+}
+EOF
+
+%build
+gcc -o test test.c
+
+%install
+install -m 755 test -D ${RPM_BUILD_ROOT}/usr/bin/test
+
+%files
+%caps(cap_net_raw=p) /usr/bin/test

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2995,3 +2995,33 @@ runroot rpmbuild --quiet -bb /data/SPECS/noperms.spec
 [],
 [])
 RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild %caps])
+AT_KEYWORDS([build])
+AT_SKIP_IF([$CAP_DISABLED])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+runroot rpmbuild --quiet -bb /data/SPECS/caps.spec
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -q --filecaps /build/RPMS/*/caps-1.0-1.*.rpm | grep -v build-id
+],
+[0],
+[/usr/bin/test	cap_net_raw=p
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U --nodeps /build/RPMS/*/caps-1.0-1.*.rpm
+runroot_other /usr/sbin/getcap /usr/bin/test
+],
+[0],
+[/usr/bin/test cap_net_raw=p]
+[])
+
+RPMTEST_CLEANUP


### PR DESCRIPTION
This leak has been there ever since rpm 4.7.0, so pretty close to 15 years. ASAN would've caught it, if it had it been tested. Oops. Of course, in the fakechroot era we couldn't have tested installation but we could've at least tested the parsing side.

Add tests for parsing, query and install functionality, and fix the leak that is now very visible.