### PR TITLE
Always create %specpartsdir on build

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -321,12 +321,10 @@ static int doCheckBuildRequires(rpmts ts, rpmSpec spec, int test)
 
 static rpmRC doBuildDir(rpmSpec spec, int test, StringBuf *sbp)
 {
-    char *fix = rpmExpand("%{_fixperms}", NULL);
-    char *doDir = rstrscat(NULL,
-			   "test -d '", spec->buildDir, "' && ",
-			   fix, " '", spec->buildDir, "'\n",
-			   "rm -rf '", spec->buildDir, "'\n",
-			   "mkdir -p '", spec->buildDir, "'\n",
+    char *doDir = rpmExpand("test -d '", spec->buildDir, "' && ",
+			   "%{_fixperms} '", spec->buildDir, "'\n",
+			   "%{__rm} -rf '", spec->buildDir, "'\n",
+			   "%{__mkdir_p} '", spec->buildDir, "'\n",
 			   NULL);
 
     rpmRC rc = doScript(spec, RPMBUILD_MKBUILDDIR, "%mkbuilddir",
@@ -337,7 +335,6 @@ static rpmRC doBuildDir(rpmSpec spec, int test, StringBuf *sbp)
 		spec->buildDir, strerror(errno));
     }
     free(doDir);
-    free(fix);
     return rc;
 }
 

--- a/build/build.c
+++ b/build/build.c
@@ -325,6 +325,7 @@ static rpmRC doBuildDir(rpmSpec spec, int test, StringBuf *sbp)
 			   "%{_fixperms} '", spec->buildDir, "'\n",
 			   "%{__rm} -rf '", spec->buildDir, "'\n",
 			   "%{__mkdir_p} '", spec->buildDir, "'\n",
+			   "%{__mkdir_p} '%{specpartsdir}'\n",
 			   NULL);
 
     rpmRC rc = doScript(spec, RPMBUILD_MKBUILDDIR, "%mkbuilddir",

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -276,16 +276,6 @@ void doSetupMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
 	free(buf);
     }
 
-    /* mkdir for dynamic specparts */
-    if (rpmMacroIsDefined(spec->macros, "specpartsdir")) {
-	buf = rpmExpand("rm -rf '%{specpartsdir}'", NULL);
-	appendMb(mb, buf, 1);
-	free(buf);
-	buf = rpmExpand("%{__mkdir_p} '%{specpartsdir}'", NULL);
-	appendMb(mb, buf, 1);
-	free(buf);
-    }
-
     appendMb(mb, getStringBuf(after), 0);
 
     /* Fix the permissions of the setup build tree */

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -278,6 +278,7 @@ runroot_other find /build/BUILD|sort
 /build/BUILD/simple-1.0-build/BUILDROOT/opt
 /build/BUILD/simple-1.0-build/BUILDROOT/opt/bin
 /build/BUILD/simple-1.0-build/BUILDROOT/opt/bin/simple
+/build/BUILD/simple-1.0-build/SPECPARTS
 /build/BUILD/simple-1.0-build/simple
 ],
 [ignore])

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -334,8 +334,6 @@ if [ $STATUS -ne 0 ]; then
   exit $STATUS
 fi
 cd 'hello-1.0'
-rm -rf '/build/BUILD/hello-1.0-build/SPECPARTS'
-/usr/bin/mkdir -p '/build/BUILD/hello-1.0-build/SPECPARTS'
 /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
 
 echo "Patch #0 (hello-1.0-modernize.patch):"


### PR DESCRIPTION
There's no reason %specpartsdir should be dependent on %setup use, just create it when we create the build directory too. Update tests accordingly.

The spec parse test is noteworthy, the specparts dir creation no longer shows up in spec parse output, which certainly is the way it should be: this is rpm internal infrastructure stuff and nothing to do with spec *parse*, this all only takes place during builds.

Fixes: #3063
