### PR TITLE
Ensure noarch packages don't get debuginfo

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -195,9 +195,11 @@ package or when debugging this package.\
 %{nil}
 
 %debug_package \
+%ifnarch noarch\
 %global __debug_package 1\
 %_debuginfo_template\
 %{?_debugsource_packages:%_debugsource_template}\
+%endif\
 %{nil}
 
 %_langpack_template() \

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2224,7 +2224,19 @@ No hello.debug
 [ignore])
 RPMTEST_CLEANUP
 
+AT_SETUP([explicit %_enable_debug_package on noarch])
+AT_KEYWORDS([build debuginfo])
+RPMTEST_CHECK([
+RPMDB_INIT
 
+runroot rpmbuild --quiet -bb \
+		--define "%_enable_debug_packages 1" \
+		/data/SPECS/hlinktest.spec
+],
+[0],
+[ignore],
+[ignore])
+RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires


### PR DESCRIPTION
Add back the %ifnarch noarch test overconfidently removed in commit 8535694599ee7f35747d44e2ea0a62dc5e8880e5, "it's more complicated than that".

This is band-aid for #3115.