### PR TITLE
Fix build scriptlet append/prepend interaction with Buildsystem

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -791,9 +791,9 @@ static int addBuildOption(rpmSpec spec, const char *sect, const char *opt)
     if (*sect == '\0')
 	sect = "conf";
 
-    int sn = getSection(sect);
-    if (sn >= 0) {
-	argvAdd(&(spec->buildopts[sn]), opt);
+    const struct sectname_s *sc = getSection(sect, 0);
+    if (sc) {
+	argvAdd(&(spec->buildopts[sc->section]), opt);
 	rc = RPMRC_OK;
     }
     return rc;

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -922,33 +922,26 @@ exit:
     return res;
 }
 
-struct sectname_s {
-    const char *name;
-    int section;
-    int required;
-};
-
 struct sectname_s sectList[] = {
-    { "prep", SECT_PREP, 0 },
-    { "conf", SECT_CONF, 1 },
-    { "generate_buildrequires", SECT_BUILDREQUIRES, 0 },
-    { "build", SECT_BUILD, 1 },
-    { "install", SECT_INSTALL, 1 },
-    { "check", SECT_CHECK, 0 },
-    { "clean", SECT_CLEAN, 0 },
-    { NULL, -1 }
+    { "prep", SECT_PREP, PART_PREP, 0 },
+    { "conf", SECT_CONF, PART_CONF, 1 },
+    { "generate_buildrequires", SECT_BUILDREQUIRES, PART_BUILDREQUIRES, 0 },
+    { "build", SECT_BUILD, PART_BUILD, 1 },
+    { "install", SECT_INSTALL, PART_INSTALL, 1 },
+    { "check", SECT_CHECK, PART_CHECK, 0 },
+    { "clean", SECT_CLEAN, PART_CLEAN, 0 },
+    { NULL, -1, -1, 0 }
 };
 
