### PR TITLE
Convert a bunch of librpm stuff to native C++ allocation (and containers)

### DIFF
--- a/lib/backend/dbi.h
+++ b/lib/backend/dbi.h
@@ -1,6 +1,8 @@
 #ifndef _DBI_H
 #define _DBI_H
 
+#include <unordered_map>
+
 #include <stdio.h>
 #include "dbiset.h"
 #include <rpm/rpmtag.h>
@@ -31,6 +33,8 @@ struct dbConfig_s {
     int	db_no_fsync;	/*!< no-op fsync for db */
 };
 
+typedef std::unordered_map<unsigned int,rpmRC> dbChk;
+
 struct rpmdbOps_s;
 
 /** \ingroup rpmdb
@@ -44,7 +48,7 @@ struct rpmdb_s {
     int		db_mode;	/*!< open mode */
     int		db_perms;	/*!< open permissions */
     const char	* db_descr;	/*!< db backend description (for error msgs) */
-    struct dbChk_s * db_checked;/*!< headerCheck()'ed package instances */
+    dbChk	db_checked;	/*!< headerCheck()'ed package instances */
     rpmdb	db_next;
     int		db_opens;
     dbiIndex	db_pkgs;	/*!< Package db */

--- a/lib/cpio.c
+++ b/lib/cpio.c
@@ -83,7 +83,7 @@ rpmcpio_t rpmcpioOpen(FD_t fd, char mode)
         (mode & O_ACCMODE) != O_WRONLY)
         return NULL;
 
-    rpmcpio_t cpio = (rpmcpio_t)xcalloc(1, sizeof(*cpio));
+    rpmcpio_t cpio = new rpmcpio_s {};
     cpio->fd = fdLink(fd);
     cpio->mode = mode;
     cpio->offset = 0;
@@ -460,7 +460,7 @@ rpmcpio_t rpmcpioFree(rpmcpio_t cpio)
     if (cpio) {
 	if (cpio->fd)
 	    (void) rpmcpioClose(cpio);
-	free(cpio);
+	delete cpio;
     }
     return NULL;
 }

--- a/lib/fprint.c
+++ b/lib/fprint.c
@@ -90,9 +90,7 @@ struct fprintCache_s {
 
 fingerPrintCache fpCacheCreate(int sizeHint, rpmstrPool pool)
 {
-    fingerPrintCache fpc;
-
-    fpc = (fingerPrintCache)xcalloc(1, sizeof(*fpc));
+    fingerPrintCache fpc = new fprintCache_s {};
     fpc->ht = rpmFpEntryHashCreate(sizeHint, sidHash, sidCmp,
 				   NULL, (rpmFpEntryHashFreeData)free);
     fpc->pool = (pool != NULL) ? rpmstrPoolLink(pool) : rpmstrPoolCreate();
@@ -105,7 +103,7 @@ fingerPrintCache fpCacheFree(fingerPrintCache cache)
 	cache->ht = rpmFpEntryHashFree(cache->ht);
 	cache->fp = rpmFpHashFree(cache->fp);
 	cache->pool = rpmstrPoolFree(cache->pool);
-	free(cache);
+	delete cache;
     }
     return NULL;
 }

--- a/lib/header.c
+++ b/lib/header.c
@@ -272,13 +272,13 @@ Header headerFree(Header h)
     }
     h->blob = _free(h->blob);
 
