### PR TITLE
Drop architecture from %builddir path

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -1295,7 +1295,7 @@ int parsePreamble(rpmSpec spec, int initialPackage, enum parseStages stage)
 	    }
 
 	    /* Using release here causes a buildid no-recompute test to fail */
-	    spec->buildDir = rpmExpand("%{_top_builddir}/%{NAME}-%{VERSION}-%{_arch}", NULL);
+	    spec->buildDir = rpmExpand("%{_top_builddir}/%{NAME}-%{VERSION}-build", NULL);
 	    /* Override toplevel _builddir for backwards compatibility */
 	    rpmPushMacroFlags(spec->macros, "_builddir", NULL, spec->buildDir,
 				RMIL_SPEC, RPMMACRO_LITERAL);

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -273,12 +273,12 @@ runroot_other find /build/BUILD|sort
 ],
 [0],
 [/build/BUILD
-/build/BUILD/simple-1.0-noarch
-/build/BUILD/simple-1.0-noarch/BUILDROOT
-/build/BUILD/simple-1.0-noarch/BUILDROOT/opt
-/build/BUILD/simple-1.0-noarch/BUILDROOT/opt/bin
-/build/BUILD/simple-1.0-noarch/BUILDROOT/opt/bin/simple
-/build/BUILD/simple-1.0-noarch/simple
+/build/BUILD/simple-1.0-build
+/build/BUILD/simple-1.0-build/BUILDROOT
+/build/BUILD/simple-1.0-build/BUILDROOT/opt
+/build/BUILD/simple-1.0-build/BUILDROOT/opt/bin
+/build/BUILD/simple-1.0-build/BUILDROOT/opt/bin/simple
+/build/BUILD/simple-1.0-build/simple
 ],
 [ignore])
 
@@ -291,18 +291,18 @@ runroot_other find /build/BUILD|sort
 ],
 [0],
 [/build/BUILD
-/build/BUILD/simple-1.0-noarch
-/build/BUILD/simple-1.0-noarch/BUILDROOT
-/build/BUILD/simple-1.0-noarch/BUILDROOT/opt
-/build/BUILD/simple-1.0-noarch/BUILDROOT/opt/bin
-/build/BUILD/simple-1.0-noarch/BUILDROOT/opt/bin/simple
-/build/BUILD/simple-1.0-noarch/SPECPARTS
-/build/BUILD/simple-1.0-noarch/simple-1.0
-/build/BUILD/simple-1.0-noarch/simple-1.0/dir1
-/build/BUILD/simple-1.0-noarch/simple-1.0/dir1/file3
-/build/BUILD/simple-1.0-noarch/simple-1.0/file1
-/build/BUILD/simple-1.0-noarch/simple-1.0/file2
-/build/BUILD/simple-1.0-noarch/simple-1.0/simple
+/build/BUILD/simple-1.0-build
+/build/BUILD/simple-1.0-build/BUILDROOT
+/build/BUILD/simple-1.0-build/BUILDROOT/opt
+/build/BUILD/simple-1.0-build/BUILDROOT/opt/bin
+/build/BUILD/simple-1.0-build/BUILDROOT/opt/bin/simple
+/build/BUILD/simple-1.0-build/SPECPARTS
+/build/BUILD/simple-1.0-build/simple-1.0
+/build/BUILD/simple-1.0-build/simple-1.0/dir1
+/build/BUILD/simple-1.0-build/simple-1.0/dir1/file3
+/build/BUILD/simple-1.0-build/simple-1.0/file1
+/build/BUILD/simple-1.0-build/simple-1.0/file2
+/build/BUILD/simple-1.0-build/simple-1.0/simple
 ],
 [ignore])
 RPMTEST_CLEANUP
@@ -2416,17 +2416,17 @@ runroot rpmbuild -bb --quiet /data/SPECS/filemiss.spec
 ],
 [1],
 [],
-[error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/doc/filemisstest-1.0/CREDITS
-error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/foo
-error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/bar{a,b}
-cp: cannot stat '/build/BUILD/filemisstest-1.0-x86_64/INSTALL': No such file or directory
-cp: cannot stat '/build/BUILD/filemisstest-1.0-x86_64/README*': No such file or directory
-error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/doc/filemisstest-1.0/INSTALL
-error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/doc/filemisstest-1.0/README*
-cp: cannot stat '/build/BUILD/filemisstest-1.0-x86_64/LICENSE': No such file or directory
-cp: cannot stat '/build/BUILD/filemisstest-1.0-x86_64/OTHERLICENSE?': No such file or directory
-error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/licenses/filemisstest-1.0/LICENSE
-error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
+[error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/share/doc/filemisstest-1.0/CREDITS
+error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/foo
+error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/bar{a,b}
+cp: cannot stat '/build/BUILD/filemisstest-1.0-build/INSTALL': No such file or directory
+cp: cannot stat '/build/BUILD/filemisstest-1.0-build/README*': No such file or directory
+error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/share/doc/filemisstest-1.0/INSTALL
+error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/share/doc/filemisstest-1.0/README*
+cp: cannot stat '/build/BUILD/filemisstest-1.0-build/LICENSE': No such file or directory
+cp: cannot stat '/build/BUILD/filemisstest-1.0-build/OTHERLICENSE?': No such file or directory
+error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/share/licenses/filemisstest-1.0/LICENSE
+error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
 ],
 )
 RPMTEST_CLEANUP

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -326,7 +326,7 @@ Prefix: /usr
 Simple rpm demonstration.
 
 %prep
-cd '/build/BUILD/hello-1.0-x86_64'
+cd '/build/BUILD/hello-1.0-build'
 rm -rf 'hello-1.0'
 /usr/lib/rpm/rpmuncompress -x '/build/SOURCES/hello-1.0.tar.gz'
 STATUS=$?
@@ -334,8 +334,8 @@ if [ $STATUS -ne 0 ]; then
   exit $STATUS
 fi
 cd 'hello-1.0'
-rm -rf '/build/BUILD/hello-1.0-x86_64/SPECPARTS'
-/usr/bin/mkdir -p '/build/BUILD/hello-1.0-x86_64/SPECPARTS'
+rm -rf '/build/BUILD/hello-1.0-build/SPECPARTS'
+/usr/bin/mkdir -p '/build/BUILD/hello-1.0-build/SPECPARTS'
 /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
 
 echo "Patch #0 (hello-1.0-modernize.patch):"


### PR DESCRIPTION
This causes more issues than it solves, at least presently. For one, when BuildArch is used it typically causes the path to disagree with the actual arch (eg on noarch packages). Which looks weird and causes yet other issues in turn. The other issue, raised by Neal Gompa, is that it can cause superfluous path differences in noarch subpackages, which sharing the noarch package across multiple architectures in at least koji.

Use -build suffix instead of %{_arch}. -build may seem redundant since by default it's in BUILD directory already, but this makes it more obvious in cases where the default is overridden (eg fedpkg overrides to current directory), and helps differentiating it from the %buildsubdir directory commonly created by %setup.

Suggested-by: Neal Gompa <neal@gompa.dev>