### PR TITLE
Convert major librpmbuild structs to native C++ allocation / initialization

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2610,7 +2610,7 @@ static void addPackageFileList (struct FileList_s *fl, Package pkg,
 static rpmRC processPackageFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 				 Package pkg, int didInstall, int test)
 {
-    struct FileList_s fl;
+    struct FileList_s fl {};
     specialDir specialDoc = NULL;
     specialDir specialLic = NULL;
 
@@ -2621,8 +2621,6 @@ static rpmRC processPackageFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 	    return RPMRC_FAIL;
     }
     /* Init the file list structure */
-    memset(&fl, 0, sizeof(fl));
-
     fl.pool = rpmstrPoolLink(spec->pool);
     /* XXX spec->buildRoot == NULL, then xstrdup("") is returned */
     fl.buildRoot = rpmGenPath(spec->rootDir, spec->buildRoot, NULL);
@@ -2689,7 +2687,7 @@ exit:
 rpmRC processSourceFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags)
 {
     struct Source *srcPtr;
-    struct FileList_s fl;
+    struct FileList_s fl {};
     ARGV_t files = NULL;
     Package pkg;
     Package sourcePkg = spec->sourcePackage;
@@ -2725,7 +2723,6 @@ rpmRC processSourceFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags)
     sourcePkg->cpioList = NULL;
 
     /* Init the file list structure */