-    h = _free(h);
+    delete h;
     return NULL;
 }
 
 static Header headerCreate(void *blob, int32_t indexLen)
 {
-    Header h = (Header)xcalloc(1, sizeof(*h));
+    Header h = new headerToken_s {};
     if (blob) {
 	h->blob = blob;
 	h->indexAlloced = indexLen + 1;
@@ -1046,7 +1046,7 @@ rpmRC hdrblobImport(hdrblob blob, int fast, Header *hdrp, char **emsg)
 errxit:
     if (h) {
 	free(h->index);
-	free(h);
+	delete h;
 	rasprintf(emsg, _("hdr load: BAD"));
     }
     return RPMRC_FAIL;
@@ -1763,14 +1763,14 @@ HeaderIterator headerFreeIterator(HeaderIterator hi)
 {
     if (hi != NULL) {
 	hi->h = headerFree(hi->h);
-	hi = _free(hi);
+	delete hi;
     }
     return NULL;
 }
 
 HeaderIterator headerInitIterator(Header h)
 {
-    HeaderIterator hi = (HeaderIterator)xmalloc(sizeof(*hi));
+    HeaderIterator hi = new headerIterator_s {};
 
     headerSort(h);
 
@@ -1945,7 +1945,7 @@ exit:
 
 hdrblob hdrblobCreate(void)
 {
-    hdrblob blob = (hdrblob)xcalloc(1, sizeof(*blob));
+    hdrblob blob = new hdrblob_s {};
     return blob;
 }
 
@@ -1953,7 +1953,7 @@ hdrblob hdrblobFree(hdrblob blob)
 {
     if (blob) {
 	free(blob->ei);
-	free(blob);
+	delete blob;
     }
     return NULL;
 }

--- a/lib/psm.c
+++ b/lib/psm.c
@@ -592,8 +592,7 @@ static rpmpsm rpmpsmFree(rpmpsm psm)
 	rpmfilesFree(psm->files);
 	rpmtsFree(psm->ts),
 	/* XXX rpmte not refcounted yet */
-	memset(psm, 0, sizeof(*psm)); /* XXX trash and burn */
-    	free(psm);
+	delete psm;
     }
     return NULL;
 }
@@ -615,7 +614,7 @@ static int isUpdate(rpmts ts, rpmte te)
 
 static rpmpsm rpmpsmNew(rpmts ts, rpmte te, pkgGoal goal)
 {
-    rpmpsm psm = (rpmpsm)xcalloc(1, sizeof(*psm));
+    rpmpsm psm = new rpmpsm_s {};
     psm->ts = rpmtsLink(ts);
     psm->files = rpmteFiles(te);
     psm->te = te; /* XXX rpmte not refcounted yet */

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -386,7 +386,7 @@ int rpmdbClose(rpmdb db)
     db->db_checked = dbChkFree(db->db_checked);
     db->db_indexes = _free(db->db_indexes);
 
-    db = _free(db);
+    delete db;
 
 exit:
     return rc;
@@ -425,7 +425,7 @@ static rpmdb newRpmdb(const char * root, const char * home,
 	return NULL;
     }
 
-    db = (rpmdb)xcalloc(sizeof(*db), 1);
+    db = new rpmdb_s {};
 
     if (!(perms & 0600)) perms = 0644;	/* XXX sanity */
 
@@ -977,7 +977,7 @@ rpmdbMatchIterator rpmdbFreeIterator(rpmdbMatchIterator mi)
     rpmdbClose(mi->mi_db);
     mi->mi_ts = rpmtsFree(mi->mi_ts);
 
-    mi = _free(mi);
+    delete mi;
 
     return NULL;
 }
@@ -1589,7 +1589,7 @@ rpmdbMatchIterator rpmdbNewIterator(rpmdb db, rpmDbiTagVal dbitag)
 	    return NULL;
     }
 
-    mi = (rpmdbMatchIterator)xcalloc(1, sizeof(*mi));
+    mi = new rpmdbMatchIterator_s {};
     mi->mi_set = NULL;
     mi->mi_db = rpmdbLink(db);
     mi->mi_rpmtag = dbitag;
@@ -1793,7 +1793,7 @@ rpmdbIndexIterator rpmdbIndexIteratorInit(rpmdb db, rpmDbiTag rpmtag)
     if (indexOpen(db, rpmtag, 0, &dbi))
 	return NULL;
 
-    ii = (rpmdbIndexIterator)xcalloc(1, sizeof(*ii));
+    ii = new rpmdbIndexIterator_s {};
     ii->ii_db = rpmdbLink(db);
     ii->ii_rpmtag = rpmtag;
     ii->ii_dbi = dbi;
@@ -1932,7 +1932,7 @@ rpmdbIndexIterator rpmdbIndexIteratorFree(rpmdbIndexIterator ii)
     if (ii->ii_hdrNums)
 	ii->ii_hdrNums = _free(ii->ii_hdrNums);
 
-    ii = _free(ii);
+    delete ii;
     return NULL;
 }
 

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -241,8 +241,7 @@ rpmds rpmdsFree(rpmds ds)
     ds->Color = _free(ds->Color);
 
     (void) rpmdsUnlink(ds);
-    memset(ds, 0, sizeof(*ds));		/* XXX trash and burn */
-    ds = _free(ds);
+    delete ds;
     return NULL;
 }
 
