### PR TITLE
Fix multiply defined local macros escaping scope

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1087,7 +1087,6 @@ RPMTEST_CLEANUP
 AT_SETUP([%define + %undefine in nested levels 3])
 AT_KEYWORDS([macros define])
 RPMTEST_CHECK([
-AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 # %define macro twice in a nested scope
 runroot rpm \
     --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %define xxx 2} %{echo:%xxx}' \
@@ -1100,6 +1099,15 @@ runroot rpm \
 .    .
 %xxx
 ])
+
+RPMTEST_CHECK([
+runroot rpm --define "aa 0" --define "my() %{define:aa 1}%{define:aa 2}" --eval "%my" --eval "%aa"
+],
+[0],
+[
+0
+],
+[ignore])
 RPMTEST_CLEANUP
 
 AT_SETUP([%define + %undefine in nested levels 4])


### PR DESCRIPTION
freeArgs() only popped any local macros once, so if a local macro was pushed multiple times, whether through %define or multiple identical options getting passed, we leaked any remaining macros to the outside scope.

Simply pop the local macros in a loop to fix. Have the internal popMacro() return the previous pointer (if any) to simplify the job. We even had an expected-fail test for this, which now passes.

This bug was circa 26 years old. Some might call it vintage at this point.

Fixes: #3056