### PR TITLE
Fix a regression on dependency generator namespace directive

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1045,7 +1045,7 @@ static int applyAttr(rpmfc fc, int aix,
 	}
 
 	if (rpmMacroIsDefined(NULL, mname)) {
-	    char *ns = rpmfcAttrMacro(aname, "namespc", NULL);
+	    char *ns = rpmfcAttrMacro(aname, "namespace", NULL);
 	    rc = rpmfcHelper(fc, fnx.data(), fnx.size(), attr->proto,
 			    excl, dep->type, dep->tag, ns, mname);
 	    free(ns);

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1120,11 +1120,12 @@ RPMDB_INIT
 runroot rpmbuild -bb --quiet \
 		--define '__script_mime text/plain' \
 		--define '__script_magic %{nil}' \
+		--define '__script_namespace mine' \
 		/data/SPECS/shebang.spec
 runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^rpmlib
 ],
 [0],
-[/bin/blabla
+[mine(/bin/blabla)
 ],
 [])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Commit ce6c3812af4c2a9e9fc6c2dc77e00e1e1487bb83 accidentally changed this namespace string literal too, oops. Possible because there was no test on it, so add one.