@@ -250,7 +249,7 @@ static rpmds rpmdsCreate(rpmstrPool pool,
 		  rpmTagVal tagN, const char * Type, int Count,
 		  unsigned int instance)
 {
-    rpmds ds = (rpmds)xcalloc(1, sizeof(*ds));
+    rpmds ds = new rpmds_s {};
 
     ds->pool = (pool != NULL) ? rpmstrPoolLink(pool) : rpmstrPoolCreate();
     ds->tagN = tagN;

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -1242,7 +1242,7 @@ rpmfiles rpmfilesFree(rpmfiles fi)
     if (rpmfilesFC(fi) > 0) {
 	if (fi->ofndata != &fi->fndata) {
 	    rpmfnClear(fi->ofndata);
-	    free(fi->ofndata);
+	    delete fi->ofndata;
 	}
 	rpmfnClear(&fi->fndata);
 
@@ -1291,8 +1291,7 @@ rpmfiles rpmfilesFree(rpmfiles fi)
     fi->nlinks = nlinkHashFree(fi->nlinks);
 
     (void) rpmfilesUnlink(fi);
-    memset(fi, 0, sizeof(*fi));		/* XXX trash and burn */
-    fi = _free(fi);
+    delete fi;
 
     return NULL;
 }
@@ -1310,7 +1309,7 @@ rpmfi rpmfiFree(rpmfi fi)
     fi->found = _free(fi->found);
     fi->archive = rpmcpioFree(fi->archive);
 
-    free(fi);
+    delete fi;
     return NULL;
 }
 
