### PR TITLE
Remove C++ guards from internal headers

### DIFF
--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -282,10 +282,6 @@ typedef enum rpmParseState_e {
 
 #define ALLOW_EMPTY         (1 << 16)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmbuild
  * Create and initialize rpmSpec structure.
  * @return spec		spec file control structure
@@ -671,9 +667,5 @@ void doPatchMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
 /* Return section number, -1 on error */
 RPM_GNUC_INTERNAL
 const struct sectname_s *getSection(const char *name, int part);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _RPMBUILD_INTERNAL_H */

--- a/build/rpmbuild_misc.h
+++ b/build/rpmbuild_misc.h
@@ -5,10 +5,6 @@
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmds.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmbuild
  * Truncate comment lines.
  * @param s		skip white space, truncate line at '#'
@@ -65,9 +61,5 @@ void appendStringBufAux(StringBuf sb, const char * s, int nl);
  */
 RPM_GNUC_INTERNAL
 int parseUnsignedNum(const char * line, uint32_t * res);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _RPMBUILD_MISC_H */

--- a/lib/backend/dbi.h
+++ b/lib/backend/dbi.h
@@ -121,10 +121,6 @@ union _dbswap {
 typedef rpmRC (*idxfunc)(dbiIndex dbi, dbiCursor dbc,
 			const char *keyp, size_t keylen, dbiIndexItem rec);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 RPM_GNUC_INTERNAL
 rpmRC tag2index(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h,
 		idxfunc idxupdate);
@@ -283,9 +279,5 @@ extern struct rpmdbOps_s sqlite_dbops;
 
 RPM_GNUC_INTERNAL
 extern struct rpmdbOps_s dummydb_dbops;
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _DBI_H */

--- a/lib/backend/dbiset.h
+++ b/lib/backend/dbiset.h
@@ -16,10 +16,6 @@ typedef struct dbiIndexSet_s {
     size_t alloced;			/*!< alloced size */
 } * dbiIndexSet;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Create an empty index set, optionally with sizehint reservation for recs */
 RPM_GNUC_INTERNAL
 dbiIndexSet dbiIndexSetNew(unsigned int sizehint);
@@ -124,7 +120,4 @@ unsigned int dbiIndexRecordFileNumber(dbiIndexSet set, unsigned int recno);
 RPM_GNUC_INTERNAL
 dbiIndexSet dbiIndexSetFree(dbiIndexSet set);
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/lib/cpio.h
+++ b/lib/cpio.h
@@ -14,10 +14,6 @@
 
 typedef struct rpmcpio_s * rpmcpio_t;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * Create CPIO file object
  * @param fd		file
@@ -71,9 +67,5 @@ RPM_GNUC_INTERNAL
 void rpmcpioSetExpectedFileSize(rpmcpio_t cpio, off_t fsize);
 
 ssize_t rpmcpioRead(rpmcpio_t cpio, void * buf, size_t size);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* H_CPIO */

--- a/lib/fprint.h
+++ b/lib/fprint.h
@@ -22,10 +22,6 @@ struct rpmffi_s {
   int   fileno;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * Create finger print cache.
  * @param sizeHint	number of elements expected
@@ -116,9 +112,5 @@ RPM_GNUC_INTERNAL
 fingerPrint * fpLookupList(fingerPrintCache cache, rpmstrPool pool,
 			   rpmsid * dirNames, rpmsid * baseNames,
 			   const uint32_t * dirIndexes, int fileCount);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/lib/fsm.h
+++ b/lib/fsm.h
@@ -9,10 +9,6 @@
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcallback.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef struct rpmpsm_s * rpmpsm;
 
 /**
@@ -36,8 +32,5 @@ int rpmfiArchiveReadToFilePsm(rpmfi fi, FD_t fd, int nodigest, rpmpsm psm);
 
 RPM_GNUC_INTERNAL
 void rpmpsmNotify(rpmpsm psm, rpmCallbackType what, rpm_loff_t amount);
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* H_FSM */

--- a/lib/header_internal.h
+++ b/lib/header_internal.h
@@ -24,10 +24,6 @@ struct hdrblob_s {
     uint32_t rdl;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 RPM_GNUC_INTERNAL
 hdrblob hdrblobCreate(void);
 
@@ -65,8 +61,5 @@ ssize_t Freadall(FD_t fd, void * buf, ssize_t size);
 
 RPM_GNUC_INTERNAL
 int headerIsSourceHeuristic(Header h);
-#ifdef __cplusplus
-}   
-#endif
 
 #endif  /* H_HEADER_INTERNAL */

--- a/lib/manifest.h
+++ b/lib/manifest.h
@@ -6,10 +6,6 @@
  * Routines to expand a manifest containing glob expressions into an argv list.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * Return ls(1)-like formatted mode string.
  * @param mode		file mode
@@ -26,9 +22,5 @@ char * rpmPermsString(int mode)
  * @return		RPMRC_OK on success
  */
 rpmRC rpmReadPackageManifest(FD_t fd, int * argcPtr, char *** argvPtr);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* H_MANIFEST */

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -13,10 +13,6 @@
 
 typedef const struct headerFmt_s * headerFmt;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* known arch? */
 RPM_GNUC_INTERNAL
 int rpmIsKnownArch(const char *name);
@@ -61,9 +57,5 @@ int rpmRelocateSrpmFileList(Header h, const char *rootDir);
 RPM_GNUC_INTERNAL
 void rpmRelocationBuild(Header h, rpmRelocation *rawrelocs,
 		int *rnrelocs, rpmRelocation **rrelocs, uint8_t **rbadrelocs);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* H_MISC */

--- a/lib/rpmal.h
+++ b/lib/rpmal.h
@@ -9,10 +9,6 @@
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmts.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef struct rpmal_s * rpmal;
 
 /**
@@ -84,9 +80,5 @@ rpmte rpmalSatisfiesDepend(const rpmal al, const rpmte te, const rpmds ds);
  */
 RPM_GNUC_INTERNAL
 unsigned int rpmalLookupTE(const rpmal al, const rpmte te);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* H_RPMAL */

--- a/lib/rpmchroot.h
+++ b/lib/rpmchroot.h
@@ -3,10 +3,6 @@
 
 #include <rpm/rpmutil.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmchroot
  * Set or clear process-wide chroot directory.
  * Calling this while chrooted is an error.
@@ -36,10 +32,5 @@ int rpmChrootOut(void);
  */
 /* RPM_GNUC_INTERNAL */
 int rpmChrootDone(void);
-
-#ifdef __cplusplus
-}
-#endif
-
 
 #endif /* _RPMCHROOT_H */

--- a/lib/rpmdb_internal.h
+++ b/lib/rpmdb_internal.h
@@ -8,10 +8,6 @@
 #include <rpm/rpmutil.h>
 #include "backend/dbi.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define HASHTYPE packageHash
 #define HTKEYTYPE unsigned int
 #define HTDATATYPE struct rpmte_s *
@@ -213,9 +209,5 @@ unsigned int rpmdbGetIteratorOffsetFor(rpmdbMatchIterator mi, unsigned int ix);
  */
 RPM_GNUC_INTERNAL
 Header rpmdbGetHeaderAt(rpmdb db, unsigned int offset);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/lib/rpmds_internal.h
+++ b/lib/rpmds_internal.h
@@ -3,10 +3,6 @@
 
 #include <rpm/rpmds.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmds
  * Swiss army knife dependency matching function.
  * @param pool		string pool (or NULL for private pool)
@@ -86,8 +82,5 @@ int rpmdsCompareIndex(rpmds A, int aix, rpmds B, int bix);
  */
 RPM_GNUC_INTERNAL
 rpmds rpmdsFilterTi(rpmds ds, int ti);
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _RPMDS_INTERNAL_H */

--- a/lib/rpmfi_internal.h
+++ b/lib/rpmfi_internal.h
@@ -9,10 +9,6 @@
 
 #define	RPMFIMAGIC	0x09697923
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmfi
  * Callback on file iterator directory changes
  * @param fi		file info
@@ -124,9 +120,6 @@ rpmfiles rpmfiFiles(rpmfi fi);
  */
 RPM_GNUC_INTERNAL
 rpmfi rpmfilesFindPrefix(rpmfiles fi, const char *pfx);
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* _RPMFI_INTERNAL_H */
 

--- a/lib/rpmfs.h
+++ b/lib/rpmfs.h
@@ -18,10 +18,6 @@ struct sharedFileInfo_s {
     char rstate;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 RPM_GNUC_INTERNAL
 rpmfs rpmfsNew(rpm_count_t fc, int initState);
 
@@ -56,9 +52,5 @@ void rpmfsSetAction(rpmfs fs, unsigned int ix, rpmFileAction action);
 
 RPM_GNUC_INTERNAL
 void rpmfsResetActions(rpmfs fs);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _RPMFS_H */

--- a/lib/rpmgi.h
+++ b/lib/rpmgi.h
@@ -8,10 +8,6 @@
 #include <rpm/rpmtypes.h>
 #include <rpm/argv.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmgi
  */
 enum rpmgiFlags_e {
@@ -57,9 +53,5 @@ Header rpmgiNext(rpmgi gi);
  */
 RPM_GNUC_INTERNAL
 int rpmgiNumErrors(rpmgi gi);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* H_RPMGI */

--- a/lib/rpmlead.h
+++ b/lib/rpmlead.h
@@ -5,10 +5,6 @@
  * \file rpmlead.h
  * Routines to read and write an rpm lead structure for a a package.
  */
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define RPMLEAD_BINARY 0
 #define RPMLEAD_SOURCE 1
 
@@ -34,9 +30,5 @@ rpmRC rpmLeadWrite(FD_t fd, Header h);
  * @return		RPMRC_OK on success, RPMRC_FAIL/RPMRC_NOTFOUND on error
  */
 rpmRC rpmLeadRead(FD_t fd, char **emsg);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* _H_RPMLEAD */

--- a/lib/rpmlock.h
+++ b/lib/rpmlock.h
@@ -11,10 +11,6 @@ enum {
     RPMLOCK_WAIT   = 1 << 2,
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 RPM_GNUC_INTERNAL
 rpmlock rpmlockNew(const char *lock_path, const char *descr);
 
@@ -29,9 +25,5 @@ void rpmlockRelease(rpmlock lock);
 
 RPM_GNUC_INTERNAL
 rpmlock rpmlockFree(rpmlock lock);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/lib/rpmplugins.h
+++ b/lib/rpmplugins.h
@@ -5,10 +5,6 @@
 #include <rpm/rpmfi.h>
 #include <rpm/rpmplugin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmplugins
  * Create a new plugins structure
  * @param ts		transaction set
@@ -168,7 +164,4 @@ rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
                                    int fd, const char *path, const char *dest,
                                    mode_t mode, rpmFsmOp op);
 
-#ifdef __cplusplus
-}
-#endif
 #endif	/* _PLUGINS_H */

--- a/lib/rpmscript.h
+++ b/lib/rpmscript.h
@@ -47,10 +47,6 @@ typedef struct rpmScript_s * rpmScript;
 
 typedef const char *(*nextfilefunc)(void *);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 RPM_GNUC_INTERNAL
 rpmTagVal triggerDsTag(rpmscriptTriggerModes tm);
 
@@ -96,7 +92,4 @@ int rpmScriptChrootIn(rpmScript script);
 RPM_GNUC_INTERNAL
 int rpmScriptChrootOut(rpmScript script);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* _RPMSCRIPT_H */

--- a/lib/rpmte_internal.h
+++ b/lib/rpmte_internal.h
@@ -34,10 +34,6 @@ enum addOp_e {
   RPMTE_RESTORE       = 3,
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmte
  * Create a transaction element.
  * @param ts		transaction set
@@ -121,10 +117,6 @@ rpmRC rpmpsmRun(rpmts ts, rpmte te, pkgGoal goal);
 
 RPM_GNUC_INTERNAL
 int rpmteAddOp(rpmte te);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* _RPMTE_INTERNAL_H */
 

--- a/lib/rpmtriggers.h
+++ b/lib/rpmtriggers.h
@@ -16,11 +16,6 @@ typedef struct rpmtriggers_s {
     int alloced;
 } *rpmtriggers;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 RPM_GNUC_INTERNAL
 rpmtriggers rpmtriggersCreate(unsigned int hint);
 
@@ -78,8 +73,5 @@ rpmRC runFileTriggers(rpmts ts, rpmte te, int arg2, rpmsenseFlags sense,
 RPM_GNUC_INTERNAL
 rpmRC runImmedFileTriggers(rpmts ts, rpmte te, int arg1, rpmsenseFlags sense,
 			    rpmscriptTriggerModes tm, int priorityClass);
-#ifdef __cplusplus
-}
-#endif
 #endif /* _RPMTRIGGERS_H */
 

--- a/lib/rpmts_internal.h
+++ b/lib/rpmts_internal.h
@@ -96,10 +96,6 @@ struct rpmts_s {
     time_t overrideTime;	/*!< Time value used when overriding system clock. */
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmts
  * Return transaction global string pool handle, creating the pool if needed.
  * @param ts		transaction set
@@ -141,7 +137,4 @@ int rpmtsNotifyChange(rpmts ts, int event, rpmte te, rpmte other);
 RPM_GNUC_INTERNAL
 rpm_time_t rpmtsGetTime(rpmts ts, time_t step);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* _RPMTS_INTERNAL_H */

--- a/lib/rpmug.h
+++ b/lib/rpmug.h
@@ -4,10 +4,6 @@
 #include <rpm/rpmutil.h>
 #include <sys/types.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 RPM_GNUC_INTERNAL
 int rpmugUid(const char * name, uid_t * uid);
 
@@ -22,10 +18,5 @@ const char * rpmugGname(gid_t gid);
 
 RPM_GNUC_INTERNAL
 void rpmugFree(void);
-
-#ifdef __cplusplus
-}
-#endif
-
 
 #endif /* _RPMUG_H */

--- a/lib/rpmvs.h
+++ b/lib/rpmvs.h
@@ -45,10 +45,6 @@ struct rpmsinfo_s {
  */
 typedef int (*rpmsinfoCb)(struct rpmsinfo_s *sinfo, void *cbdata);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 const char *rpmsinfoDescr(struct rpmsinfo_s *sinfo);
 
 char *rpmsinfoMsg(struct rpmsinfo_s *sinfo);
@@ -74,9 +70,5 @@ int rpmvsVerify(struct rpmvs_s *sis, int type,
 
 rpmRC rpmpkgRead(struct rpmvs_s *vs, FD_t fd,
 		hdrblob *sigblobp, hdrblob *blobp, char **emsg);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _RPMVS_H */

--- a/lib/signature.h
+++ b/lib/signature.h
@@ -7,10 +7,6 @@
  */
 #include <rpm/rpmtypes.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup signature
  * Read (and verify header+payload size) signature header.
  * If an old-style signature is found, we emulate a new style one.
@@ -42,9 +38,5 @@ int rpmWriteSignature(FD_t fd, Header h);
 rpmRC rpmGenerateSignature(char *SHA256, char *SHA1, uint8_t *MD5,
 			rpm_loff_t size, rpm_loff_t payloadSize, FD_t fd,
 			int rpmver);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* H_SIGNATURE */

--- a/rpmio/rpmhook.h
+++ b/rpmio/rpmhook.h
@@ -16,10 +16,6 @@ typedef struct rpmhookArgs_s {
 
 typedef int (*rpmhookFunc) (rpmhookArgs args, void *data);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
- 
 rpmhookArgs rpmhookArgsNew(int argc);
 rpmhookArgs rpmhookArgsFree(rpmhookArgs args);
 
@@ -29,9 +25,5 @@ void rpmhookUnregisterAny(const char *name, rpmhookFunc func);
 void rpmhookUnregisterAll(const char *name);
 void rpmhookCall(const char *name, const char *argt, ...);
 void rpmhookCallArgs(const char *name, rpmhookArgs args);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/rpmio/rpmio_internal.h
+++ b/rpmio/rpmio_internal.h
@@ -8,10 +8,6 @@
 #include <rpm/rpmio.h>
 #include <rpm/rpmpgp.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 void fdSetBundle(FD_t fd, rpmDigestBundle bundle);
 rpmDigestBundle fdGetBundle(FD_t fd, int create);
 
@@ -68,10 +64,6 @@ extern const FDIO_t lzdio;
 #ifdef HAVE_ZSTD
 RPM_GNUC_INTERNAL
 extern const FDIO_t zstdio;
-#endif
-
-#ifdef __cplusplus
-}
 #endif
 
 #endif	/* H_RPMIO_INTERNAL */

--- a/rpmio/rpmlua.h
+++ b/rpmio/rpmlua.h
@@ -15,6 +15,10 @@ extern "C" {
 #include <lualib.h>
 #include <lauxlib.h>
 
+#ifdef __cplusplus
+}
+#endif
+
 typedef char * (*rpmluarl)(const char *);
 
 rpmlua rpmluaNew(void);
@@ -33,9 +37,5 @@ char *rpmluaPopPrintBuffer(rpmlua lua);
 void rpmluaPushPrintBuffer(rpmlua lua);
 
 char *rpmluaCallStringFunction(rpmlua lua, const char *function, struct rpmhookArgs_s *args);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* RPMLUA_H */

--- a/rpmio/rpmmacro_internal.h
+++ b/rpmio/rpmmacro_internal.h
@@ -10,10 +10,6 @@
  * Internal Macro API
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** \ingroup rpmmacro
  * Find the end of a macro call
  * @param str           pointer to the character after the initial '%'
@@ -33,9 +29,5 @@ void splitQuoted(ARGV_t *av, const char * str, const char * seps);
 
 RPM_GNUC_INTERNAL
 char *unsplitQuoted(ARGV_const_t av, const char *sep);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif	/* _H_ MACRO_INTERNAL */

--- a/sign/rpmsignfiles.h
+++ b/sign/rpmsignfiles.h
@@ -11,6 +11,10 @@ extern "C" {
 /* This doesn't have c++ guards on its own */
 #include <imaevm.h>
 
+#ifdef __cplusplus
+}
+#endif
+
 /**
  * Sign file digests in header into signature header
  * @param sigh		package signature header
@@ -21,9 +25,5 @@ extern "C" {
  */
 RPM_GNUC_INTERNAL
 rpmRC rpmSignFiles(Header sigh, Header h, const char *key, char *keypass);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* H_RPMSIGNFILES */

--- a/sign/rpmsignverity.h
+++ b/sign/rpmsignverity.h
@@ -4,10 +4,6 @@
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmutil.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * Block size used to generate the Merkle tree for fsverity. For now
  * we only support 4K blocks, if we ever decide to support different
@@ -28,9 +24,5 @@ extern "C" {
 RPM_GNUC_INTERNAL
 rpmRC rpmSignVerity(FD_t fd, Header sigh, Header h, char *key,
 		    char *keypass, char *cert, uint16_t algo);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* H_RPMSIGNVERITY */


### PR DESCRIPTION
While these were necessary to get things going, they are only counterproductive now: we want to be able to freely use C++ features inside rpm.