### PR TITLE
Upstream debuginfo enablement

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -1197,7 +1197,6 @@ static rpmRC parseSpecSection(rpmSpec *specptr, enum parseStages stage)
 			spec->BACount = index;
 			goto errxit;
 		}
-		rpmPopMacro(NULL, "_target_cpu");
 		index++;
 	    }
 
@@ -1214,8 +1213,8 @@ static rpmRC parseSpecSection(rpmSpec *specptr, enum parseStages stage)
 	     * causes problems for "rpm -q --specfile". This is
 	     * still a hack because there may be more than 1 arch
 	     * specified (unlikely but possible.) There's also the
-	     * further problem that the macro context, particularly
-	     * %{_target_cpu}, disagrees with the info in the header.
+	     * further problem that the macro context, disagrees
+	     * with the info in the header.
 	     */
 	    if (spec->BACount >= 1) {
 		rpmSpec nspec = spec->BASpecs[0];

--- a/macros.in
+++ b/macros.in
@@ -198,11 +198,12 @@ package or when debugging this package.\
 %{nil}
 
 %debug_package \
-%ifnarch noarch\
 %global __debug_package 1\
+%(cat > "%{specpartsdir}/rpm-debuginfo.specpart" << EOL\
 %_debuginfo_template\
 %{?_debugsource_packages:%_debugsource_template}\
-%endif\
+EOL\
+)\
 %{nil}
 
 %_langpack_template() \
@@ -878,6 +879,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %{nil}
 %__spec_install_template	#!%{__spec_install_shell}\
 %{__spec_install_pre}\
+%[ "%{_target_cpu}" != "noarch" ? "%{?_enable_debug_packages:%{?buildsubdir:%{debug_package}}}" : ""]\
 %{nil}
 
 #%{__spec_install_body}\

--- a/macros.in
+++ b/macros.in
@@ -145,6 +145,9 @@
 #%__systemd_sysusers	@__SYSTEMD_SYSUSERS@
 %__systemd_sysusers	%{_rpmconfigdir}/sysusers.sh
 
+# enable debug package generation
+%_enable_debug_packages 1
+
 #
 #	Path to script that creates debug symbols in a /usr/lib/debug
 #	shadow tree.

--- a/tests/data/macros.debug
+++ b/tests/data/macros.debug
@@ -26,10 +26,6 @@
     %{__os_install_post}\
 %{nil}
 
-%install %{?_enable_debug_packages:%{?buildsubdir:%{debug_package}}}\
-%%install\
-%{nil}
-
 # Should missing buildids terminate a build?
 %_missing_build_ids_terminate_build    1
 


### PR DESCRIPTION
! This removes the %ifnarch noarch check. We need to find a solution for this before merging (or decise it is just an optimization we don't really need)

All these years, enabling debuginfo has required distros to hijack the spec %install section with a macro like this:

    %install %{?_enable_debug_packages:%{?buildsubdir:%{debug_package}}}\
    %%install\
    %{nil}

This for a widely used, longtime upstream supported feature is just gross, and also very non-obvious, feeble and whatnot. And totally prevents the new append/prepend options from being used with %install.

Turn this isto a proper macro that drops the package definition into a .SPECPART file. This way debuginfo can be part of the %install script without messing up the parsing.

Fixes: #2204
Fixes: #1878