@@ -1709,7 +1708,7 @@ static int rpmfilesPopulate(rpmfiles fi, Header h, rpmfiFlags flags)
 
 rpmfiles rpmfilesNew(rpmstrPool pool, Header h, rpmTagVal tagN, rpmfiFlags flags)
 {
-    rpmfiles fi = (rpmfiles)xcalloc(1, sizeof(*fi));
+    rpmfiles fi = new rpmfiles_s {};
     int fc;
 
     fi->magic = RPMFIMAGIC;
@@ -1732,7 +1731,7 @@ rpmfiles rpmfilesNew(rpmstrPool pool, Header h, rpmTagVal tagN, rpmfiFlags flags
 	if (headerIsEntry(h, RPMTAG_ORIGBASENAMES)) {
 	    /* For relocated packages, grab the original paths too */
 	    int ofc;
-	    fi->ofndata = (rpmfn)xmalloc(sizeof(*fi->ofndata));
+	    fi->ofndata = new rpmfn_s {};
 	    ofc = rpmfnInit(fi->ofndata, RPMTAG_ORIGBASENAMES, h, fi->pool);
 	    
 	    if (ofc != 0 && ofc != fc)
@@ -1780,7 +1779,7 @@ static rpmfi initIter(rpmfiles files, int itype, int link)
     rpmfi fi = NULL;
 
     if (files && itype>=0 && itype<=RPMFILEITERMAX) {
-	fi = (rpmfi)xcalloc(1, sizeof(*fi));
+	fi = new rpmfi_s {};
 	fi->i = -1;
 	fi->j = -1;
 	fi->files = link ? rpmfilesLink(files) : files;

--- a/lib/rpmgi.c
+++ b/lib/rpmgi.c
@@ -196,16 +196,14 @@ rpmgi rpmgiFree(rpmgi gi)
     if (gi != NULL) {
 	rpmtsFree(gi->ts);
 	argvFree(gi->argv);
-
-	memset(gi, 0, sizeof(*gi)); /* XXX trash and burn */
-	free(gi);
+	delete gi;
     }
     return NULL;
 }
 
 rpmgi rpmgiNew(rpmts ts, rpmgiFlags flags, ARGV_const_t argv)
 {
-    rpmgi gi = (rpmgi)xcalloc(1, sizeof(*gi));
+    rpmgi gi = new rpmgi_s {};
 
     gi->ts = rpmtsLink(ts);
 

--- a/lib/rpmlock.c
+++ b/lib/rpmlock.c
@@ -24,7 +24,7 @@ struct rpmlock_s {
 
 static rpmlock rpmlock_new(const char *lock_path, const char *descr)
 {
-    rpmlock lock = (rpmlock) malloc(sizeof(*lock));
+    rpmlock lock = new rpmlock_s {};
 
     if (lock != NULL) {
 	mode_t oldmask = umask(022);
@@ -35,7 +35,7 @@ static rpmlock rpmlock_new(const char *lock_path, const char *descr)
 	    if (errno == EACCES)
 		lock->fd = open(lock_path, O_RDONLY);
 	    if (lock->fd == -1) {
-		free(lock);
+		delete lock;
 		lock = NULL;
 	    } else {
 		lock->openmode = RPMLOCK_READ;
@@ -58,7 +58,7 @@ static void rpmlock_free(rpmlock lock)
 	free(lock->path);
 	free(lock->descr);
 	(void) close(lock->fd);
-	free(lock);
+	delete lock;
     }
 }
 

--- a/lib/rpmprob.c
+++ b/lib/rpmprob.c
@@ -29,7 +29,7 @@ rpmProblem rpmProblemCreate(rpmProblemType type,
                             const char * altNEVR,
                             const char * str, uint64_t number)
 {
-    rpmProblem p = (rpmProblem)xcalloc(1, sizeof(*p));
+    rpmProblem p = new rpmProblem_s {};
 
     p->type = type;
     p->key = key;
@@ -52,7 +52,7 @@ rpmProblem rpmProblemFree(rpmProblem prob)
     prob->pkgNEVR = _free(prob->pkgNEVR);
     prob->altNEVR = _free(prob->altNEVR);
     prob->str1 = _free(prob->str1);
-    free(prob);
+    delete prob;
     return NULL;
 }
 

--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -525,7 +525,7 @@ static rpmScript rpmScriptNew(Header h, rpmTagVal tag, const char *body,
 			      rpmscriptFlags flags, const char *prefix)
 {
     char *nevra = headerGetAsString(h, RPMTAG_NEVRA);
-    rpmScript script = (rpmScript)xcalloc(1, sizeof(*script));
+    rpmScript script = new rpmScript_s {};
     script->tag = tag;
     script->type = getScriptType(tag);
     script->flags = getDefFlags(tag) | flags;
@@ -553,7 +553,7 @@ static rpmScript rpmScriptNew(Header h, rpmTagVal tag, const char *body,
 void rpmScriptSetNextFileFunc(rpmScript script, nextfilefunc func,
 			    void *param)
 {
-    script->nextFileFunc = (struct scriptNextFileFunc_s *)xmalloc(sizeof(*script->nextFileFunc));
+    script->nextFileFunc = new scriptNextFileFunc_s {};
     script->nextFileFunc->func = func;
     script->nextFileFunc->param = param;
 }
@@ -706,8 +706,8 @@ rpmScript rpmScriptFree(rpmScript script)
 	free(script->args);
 	free(script->body);
 	free(script->descr);
-	free(script->nextFileFunc);
-	free(script);
+	delete script->nextFileFunc;
+	delete script;
     }
     return NULL;
 }

--- a/lib/rpmtd.c
+++ b/lib/rpmtd.c
@@ -9,7 +9,7 @@
 
 rpmtd rpmtdNew(void)
 {
-    rpmtd td = (rpmtd)xmalloc(sizeof(*td));
+    rpmtd td = new rpmtd_s {};
     rpmtdReset(td);
     return td;
 }
@@ -19,7 +19,7 @@ rpmtd rpmtdFree(rpmtd td)
     /* permit free on NULL td */
     if (td != NULL) {
 	rpmtdFreeData(td);
-	free(td);
+	delete td;
     }
     return NULL;
 }

--- a/lib/rpmte.c
+++ b/lib/rpmte.c
@@ -4,6 +4,8 @@
  */
 #include "system.h"
 
+#include <vector>
+
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmlib.h>		/* RPM_MACHTABLE_* */
 #include <rpm/rpmmacro.h>
@@ -256,8 +258,7 @@ rpmte rpmteFree(rpmte te)
 	rpmpsFree(te->probs);
 	rpmteCleanDS(te);
 
-	memset(te, 0, sizeof(*te));	/* XXX trash and burn */
-	free(te);
+	delete te;
     }
     return NULL;
 }
@@ -265,7 +266,7 @@ rpmte rpmteFree(rpmte te)
 rpmte rpmteNew(rpmts ts, Header h, rpmElementType type, fnpyKey key,
 	       rpmRelocation * relocs, int addop)
 {
-    rpmte p = (rpmte)xcalloc(1, sizeof(*p));
+    rpmte p = new rpmte_s {};
     p->ts = ts;
     p->type = type;
     p->addop = addop;
@@ -492,7 +493,6 @@ static void rpmteColorDS(rpmte te, rpmTag tag)
     char deptype = rpmdsD(ds);
     char mydt;
     const uint32_t * ddict;
-    rpm_color_t * colors;
     rpm_color_t val;
     int Count;
     unsigned ix;
@@ -501,7 +501,7 @@ static void rpmteColorDS(rpmte te, rpmTag tag)
     if (!(te && deptype && (Count = rpmdsCount(ds)) > 0 && rpmfilesFC(te->files) > 0))
 	return;
 
-    colors = (rpm_color_t *)xcalloc(Count, sizeof(*colors));
+    std::vector<rpm_color_t> colors(Count, 0);
 
     /* Calculate dependency color. */
     fi = rpmfilesIter(te->files, RPMFI_ITER_FWD);
@@ -528,7 +528,6 @@ assert (ix < Count);
 	te->color |= val;
 	(void) rpmdsSetColor(ds, val);
     }
-    free(colors);
     rpmfiFree(fi);
 }
 

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -835,7 +835,7 @@ rpmts rpmtsFree(rpmts ts)
     tsmem->removedPackages = packageHashFree(tsmem->removedPackages);
     tsmem->installedPackages = packageHashFree(tsmem->installedPackages);
     tsmem->order = _free(tsmem->order);
-    ts->members = _free(ts->members);
+    delete ts->members;
 
     ts->dsi = _free(ts->dsi);
 
@@ -859,8 +859,7 @@ rpmts rpmtsFree(rpmts ts)
 	rpmtsPrintStats(ts);
 
     (void) rpmtsUnlink(ts);
-
-    ts = _free(ts);
+    delete ts;
 
     return NULL;
 }
@@ -1190,7 +1189,7 @@ static int vfylevel_init(void)
 
 rpmts rpmtsCreate(void)
 {
-    rpmts ts = (rpmts)xcalloc(1, sizeof(*ts));
+    rpmts ts = new rpmts_s {};
     tsMembers tsmem;
     char *source_date_epoch = NULL;
 
@@ -1241,7 +1240,7 @@ rpmts rpmtsCreate(void)
 	free(tmp);
     }
 
-    tsmem = (tsMembers)xcalloc(1, sizeof(*ts->members));
+    tsmem = new tsMembers_s {};
     tsmem->pool = NULL;
     tsmem->delta = 5;
     tsmem->addedPackages = NULL;
@@ -1288,16 +1287,14 @@ rpmtsi rpmtsiFree(rpmtsi tsi)
     /* XXX watchout: a funky recursion segfaults here iff nrefs is wrong. */
     if (tsi) {
 	tsi->ts = rpmtsFree(tsi->ts);
-	_free(tsi);
+	delete tsi;
     }
     return NULL;
 }
 
 rpmtsi rpmtsiInit(rpmts ts)
 {
-    rpmtsi tsi = NULL;
-
-    tsi = (rpmtsi)xcalloc(1, sizeof(*tsi));
+    rpmtsi tsi = new rpmtsi_s {};
     tsi->ts = rpmtsLink(ts);
     tsi->oc = 0;
     return tsi;
@@ -1364,7 +1361,7 @@ rpmtxn rpmtxnBegin(rpmts ts, rpmtxnFlags flags)
 	ts->lock = rpmlockNew(ts->lockPath, _("transaction"));
 
     if (rpmlockAcquire(ts->lock)) {
-	txn = (rpmtxn)xcalloc(1, sizeof(*txn));
+	txn = new rpmtxn_s {};
 	txn->lock = ts->lock;
 	txn->flags = flags;
 	txn->ts = rpmtsLink(ts);
@@ -1382,7 +1379,7 @@ rpmtxn rpmtxnEnd(rpmtxn txn)
 	if (txn->flags & RPMTXN_WRITE)
 	    rpmsqBlock(SIG_UNBLOCK);
 	rpmtsFree(txn->ts);
-	free(txn);
+	delete txn;
     }
     return NULL;
 }

