### PR TITLE
Automatically reload rpm configuration on mismatching BuildArch

### DIFF
--- a/tests/data/SPECS/templ.spec
+++ b/tests/data/SPECS/templ.spec
@@ -1,0 +1,12 @@
+Name: templ
+Version: 1
+Release: 1
+License: Public domain
+Summary: Spec template tests
+BuildArch: noarch
+
+%description
+%{summary}
+
+%build
+echo BUILD ${RPM_ARCH} %{_arch} %{_target_cpu} >> /tmp/build.out

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1105,7 +1105,7 @@ RPMDB_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '__script_mime text/plain' \
-		--undefine '__script_magic' \
+		--define '__script_magic %{nil}' \
 		/data/SPECS/shebang.spec
 runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^rpmlib
 ],
@@ -3065,6 +3065,58 @@ runroot rpm -q --qf "[%{SOURCE}\n]" --qf "[%{PATCH}\n]" /build/SRPMS/macrosource
 [0],
 [hello-2.0.tar.gz
 hello-1.0-install.patch
+],
+[])
+RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild target macro sanity])
+AT_KEYWORDS([build])
+RPMDB_INIT
+
+# This is surprisingly tricky - we need to place these macros in a place
+# that is after the platform stuff in macro path so we can't just drop
+# into macros.d, and then we need to take cmake prefix into account,
+# escape \'s and $'s and whatnot. Pff. Would be easier to place to
+# a macro file, but this is so tightly coupled that seems saner to
+# have it all here.
+etcdir=$(runroot rpm --eval "%_sysconfdir")
+mkdir -p ${RPMTEST}/${etcdir}/rpm/
+
+cat << EOF >> ${RPMTEST}/${etcdir}/rpm/macros.template
+%__spec_build_pre\\
+%{___build_pre_env}\\
+echo BUILD_PRE \${RPM_ARCH} %{_arch} %{_target_cpu} >> /tmp/build.out\\
+%{nil}
+
+%__spec_build_post\\
+echo BUILD_POST \${RPM_ARCH} %{_arch} %{_target_cpu} >> /tmp/build.out\\
+%{nil}
+EOF
+
+RPMTEST_CHECK([
+runroot_other rm -f /tmp/build.out
+runroot rpmbuild --quiet \
+	-bc /data/SPECS/templ.spec
+runroot_other cat /tmp/build.out
+],
+[0],
+[BUILD_PRE noarch noarch noarch
+BUILD noarch noarch noarch
+BUILD_POST noarch noarch noarch
+],
+[])
+
+RPMTEST_CHECK([
+runroot_other rm -f /tmp/build.out
+runroot rpmbuild --quiet \
+	--target noarch \
+	-bc /data/SPECS/templ.spec
+runroot_other cat /tmp/build.out
+],
+[0],
+[BUILD_PRE noarch noarch noarch
+BUILD noarch noarch noarch
+BUILD_POST noarch noarch noarch
 ],
 [])
 RPMTEST_CLEANUP

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -549,8 +549,8 @@ static int build(rpmts ts, const char * arg, BTA_t ba, const char * rcfile)
     }
 
     /* parse up the build operators */
-
-    fprintf(stderr, _("Building target platforms: %s\n"), targets);
+    if (!quiet)
+	fprintf(stderr, _("Building target platforms: %s\n"), targets);
 
     ba->buildAmount &= ~buildCleanMask;
     for (ARGV_const_t target = build_targets; target && *target; target++) {
@@ -558,7 +558,8 @@ static int build(rpmts ts, const char * arg, BTA_t ba, const char * rcfile)
 	if (*(target + 1) == NULL)
 	    ba->buildAmount |= cleanFlags;
 
-	fprintf(stderr, _("Building for target %s\n"), *target);
+	if (!quiet)
+	    fprintf(stderr, _("Building for target %s\n"), *target);
 
 	/* Read in configuration for target. */
 	rpmFreeMacros(NULL);


### PR DESCRIPTION
When BuildArch is encountered during spec parse, rpm recurses the parse, but this doesn't reset/reload the global configuration and macros to match. So eg a "BuildArch: noarch" package gets built with a dramatically different macros depending on whether "--target noarch" was used or not, whereas people expect it to be the same - after all we give zero indication that anything might be wrong when --target wasn't specified.
    
Automatically detect and handle this condition in the rpmbuild tool: if the spec parse architecture disagrees with our loaded configuration, request a reparse with reloaded configuration for the matching target. This ensures 'rpmbuild -bb noarch.spec' and 'rpmbuild -bb --target noarch noarch.spec' run with the same exact configuration. 
Doing this also fixes the situation where build-time macro expansion of build scriptlets (for template bits and dynamically generated spec parts) yields totally different (bogus) than in the initial spec parse. This also goes for RPM_ARCH environment and similar.
    
Avoid --undefine for dependency generation test, it doesn't work.  --undefine with --target was always broken, now it's just more visible since it automatically applies to BuildArch too. Fixing that is a  separate matter (#3070).
    
A more sophisticated fix could be having a stack of macro contexts that we copy, push and pop as necessary. That ought to solve the undefine too.
    
Fixes: #3049