### PR TITLE
Add the "Primary Binding" pgp signature type

### DIFF
--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -81,6 +81,7 @@ typedef enum pgpSigType_e {
     PGPSIGTYPE_POSITIVE_CERT	 = 0x13,
 		/*!< Positive certification of a User ID & Public Key */
     PGPSIGTYPE_SUBKEY_BINDING	 = 0x18, /*!< Subkey Binding */
+    PGPSIGTYPE_PRIMARY_BINDING	 = 0x19, /*!< Primary Binding */
     PGPSIGTYPE_SIGNED_KEY	 = 0x1F, /*!< Signature directly on a key */
     PGPSIGTYPE_KEY_REVOKE	 = 0x20, /*!< Key revocation */
     PGPSIGTYPE_SUBKEY_REVOKE	 = 0x28, /*!< Subkey revocation */

--- a/rpmio/rpmpgpval.h
+++ b/rpmio/rpmpgpval.h
@@ -17,6 +17,7 @@ static struct pgpValTbl_s const pgpSigTypeTbl[] = {
     { PGPSIGTYPE_CASUAL_CERT,	"Casual certification of a User ID and Public Key" },
     { PGPSIGTYPE_POSITIVE_CERT,	"Positive certification of a User ID and Public Key" },
     { PGPSIGTYPE_SUBKEY_BINDING,"Subkey Binding Signature" },
+    { PGPSIGTYPE_PRIMARY_BINDING,"Primary Binding Signature" },
     { PGPSIGTYPE_SIGNED_KEY,	"Signature directly on a key" },
     { PGPSIGTYPE_KEY_REVOKE,	"Key revocation signature" },
     { PGPSIGTYPE_SUBKEY_REVOKE,	"Subkey revocation signature" },


### PR DESCRIPTION
This type is needed to verify the primary binding signature embedded in subkey binding signatures.