### PR TITLE
Free old cookie value to prevent a memory leak

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -472,6 +472,7 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
 
     /* Create and add the cookie */
     if (cookie) {
+	free(*cookie);
 	rasprintf(cookie, "%s %d", buildHost, buildTime);
 	headerPutString(pkg->header, RPMTAG_COOKIE, *cookie);
     }


### PR DESCRIPTION
This keeps the old behaviour of overriding the cookie. This may not me correct as the code looks like it reads the cookie from the srpm when doing rpmbuild --rebuild for the purpose of preserving it. Otoh the current behaviour with overriding it even in this case has been around for years. This whole cookie business seems to have some other issues, too, and needs further investigation. Here we are only trying to fix the memory leak.