### PR TITLE
Fix header source/patch names disagreeing with src.rpm contents

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -716,20 +716,22 @@ static void initSourceHeader(rpmSpec spec)
 
     /* Add tags for sources and patches */
     for (srcPtr = spec->sources; srcPtr != NULL; srcPtr = srcPtr->next) {
+	char *fn = rpmExpand(srcPtr->source, NULL);
 	if (srcPtr->flags & RPMBUILD_ISSOURCE) {
-	    headerPutString(sourcePkg->header, RPMTAG_SOURCE, srcPtr->source);
+	    headerPutString(sourcePkg->header, RPMTAG_SOURCE, fn);
 	    if (srcPtr->flags & RPMBUILD_ISNO) {
 		headerPutUint32(sourcePkg->header, RPMTAG_NOSOURCE,
 				&srcPtr->num, 1);
 	    }
 	}
 	if (srcPtr->flags & RPMBUILD_ISPATCH) {
-	    headerPutString(sourcePkg->header, RPMTAG_PATCH, srcPtr->source);
+	    headerPutString(sourcePkg->header, RPMTAG_PATCH, fn);
 	    if (srcPtr->flags & RPMBUILD_ISNO) {
 		headerPutUint32(sourcePkg->header, RPMTAG_NOPATCH,
 				&srcPtr->num, 1);
 	    }
 	}
+	free(fn);
     }
     if (spec->sourceRpmName == NULL) {
 	char *nvr = headerGetAsString(spec->packages->header, RPMTAG_NVR);

--- a/tests/data/SPECS/macrosource.spec
+++ b/tests/data/SPECS/macrosource.spec
@@ -1,0 +1,15 @@
+Name:           macrosource
+Version:        0
+Release:        0
+Summary:        ...
+License:        Public Domain
+BuildArch:      noarch
+Source0:	%{somemacro}-2.0.tar.gz
+Patch0:		%{somemacro}-1.0-install.patch
+
+%define somemacro hello
+
+%description
+...
+
+%files

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3037,3 +3037,34 @@ runroot_other /usr/sbin/getcap /usr/bin/test
 [])
 
 RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild -bs with source macro])
+AT_KEYWORDS([build])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+runroot rpmbuild --quiet -bs /data/SPECS/macrosource.spec
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -ql /build/SRPMS/macrosource-0-0.src.rpm
+],
+[0],
+[hello-1.0-install.patch
+hello-2.0.tar.gz
+macrosource.spec
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -q --qf "[%{SOURCE}\n]" --qf "[%{PATCH}\n]" /build/SRPMS/macrosource-0-0.src.rpm
+],
+[0],
+[hello-2.0.tar.gz
+hello-1.0-install.patch
+],
+[])
+RPMTEST_CLEANUP


### PR DESCRIPTION
If sources or patches in the spec are defined via a macro that does not yet exist, it'll still work for building if the macro has been defined by that time as there's another round of expansion there. But this can leave the source/patch names inserted to the header disagreeing with what actually ended up in the source package, eg in the testcase you'd previously get '%{somemacro}-2.0.tar.gz' in the header whereas the src.rpm had the right contents.

While defining sources this way seems mad and brittle, it does actually work for building rpms and there's a whole ecosystem of packages relying on it in Fedora. So lets at least be consistent about it, and re-expand the source paths once more before inserting in the header, because that's what happens for them in the actual build as well.

Originally reported at https://bugzilla.redhat.com/show_bug.cgi?id=2233878