### PR TITLE
Improve the debuginfo enablement backwards compatibility

### DIFF
--- a/platform.in
+++ b/platform.in
@@ -57,6 +57,11 @@
 #	Expanded at beginning of %install scriptlet.
 #
 
+%__spec_install_template\
+%{__spec_install_pre}\
+%[ 0%{?_enable_debug_packages} > 0 ? "%(echo "%{debug_package}" > %{specpartsdir}/rpm-debuginfo.specpart)" : "" ]\
+%{nil}
+
 %__spec_install_pre %{___build_pre}\
     %{__rm} -rf "%{buildroot}"\
     %{__mkdir_p} "%{dirname:%{buildroot}}"\
@@ -88,7 +93,6 @@
 %{nil}
 
 %__spec_install_post\
-    %[ 0%{?_enable_debug_packages} > 0 ? "%(echo "%{debug_package}" > %{specpartsdir}/rpm-debuginfo.specpart)" : "" ]\
     %{?__debug_package:%{__debug_install_post}}\
     %{__arch_install_post}\
     %{__os_install_post}\


### PR DESCRIPTION
Move the enablement logic to %__spec_install_template where it can be buried with relatively little danger of being overridden by distros or packagers. It's moderately annoying as the logic isn't no longer neatly in one spot, but %__spec_install_post is commonly overridden by distros and even packages, and in particular we don't want to have packages copy-paste all this stuff along, because that makes making any changes to this stuff even harder than it already is.

This should be entirely backwards compatible with all the pre-existing %__spec_install_post overrides.

Co-authored-by: Florian Festi <ffesti@redhat.com>