### PR TITLE
Fix --noprep regression from introducing %mkbuilddir

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2259,6 +2259,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
+# Mimick what mock does: repeat build with --noprep --noclean
+# until -br succeeds, and finally build the package.
 AT_SETUP([rpmbuild -br])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
@@ -2275,6 +2277,22 @@ runroot rpmbuild \
 	foo-bar = 2.0 is needed by buildrequires-1.0-1.noarch
 ],
 )
+
+RPMTEST_CHECK([
+runroot rpmbuild \
+    --define "provs bar foo foo-bar" \
+    --define "pkg foo" \
+    -bb --quiet /data/SPECS/deptest.spec
+
+runroot rpm -U /build/RPMS/noarch/deptest-foo-1.0-1.noarch.rpm
+
+runroot rpmbuild \
+    -br --noprep --noclean\
+    --quiet /data/SPECS/buildrequires.spec
+],
+[0],
+[],
+[])
 RPMTEST_CLEANUP
 
 # Test that -br creates an src.rpm on success

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2311,22 +2311,6 @@ runroot rpmbuild \
 )
 RPMTEST_CLEANUP
 
-# Test that -br creates an src.rpm on success
-AT_SETUP([rpmbuild -br success])
-AT_KEYWORDS([build])
-RPMTEST_CHECK([
-RPMDB_INIT
-
-runroot rpmbuild \
-  -br  /data/SPECS/mini.spec
-],
-[0],
-[Wrote: /build/SRPMS/mini-1-1.src.rpm
-],
-[],
-)
-RPMTEST_CLEANUP
-
 # ------------------------------
 # Check dynamic build requires
 AT_SETUP([rpmbuild -bd with errors])

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -261,7 +261,7 @@ static struct poptOption rpmBuildPoptTable[] = {
 
  { "noclean", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_CLEAN|RPMBUILD_RMBUILD,
 	N_("do not execute %clean stage of the build"), NULL },
- { "noprep", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_PREP,
+ { "noprep", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_PREP|RPMBUILD_MKBUILDDIR,
 	N_("do not execute %prep stage of the build"), NULL },
  { "nocheck", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_CHECK,
 	N_("do not execute %check stage of the build"), NULL },


### PR DESCRIPTION
Commit 9d35c8df497534e1fbd806a4dc78802bcf35d7cb added a new step into the build process but I literally wasn't even aware we have a --noprep switch in rpmbuild, much less that it's used. Quite widely even, by mock.

Luckily this seems simple to fix, just skip %mkbuilddir in --noprep. Extend the dynamic buildrequires test to mimick what mock does.

Fixes: #3121