--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -352,7 +352,7 @@ void rpmvsAppendTag(struct rpmvs_s *vs, hdrblob blob, rpmTagVal tag)
 
 struct rpmvs_s *rpmvsCreate(int vfylevel, rpmVSFlags vsflags, rpmKeyring keyring)
 {
-    struct rpmvs_s *sis = (struct rpmvs_s *)xcalloc(1, sizeof(*sis));
+    struct rpmvs_s *sis = new rpmvs_s {};
     sis->vsflags = vsflags;
     sis->keyring = rpmKeyringLink(keyring);
     sis->vfylevel = vfylevel;
@@ -387,7 +387,7 @@ struct rpmvs_s *rpmvsFree(struct rpmvs_s *sis)
 	    rpmsinfoFini(&sis->sigs[i]);
 	}
 	free(sis->sigs);
-	free(sis);
+	delete sis;
     }
     return NULL;
 }


### PR DESCRIPTION
Nothing hugely interesting in here, see commit 0d1071b99ada2df920ba657d9e015e0c2259d4b6 for rationale.

There are bits and pieces to finish in librpmio side still but moving on to librpm as some of this stuff is linked, eg string pool cannot use C++ containers before rpmds is updated to clean up after itself, otherwise there will be an unfixable indirect leak from rpmlibProvides_s struct on process exit :zany_face: 