### PR TITLE
Convert a bunch of librpmio stuff to native C++

### DIFF
--- a/include/rpm/rpmtypes.h
+++ b/include/rpm/rpmtypes.h
@@ -96,7 +96,7 @@ typedef struct rpmRelocation_s rpmRelocation;
 /** \ingroup rpmtypes 
  * RPM IO file descriptor type
  */
-typedef struct _FD_s * FD_t;
+typedef struct FD_s * FD_t;
 
 /** \ingroup rpmtypes
  * Package read return codes.

--- a/rpmio/digest.c
+++ b/rpmio/digest.c
@@ -34,7 +34,7 @@ static int findID(rpmDigestBundle bundle, int id)
 
 rpmDigestBundle rpmDigestBundleNew(void)
 {
-    rpmDigestBundle bundle = (rpmDigestBundle)xcalloc(1, sizeof(*bundle));
+    rpmDigestBundle bundle = new rpmDigestBundle_s {};
     return bundle;
 }
 
@@ -47,8 +47,7 @@ rpmDigestBundle rpmDigestBundleFree(rpmDigestBundle bundle)
 	    rpmDigestFinal(bundle->digests[i], NULL, NULL, 0);
 	    bundle->digests[i] = NULL;
 	}
-	memset(bundle, 0, sizeof(*bundle));
-	free(bundle);
+	delete bundle;
     }
     return NULL;
 }

--- a/rpmio/digest_libgcrypt.c
+++ b/rpmio/digest_libgcrypt.c
@@ -80,7 +80,7 @@ DIGEST_CTX rpmDigestInit(int hashalgo, rpmDigestFlags flags)
     if (!gcryalgo || gcry_md_open(&h, gcryalgo, 0) != 0)
 	return NULL;
 
-    ctx = (DIGEST_CTX)xcalloc(1, sizeof(*ctx));
+    ctx = new DIGEST_CTX_s {};
     ctx->flags = flags;
     ctx->algo = hashalgo;
     ctx->h = h;
@@ -118,7 +118,7 @@ int rpmDigestFinal(DIGEST_CTX ctx, void ** datap, size_t *lenp, int asAscii)
 	}
     }
     gcry_md_close(ctx->h);
-    free(ctx);
+    delete ctx;
     return 0;
 }
 
@@ -129,7 +129,7 @@ DIGEST_CTX rpmDigestDup(DIGEST_CTX octx)
         gcry_md_hd_t h;
 	if (gcry_md_copy(&h, octx->h))
 	    return NULL;
-	nctx = (DIGEST_CTX)memcpy(xcalloc(1, sizeof(*nctx)), octx, sizeof(*nctx));
+	nctx = new DIGEST_CTX_s { *octx };
 	nctx->h = h;
     }
     return nctx;

--- a/rpmio/digest_openssl.c
+++ b/rpmio/digest_openssl.c
@@ -28,19 +28,16 @@ DIGEST_CTX rpmDigestDup(DIGEST_CTX octx)
 {
     if (!octx) return NULL;
 
-    DIGEST_CTX nctx = NULL;
-    nctx = (DIGEST_CTX)xcalloc(1, sizeof(*nctx));
+    DIGEST_CTX nctx = new DIGEST_CTX_s { *octx };
 
-    nctx->flags = octx->flags;
-    nctx->algo = octx->algo;
     nctx->md_ctx = EVP_MD_CTX_new();
     if (!nctx->md_ctx) {
-        free(nctx);
+        delete nctx;
         return NULL;
     }
 
     if (!EVP_MD_CTX_copy(nctx->md_ctx, octx->md_ctx)) {
-        free(nctx);
+        delete nctx;
         return NULL;
     }
 
@@ -81,18 +78,18 @@ size_t rpmDigestLength(int hashalgo)
 
 DIGEST_CTX rpmDigestInit(int hashalgo, rpmDigestFlags flags)
 {
-    DIGEST_CTX ctx = (DIGEST_CTX)xcalloc(1, sizeof(*ctx));
+    DIGEST_CTX ctx = new DIGEST_CTX_s {};
 
     ctx->md_ctx = EVP_MD_CTX_new();
     if (!ctx->md_ctx) {
-        free(ctx);
+        delete ctx;
         return NULL;
     }
 
     const EVP_MD *md = getEVPMD(hashalgo);
     if (md == EVP_md_null()) {
         free(ctx->md_ctx);
-        free(ctx);
+        delete ctx;
         return NULL;
     }
 
@@ -100,7 +97,7 @@ DIGEST_CTX rpmDigestInit(int hashalgo, rpmDigestFlags flags)
     ctx->flags = flags;
     if (!EVP_DigestInit_ex(ctx->md_ctx, md, NULL)) {
         free(ctx->md_ctx);
-        free(ctx);
+        delete ctx;
         return NULL;
     }
 
@@ -158,7 +155,7 @@ done:
     }
 
     EVP_MD_CTX_free(ctx->md_ctx);
-    free(ctx);
+    delete ctx;
 
     if (ret != 1) {
         return -1;

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -2195,38 +2195,22 @@ rpmFreeMacros(rpmMacroContext mc)
 char * 
 rpmExpand(const char *arg, ...)
 {
-    size_t blen = 0;
-    char *buf = NULL, *ret = NULL;
-    char *pe;
-    const char *s;
+    if (arg == NULL)
+	return xstrdup("");
+
+    std::string buf;
+    char *ret = NULL;
     va_list ap;
-    rpmMacroContext mc;
-
-    if (arg == NULL) {
-	ret = xstrdup("");
-	goto exit;
-    }
-
-    /* precalculate unexpanded size */
-    va_start(ap, arg);
-    for (s = arg; s != NULL; s = va_arg(ap, const char *))
-	blen += strlen(s);
-    va_end(ap);
-
-    buf = (char *)xmalloc(blen + 1);
-    buf[0] = '\0';
 
     va_start(ap, arg);
-    for (pe = buf, s = arg; s != NULL; s = va_arg(ap, const char *))
-	pe = stpcpy(pe, s);
+    for (const char *s = arg; s != NULL; s = va_arg(ap, const char *))
+	buf += s;
     va_end(ap);
 
-    mc = rpmmctxAcquire(NULL);
-    (void) doExpandMacros(mc, buf, 0, &ret);
+    rpmMacroContext mc = rpmmctxAcquire(NULL);
+    (void) doExpandMacros(mc, buf.c_str(), 0, &ret);
     rpmmctxRelease(mc);
 
-    free(buf);
-exit:
     return ret;
 }
 


### PR DESCRIPTION
Convert a bunch of dynamic allocations in librpmio to native C++ new/delete to enable use of native structures in those structs and then take advantage of it. Misc other string/vector conversions too.

This is a pretty petty random stuff, the primary points being to bring the number of raw C allocations down, and at least as importantly, just to get the first real step into the C++ land over with.