-    memset(&fl, 0, sizeof(fl));
     fl.pool = rpmstrPoolLink(spec->pool);
     if (_srcdefattr) {
 	char *a = rstrscat(NULL, "%defattr ", _srcdefattr, NULL);

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -135,7 +135,7 @@ static inline int parseYesNo(const char * s)
 
 static struct Source *newSource(uint32_t num, const char *path, int flags)
 {
-    struct Source *p = (struct Source *)xmalloc(sizeof(*p));
+    struct Source *p = new Source {};
     p->num = num;
     p->fullSource = xstrdup(path);
     p->flags = flags;

--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -24,10 +24,7 @@ static int addTriggerIndex(Package pkg, const char *file,
 	rpmTagVal tag, uint32_t priority)
 {
     struct TriggerFileEntry *tfe;
-    struct TriggerFileEntry *list;
-    struct TriggerFileEntry *last = NULL;
-    int index = 0;
-    struct TriggerFileEntry **tfp;
+    std::vector<TriggerFileEntry> *tfp;
 
     if (tag == RPMTAG_FILETRIGGERSCRIPTS) {
 	tfp = &pkg->fileTriggerFiles;
@@ -37,32 +34,17 @@ static int addTriggerIndex(Package pkg, const char *file,
 	tfp = &pkg->triggerFiles;
     }
 
-    list = *tfp;
-
-    while (list) {
-	last = list;
-	list = list->next;
-    }
-
-    if (last)
-	index = last->index + 1;
-
-    tfe = (struct TriggerFileEntry *)xcalloc(1, sizeof(*tfe));
+    tfp->push_back({});
+    tfe = &tfp->back();
 
     tfe->fileName = (file) ? xstrdup(file) : NULL;
     tfe->script = (script && *script != '\0') ? xstrdup(script) : NULL;
     tfe->prog = xstrdup(prog);
     tfe->flags = flags;
-    tfe->index = index;
+    tfe->index = tfp->size() - 1;
     tfe->priority = priority;
-    tfe->next = NULL;
 
-    if (last)
-	last->next = tfe;
-    else
-	*tfp = tfe;
-
-    return index;
+    return tfe->index;
 }
 
 /* %trigger is a strange combination of %pre and Requires: behavior */

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -160,7 +160,7 @@ static void ofilineMacro(rpmMacroBuf mb,
 /* Push a file to spec's file stack, return the newly pushed entry */
 static OFI_t * pushOFI(rpmSpec spec, const char *fn)
 {
-    OFI_t *ofi = (OFI_t *)xcalloc(1, sizeof(*ofi));
+    OFI_t *ofi = new OpenFileInfo {};
 
     ofi->fp = NULL;
     ofi->fileName = xstrdup(fn);
@@ -189,7 +189,7 @@ static OFI_t * popOFI(rpmSpec spec)
 	    fclose(ofi->fp);
 	free(ofi->fileName);
 	free(ofi->readBuf);
-	free(ofi);
+	delete ofi;
 	rpmPopMacro(spec->macros, "__file_name");
 	rpmPopMacro(spec->macros, "__file_lineno");
     }
@@ -543,7 +543,7 @@ retry:
     } else if (lineType->id == LINE_ENDIF) {
 	rl = spec->readStack;
 	spec->readStack = spec->readStack->next;
-	free(rl);
+	delete rl;
 	spec->line[0] = '\0';
     } else if (spec->readStack->reading && (lineType->id == LINE_INCLUDE)) {
 	char *fileName, *endFileName, *p;
@@ -569,7 +569,7 @@ retry:
     }
 
     if (lineType->id & LINE_IFANY) {
-	rl = (struct ReadLevelEntry *)xmalloc(sizeof(*rl));
+	rl = new ReadLevelEntry {};
 	rl->reading = spec->readStack->reading && match;
 	rl->next = spec->readStack;
 	rl->lineNum = ofi->lineNum;

--- a/build/policies.c
+++ b/build/policies.c
@@ -143,7 +143,7 @@ static ModuleRec freeModule(ModuleRec mod)
 	_free(mod->data);
 	_free(mod->name);
 	argvFree(mod->types);
-	_free(mod);
+	delete mod;
     }
 
     return NULL;
@@ -162,7 +162,7 @@ static ModuleRec newModule(const char *path, const char *name,
 	return NULL;
     }
 
-    mod = (ModuleRec)xcalloc(1, sizeof(*mod));
+    mod = new ModuleRec_s {};
 
     mod->path = rpmGenPath(buildDir, NULL, path);
 

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -1,6 +1,8 @@
 #ifndef _RPMBUILD_INTERNAL_H
 #define _RPMBUILD_INTERNAL_H
 
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <rpm/rpmbuild.h>
@@ -9,13 +11,7 @@
 #include "rpmbuild_misc.h"
 #include "rpmlua.h"
 
-#define HASHTYPE fileRenameHash
-#define HTKEYTYPE const char *
-#define HTDATATYPE const char *
-#include "rpmhash.H"
-#undef HASHTYPE
-#undef HTKEYTYPE
-#undef HTDATATYPE
+typedef std::unordered_multimap<std::string,std::string> fileRenameHash;
 
 #define ALLOWED_CHARS_NAME ".-_+%{}"
 #define ALLOWED_FIRSTCHARS_NAME "_%"

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -1,6 +1,8 @@
 #ifndef _RPMBUILD_INTERNAL_H
 #define _RPMBUILD_INTERNAL_H
 
+#include <vector>
+
 #include <rpm/rpmbuild.h>
 #include <rpm/rpmutil.h>
 #include <rpm/rpmstrpool.h>
@@ -208,9 +210,9 @@ struct Package_s {
     char * postunTransFile;	/*!< %postuntrans scriptlet. */
     char * verifyFile;	/*!< %verifyscript scriptlet. */
 
-    struct TriggerFileEntry * triggerFiles;
-    struct TriggerFileEntry * fileTriggerFiles;
-    struct TriggerFileEntry * transFileTriggerFiles;
+    std::vector<TriggerFileEntry> triggerFiles;
+    std::vector<TriggerFileEntry> fileTriggerFiles;
+    std::vector<TriggerFileEntry> transFileTriggerFiles;
 
     ARGV_t fileFile;
     ARGV_t fileList;		/* If NULL, package will not be written */

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -195,7 +195,7 @@ static regex_t *rpmfcAttrReg(const char *arg, ...)
 
 static rpmfcAttr rpmfcAttrNew(const char *name)
 {
-    rpmfcAttr attr = (rpmfcAttr)xcalloc(1, sizeof(*attr));
+    rpmfcAttr attr = new rpmfcAttr_s {};
     struct matchRule *rules[] = { &attr->incl, &attr->excl, NULL };
 
     attr->name = xstrdup(name);
@@ -240,7 +240,7 @@ static rpmfcAttr rpmfcAttrFree(rpmfcAttr attr)
 	ruleFree(&attr->excl);
 	rfree(attr->name);
 	rfree(attr->proto);
-	rfree(attr);
+	delete attr;
     }
     return NULL;
 }
@@ -920,15 +920,14 @@ rpmfc rpmfcFree(rpmfc fc)
 	rpmstrPoolFree(fc->cdict);
 
 	rpmstrPoolFree(fc->pool);
-	memset(fc, 0, sizeof(*fc)); /* trash and burn */
-	free(fc);
+	delete fc;
     }
     return NULL;
 }
 
 rpmfc rpmfcCreate(const char *buildRoot, rpmFlags flags)
 {
-    rpmfc fc = (rpmfc)xcalloc(1, sizeof(*fc));
+    rpmfc fc = new rpmfc_s {};
     if (buildRoot) {
 	fc->buildRoot = xstrdup(buildRoot);
 	fc->brlen = strlen(buildRoot);

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -933,7 +933,7 @@ rpmfc rpmfcCreate(const char *buildRoot, rpmFlags flags)
 	fc->brlen = strlen(buildRoot);
     }
     fc->pool = rpmstrPoolCreate();
-    fc->pkg = (Package)xcalloc(1, sizeof(*fc->pkg));
+    fc->pkg = new Package_s {};
     fc->fileDeps.alloced = 10;
     fc->fileDeps.data = (rpmfcFileDep *)xmalloc(fc->fileDeps.alloced *
 	sizeof(fc->fileDeps.data[0]));

--- a/build/spec.c
+++ b/build/spec.c
@@ -102,7 +102,7 @@ rpmRC lookupPackage(rpmSpec spec, const char *name, int flag,Package *pkg)
 
 Package newPackage(const char *name, rpmstrPool pool, Package *pkglist)
 {
-    Package p = (Package)xcalloc(1, sizeof(*p));
+    Package p = new Package_s {};
     p->header = headerNew();
     p->autoProv = 1;
     p->autoReq = 1;
@@ -171,7 +171,7 @@ Package freePackage(Package pkg)
     pkg->transFileTriggerFiles = freeTriggerFiles(pkg->transFileTriggerFiles);
     pkg->pool = rpmstrPoolFree(pkg->pool);
 
-    free(pkg);
+    delete pkg;
     return NULL;
 }
 
@@ -203,7 +203,7 @@ rpmds * packageDependencies(Package pkg, rpmTagVal tag)
 
 rpmSpec newSpec(void)
 {
-    rpmSpec spec = (rpmSpec)xcalloc(1, sizeof(*spec));
+    rpmSpec spec = new rpmSpec_s {};
     
     spec->specFile = NULL;
 
@@ -308,9 +308,8 @@ rpmSpec rpmSpecFree(rpmSpec spec)
 
     spec->buildHost = _free(spec->buildHost);
 
-    spec = _free(spec);
-
-    return spec;
+    delete spec;
+    return NULL;
 }
 
 Header rpmSpecSourceHeader(rpmSpec spec)

--- a/build/spec.c
+++ b/build/spec.c
@@ -215,7 +215,7 @@ rpmSpec newSpec(void)
     spec->nextline = NULL;
     spec->nextpeekc = '\0';
     spec->lineNum = 0;
-    spec->readStack = (struct ReadLevelEntry*)xcalloc(1, sizeof(*spec->readStack));
+    spec->readStack = new ReadLevelEntry {};
     spec->readStack->next = NULL;
     spec->readStack->reading = 1;
     spec->readStack->lastConditional = lineTypes;
@@ -271,7 +271,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
 	struct ReadLevelEntry *rl = spec->readStack;
 	spec->readStack = rl->next;
 	rl->next = NULL;
-	free(rl);
+	delete rl;
     }
     spec->lbuf = _free(spec->lbuf);
     

--- a/build/spec.c
+++ b/build/spec.c
@@ -100,7 +100,6 @@ Package newPackage(const char *name, rpmstrPool pool, Package *pkglist)
     p->fileExcludeList = NULL;
     p->fileFile = NULL;
     p->policyList = NULL;
-    p->fileRenameMap = NULL;
     p->pool = rpmstrPoolLink(pool);
     p->dpaths = NULL;
     p->rpmver = rpmExpandNumeric("%_rpmfilever");
@@ -151,7 +150,6 @@ Package freePackage(Package pkg)
     pkg->fileFile = argvFree(pkg->fileFile);
     pkg->policyList = argvFree(pkg->policyList);
     pkg->removePostfixes = argvFree(pkg->removePostfixes);
-    pkg->fileRenameMap = fileRenameHashFree(pkg->fileRenameMap);
     pkg->cpioList = rpmfilesFree(pkg->cpioList);
     pkg->dpaths = argvFree(pkg->dpaths);
 

--- a/build/spec.c
+++ b/build/spec.c
@@ -20,24 +20,14 @@
 
 #define SKIPSPACE(s) { while (*(s) && risspace(*(s))) (s)++; }
 
-/**
- * @param p		trigger entry chain
- * @return		NULL always
- */
-static inline
-struct TriggerFileEntry * freeTriggerFiles(struct TriggerFileEntry * p)
+static void freeTriggerFiles(std::vector<TriggerFileEntry> &triggers)
 {
-    struct TriggerFileEntry *o, *q = p;
-    
-    while (q != NULL) {
-	o = q;
-	q = q->next;
-	o->fileName = _free(o->fileName);
-	o->script = _free(o->script);
-	o->prog = _free(o->prog);
-	free(o);
+    for (auto & e : triggers) {
+	free(e.fileName);
+	free(e.script);
+	free(e.prog);
     }
-    return NULL;
+    triggers.clear();
 }
 
 struct Source * freeSources(struct Source * s)
@@ -166,9 +156,9 @@ Package freePackage(Package pkg)
     pkg->dpaths = argvFree(pkg->dpaths);
 
     pkg->icon = freeSources(pkg->icon);
-    pkg->triggerFiles = freeTriggerFiles(pkg->triggerFiles);
-    pkg->fileTriggerFiles = freeTriggerFiles(pkg->fileTriggerFiles);
-    pkg->transFileTriggerFiles = freeTriggerFiles(pkg->transFileTriggerFiles);
+    freeTriggerFiles(pkg->triggerFiles);
+    freeTriggerFiles(pkg->fileTriggerFiles);
+    freeTriggerFiles(pkg->transFileTriggerFiles);
     pkg->pool = rpmstrPoolFree(pkg->pool);
 
     delete pkg;

--- a/build/spec.c
+++ b/build/spec.c
@@ -343,7 +343,7 @@ struct rpmSpecIter_s {
 #define SPEC_LISTITER_INIT(_itertype, _iteritem)	\
     _itertype iter = NULL;				\
     if (spec) {						\
-	iter = (_itertype)xcalloc(1, sizeof(*iter));		\
+	iter = new rpmSpecIter_s {};			\
 	iter->next = spec->_iteritem;			\
     }							\
     return iter
@@ -357,7 +357,7 @@ struct rpmSpecIter_s {
     return item
 
 #define SPEC_LISTITER_FREE()				\
-    free(iter);						\
+    delete iter;					\
     return NULL
 
 

--- a/build/spec.c
+++ b/build/spec.c
@@ -39,7 +39,7 @@ struct Source * freeSources(struct Source * s)
 	t = t->next;
 	r->fullSource = _free(r->fullSource);
 	r->path = _free(r->path);
-	free(r);
+	delete r;
     }
     return NULL;
 }


### PR DESCRIPTION
Details in the commits, in brief this brings the major data structures of librpmbuild under C++ native allocation and initialization, making it possible to use native data types in said structs.
A few "obvious" cases converted to STL too, but plenty more to do on that department.