-int getSection(const char *name)
+const struct sectname_s *getSection(const char *name, int part)
 {
-    int sn = -1;
-    for (struct sectname_s *sc = sectList; sc->name; sc++) {
-	if (rstreq(name, sc->name)) {
-	    sn = sc->section;
-	    break;
-	}
+    for (const struct sectname_s *sc = sectList; sc->name; sc++) {
+	if (name && rstreq(name, sc->name))
+	    return sc;
+	if (part && part == sc->part)
+	    return sc;
     }
-    return sn;
+    return NULL;
 }
 
 int checkBuildsystem(rpmSpec spec, const char *name)

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -1054,6 +1054,15 @@ static int checkPart(int parsePart, enum parseStages stage) {
     return 0;
 }
 
+static int parseBuildScript(rpmSpec spec, int part)
+{
+    const struct sectname_s *sc = getSection(NULL, part);
+    if (sc == NULL) /* can't happen */
+	return -1;
+
+    return parseSimpleScript(spec, sc->name, &spec->sections[sc->section]);
+}
+
 static rpmRC parseSpecSection(rpmSpec *specptr, enum parseStages stage)
 {
     rpmSpec spec = *specptr;
@@ -1090,34 +1099,17 @@ static rpmRC parseSpecSection(rpmSpec *specptr, enum parseStages stage)
 	case PART_PREP:
 	    rpmPushMacroAux(NULL, "setup", "-", doSetupMacro, spec, -1, 0, 0);
 	    rpmPushMacroAux(NULL, "patch", "-", doPatchMacro, spec, -1, 0, 0);
-	    parsePart = parseSimpleScript(spec, "%prep",
-					&(spec->sections[SECT_PREP]));
+	    parsePart = parseBuildScript(spec, parsePart);
 	    rpmPopMacro(NULL, "patch");
 	    rpmPopMacro(NULL, "setup");
 	    break;
 	case PART_CONF:
-	    parsePart = parseSimpleScript(spec, "%conf",
-					&(spec->sections[SECT_CONF]));
-	    break;
 	case PART_BUILDREQUIRES:
-	    parsePart = parseSimpleScript(spec, "%generate_buildrequires",
-				      &(spec->sections[SECT_BUILDREQUIRES]));
-	    break;
 	case PART_BUILD:
-	    parsePart = parseSimpleScript(spec, "%build",
-					&(spec->sections[SECT_BUILD]));
-	    break;
 	case PART_INSTALL:
-	    parsePart = parseSimpleScript(spec, "%install",
-					&(spec->sections[SECT_INSTALL]));
-	    break;
 	case PART_CHECK:
-	    parsePart = parseSimpleScript(spec, "%check",
-					&(spec->sections[SECT_CHECK]));
-	    break;
 	case PART_CLEAN:
-	    parsePart = parseSimpleScript(spec, "%clean",
-					&(spec->sections[SECT_CLEAN]));
+	    parsePart = parseBuildScript(spec, parsePart);
 	    break;
 	case PART_CHANGELOG:
 	    parsePart = parseChangelog(spec);

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -38,6 +38,14 @@ enum sections_e {
 };
 #define NR_SECT 7
 
+struct sectname_s {
+    const char *name;
+    int section;
+    int part;
+    int required;
+};
+
+
 struct TriggerFileEntry {
     int index;
     char * fileName;
@@ -654,7 +662,7 @@ void doPatchMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
 
 /* Return section number, -1 on error */
 RPM_GNUC_INTERNAL
-int getSection(const char *name);
+const struct sectname_s *getSection(const char *name, int part);
 
 #ifdef __cplusplus
 }

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -38,13 +38,18 @@ enum sections_e {
 };
 #define NR_SECT 7
 
+enum parseOps_e {
+    PARSE_NONE		= 0,
+    PARSE_PREPEND	= (1 << 0),
+    PARSE_APPEND	= (1 << 1),
+};
+
 struct sectname_s {
     const char *name;
     int section;
     int part;
     int required;
 };
-
 
 struct TriggerFileEntry {
     int index;
@@ -165,6 +170,8 @@ struct rpmSpec_s {
 
     StringBuf sections[NR_SECT]; /*!< spec sections (%prep etc) */
     ARGV_t buildopts[NR_SECT];	/*!< per-section buildsystem options */
+    ARGV_t sectionparts[NR_SECT];
+    ARGI_t sectionops[NR_SECT];
 
     StringBuf parsed;		/*!< parsed spec contents */
 
@@ -336,7 +343,8 @@ int isPart(const char * line)	;
  * @return		>= 0 next rpmParseState, < 0 on error
  */
 RPM_GNUC_INTERNAL
-int parseSimpleScript(rpmSpec spec, const char * name, StringBuf *sbp);
+int parseSimpleScript(rpmSpec spec, const char * name,
+		      StringBuf *sbp, ARGV_t *avp, int *modep);
 
 /** \ingroup rpmbuild
  * Parse %%changelog section of a spec file.

--- a/build/spec.c
+++ b/build/spec.c
@@ -283,6 +283,8 @@ rpmSpec rpmSpecFree(rpmSpec spec)
 
     for (int i = 0; i < NR_SECT; i++) {
 	argvFree(spec->buildopts[i]);
+	argvFree(spec->sectionparts[i]);
+	argiFree(spec->sectionops[i]);
     }
 
     if (!spec->recursing) {

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -496,9 +496,10 @@ omitted.
 Each section may be present only once, but in rpm >= 4.20 it is
 possible to augment them by appending or prepending to them using
 `-a` and `-p` options.
-If the main section exists, it must come first to avoid ambiguity.
-Otherwise, append and prepend can be used in any order and multiple
-times, even if the corresponding main section does not exist.
+Append and prepend can be used multiple times. They are applied relative
+to the corresponding main section, in the order they appear in the spec.
+If the main section does not exist, they are applied relative to the
+first fragment.
 
 During the execution of build scriptlets, (at least) the following
 rpm-specific environment variables are set:

--- a/tests/data/SPECS/amhello.spec
+++ b/tests/data/SPECS/amhello.spec
@@ -21,13 +21,35 @@ Release: 1
 %description
 %{summary}
 
+%build -p
+touch pre1
+
+%build -p
+touch pre2
+
 %build -a
+test -f pre1 || exit 1
+test -f pre2 || exit 1
 cat << EOF > README.distro
 Add some distro specific notes.
 EOF
 
+%install -p
+mkdir -p ${RPM_BUILD_ROOT}/%{_sysconfdir}/hello.p
+
+%install -a
+test -d ${RPM_BUILD_ROOT}/%{_sysconfdir}/hello.p || exit 1
+mkdir -p ${RPM_BUILD_ROOT}/%{_sysconfdir}/hello.d
+
+%install -a
+test -d ${RPM_BUILD_ROOT}/%{_sysconfdir}/hello.d || exit 1
+mkdir -p ${RPM_BUILD_ROOT}/%{_sysconfdir}/hello.a
+
 %files
 %doc README.distro
+%{_sysconfdir}/hello.a/
+%{_sysconfdir}/hello.d/
+%{_sysconfdir}/hello.p/
 %if %{with alt}
 /alt/%{_bindir}/alt-hello
 /alt/%{_docdir}/%{name}

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -53,13 +53,17 @@ cp "${RPMTEST}/data/macros.buildsystem" "${RPMTEST}/${RPM_CONFIGDIR_PATH}/macros
 RPMTEST_CHECK([
 runroot rpmbuild -bb \
 	--define "_prefix /usr" \
+	--define "_sysconfdir /etc" \
 	--define "_docdir_fmt %%{NAME}" \
 	--quiet /data/SPECS/amhello.spec
 
 runroot rpm -qpl --noartifact /build/RPMS/*/amhello-1.0-1.*.rpm
 ],
 [0],
-[/usr/bin/hello
+[/etc/hello.a
+/etc/hello.d
+/etc/hello.p
+/usr/bin/hello
 /usr/share/doc/amhello
 /usr/share/doc/amhello/README
 /usr/share/doc/amhello/README.distro
@@ -73,6 +77,7 @@ mv amhello-1.0 amhello-1.0-prerelease
 tar czf "${RPMTEST}"/tmp/amhello-pre.tgz amhello-1.0-prerelease/
 runroot rpmbuild -bb \
 	--define "_prefix /usr" \
+	--define "_sysconfdir /etc" \
 	--define "_docdir_fmt %%{NAME}" \
 	--define "_sourcedir /tmp" \
 	--define "srcname amhello-pre.tgz" \
@@ -81,7 +86,10 @@ runroot rpmbuild -bb \
 runroot rpm -qpl --noartifact /build/RPMS/*/amhello-1.0-1.*.rpm
 ],
 [0],
-[/usr/bin/hello
+[/etc/hello.a
+/etc/hello.d
+/etc/hello.p
+/usr/bin/hello
 /usr/share/doc/amhello
 /usr/share/doc/amhello/README
 /usr/share/doc/amhello/README.distro
@@ -91,6 +99,7 @@ runroot rpm -qpl --noartifact /build/RPMS/*/amhello-1.0-1.*.rpm
 RPMTEST_CHECK([
 runroot rpmbuild -bb \
 	--define "_prefix /usr" \
+	--define "_sysconfdir /etc" \
 	--define "_docdir_fmt %%{NAME}" \
 	--with alt \
 	--quiet /data/SPECS/amhello.spec
@@ -101,6 +110,9 @@ runroot rpm -qpl --noartifact /build/RPMS/*/amhello-1.0-1alt.*.rpm
 [/alt/usr/bin/alt-hello
 /alt/usr/share/doc/amhello
 /alt/usr/share/doc/amhello/README
+/etc/hello.a
+/etc/hello.d
+/etc/hello.p
 /usr/share/doc/amhello
 /usr/share/doc/amhello/README.distro
 ],


### PR DESCRIPTION
The append and prepend modes got added before the declarative Buildsystem, and did not get thoroughly tested with it. The existing %build -a test didn't actually work but automake handling the build in %install masked the issue embarrasingly. As the Buildsystem is parsed after everything else, there's no way the previous append/prepend implementation could work correctly with it.

Do what we should've done from the start: collect any prepend/append stuff into separate data structures and apply them after everything else has been parsed. This also lifts the artificial sounding restriction wrt the corresponding main section:it's really the right thing to do, even if it's a bit more code.

Make the tests wrt buildsystem much more thorough to ensure it all really works, blush.

Fixes: #3024