### PR TITLE
Parse dynamic spec parts for rpmbuild -bl

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -469,7 +469,8 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 			   test, sbp)))
 		goto exit;
 
-	if (((what & RPMBUILD_INSTALL) || (what & RPMBUILD_PACKAGEBINARY)) &&
+	if (((what & RPMBUILD_INSTALL) || (what & RPMBUILD_PACKAGEBINARY) ||
+	     (what & RPMBUILD_FILECHECK)) &&
 	    (rc = parseGeneratedSpecs(spec)))
 		goto exit;
 


### PR DESCRIPTION
As we need to check all file lists we need to have them parsed - even if %build and %install have not been run due to --short-circuit


Tested manually with #3040. There is fixes test 334.