### PR TITLE
Add proper logic for debuginfo enablement

### DIFF
--- a/installplatform
+++ b/installplatform
@@ -28,6 +28,7 @@ for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2` ${RPM_CUSTOM_ARCH:+cu
   ISABITS=
   CANONARCH=
   CANONCOLOR=
+  DEBUGINFO=0
   FILTER=cat
   case "${ARCH}" in
     custom)
@@ -207,6 +208,10 @@ for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2` ${RPM_CUSTOM_ARCH:+cu
       LIB=${LIB}64
   fi
 
+  if [ "$OS" = "linux" ] && [ "$CANONARCH" != "noarch" ]; then
+      DEBUGINFO=1
+  fi
+
   PPD="${DESTDIR}/${platformdir}/${ARCH}-${OS}"
   [ -d $PPD ] || mkdir -p $PPD
 
@@ -215,6 +220,7 @@ for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2` ${RPM_CUSTOM_ARCH:+cu
 	-e "s,=RPMCANONARCH=,$CANONARCH,g" \
 	-e "s,=RPMCANONCOLOR=,$CANONCOLOR," \
 	-e "s,=RPMRC_GNU=,$RPMRC_GNU," \
+	-e "s,=RPMDEBUGINFO=,$DEBUGINFO," \
 	-e "s,=LIB=,$LIB," \
 	-e "s,=ARCH_INSTALL_POST=,$ARCH_INSTALL_POST," \
 	-e '/\${\w*:-/!s,\${,%{_,' \

--- a/macros.in
+++ b/macros.in
@@ -195,11 +195,9 @@ package or when debugging this package.\
 %{nil}
 
 %debug_package \
-%ifnarch noarch\
 %global __debug_package 1\
 %_debuginfo_template\
 %{?_debugsource_packages:%_debugsource_template}\
-%endif\
 %{nil}
 
 %_langpack_template() \

--- a/platform.in
+++ b/platform.in
@@ -48,6 +48,8 @@
 
 %_defaultdocdir		%{_datadir}/doc
 
+%_enable_debug_packages =RPMDEBUGINFO=
+
 #==============================================================================
 # ---- Build policy macros.
 #
@@ -86,6 +88,7 @@
 %{nil}
 
 %__spec_install_post\
+    %[ 0%{?_enable_debug_packages} > 0 ? "%(echo "%{debug_package}" > %{specpartsdir}/rpm-debuginfo.specpart)" : "" ]\
     %{?__debug_package:%{__debug_install_post}}\
     %{__arch_install_post}\
     %{__os_install_post}\

--- a/tests/data/SPECS/specstep.spec
+++ b/tests/data/SPECS/specstep.spec
@@ -3,6 +3,7 @@ Version: 1.0
 Release: 1
 Summary: Testing spec steps
 License: GPL
+BuildArch: noarch
 %{?preamble}
 
 %description

--- a/tests/data/macros.debug
+++ b/tests/data/macros.debug
@@ -20,16 +20,6 @@
     %{_rpmconfigdir}/brp-strip-static-archive %{__strip} \
 %{nil}
 
-%__spec_install_post\
-    %{?__debug_package:%{__debug_install_post}}\
-    %{__arch_install_post}\
-    %{__os_install_post}\
-%{nil}
-
-%install %{?_enable_debug_packages:%{?buildsubdir:%{debug_package}}}\
-%%install\
-%{nil}
-
 # Should missing buildids terminate a build?
 %_missing_build_ids_terminate_build    1
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3022,6 +3022,15 @@ runroot rpmbuild --quiet -bb /data/SPECS/caps.spec
 [])
 
 RPMTEST_CHECK([
+runroot rpm -qp --qf "%{name}\n" /build/RPMS/*/*.rpm|sort
+],
+[0],
+[caps
+caps-debuginfo
+],
+[])
+
+RPMTEST_CHECK([
 runroot rpm -q --filecaps /build/RPMS/*/caps-1.0-1.*.rpm | grep -v build-id
 ],
 [0],


### PR DESCRIPTION
All these years, enabling debuginfo has required distros to hijack the spec %install section with a macro like this:

    %install %{?_enable_debug_packages:%{?buildsubdir:%{debug_package}}}\
    %%install\
    %{nil}

This for a widely used, longtime upstream supported feature is just gross, and also very non-obvious, feeble and whatnot. And totally prevents the new append/prepend options from being used with %install.

Take advantage of several newish features to make this happen: we need expressions to properly handle the numeric %_enable_debug_packages value from a macro, and if enabled, output the debuginfo template as a dynamic .specpart.

Enable debuginfo on Linux by default in the platform configuration. Notably noarch should not have debuginfo so it's disabled in the platform configuration - since 96467dce18f264b278e17ffe1859c88d9b5aa4b6 we can now actually rely on the platform configuration being valid, so we can drop the "%ifnarch noarch" from the debug package check. Further streamlining should be possible.

specstep.spec needs to be made noarch here, otherwise it'll now try to produce debuginfo and fail.

Fixes: https://github.com/rpm-software-management/rpm/issues/2204
Fixes: https://github.com/rpm-software-management/rpm/issues/1878