### PR TITLE
Add proper program logic for debuginfo enablement

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -195,11 +195,8 @@ package or when debugging this package.\
 %{nil}
 
 %debug_package \
-%ifnarch noarch\
-%global __debug_package 1\
 %_debuginfo_template\
 %{?_debugsource_packages:%_debugsource_template}\
-%endif\
 %{nil}
 
 %_langpack_template() \

--- a/macros.in
+++ b/macros.in
@@ -470,6 +470,9 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #
 #%_missing_build_ids_terminate_build	1
 
+# Enable debuginfo package generation
+%_enable_debug_packages		1
+
 #
 # Include minimal debug information in build binaries.
 # Requires _enable_debug_packages.

--- a/tests/data/macros.debug
+++ b/tests/data/macros.debug
@@ -26,10 +26,6 @@
     %{__os_install_post}\
 %{nil}
 
-%install %{?_enable_debug_packages:%{?buildsubdir:%{debug_package}}}\
-%%install\
-%{nil}
-
 # Should missing buildids terminate a build?
 %_missing_build_ids_terminate_build    1
 


### PR DESCRIPTION
All these years, enabling debuginfo has required distros to hijack the spec %install section with a macro like this:

    %install %{?_enable_debug_packages:%{?buildsubdir:%{debug_package}}}\
    %%install\
    %{nil}

This for a widely used, longtime upstream supported feature is just gross, and also very non-obvious, feeble and whatnot. And totally prevents the new append/prepend options from being used with %install.

Replace the logic parts with actual C code where the logic is more straightforward to follow, taking advantage of dynamic spec generation so debuginfo packages are only ever generated during an actual build.

There's a crazy amount of details buried in such a tiny piece, commented in the code now.

A noteworthy point here is that the presence of the old %install hack now causes an explicit failure, something like:

    error: line 4: %package debuginfo: package foo-debuginfo already exists
    error: parsing failed

This explicit break is very much intentional as we want distros to remove those %install hacks from their macro files.

Fixes: #2204
Fixes: #1878