### PR TITLE
Make --build-in-place much less of a hack and also, work

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -321,6 +321,61 @@ run rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
+AT_SETUP([rpmbuild --build-in-place])
+AT_KEYWORDS([build])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
+runroot_other mv hello-2.0/hello.spec .
+runroot_other find hello-2.0 | sort
+],
+[0],
+[hello-2.0
+hello-2.0/COPYING
+hello-2.0/FAQ
+hello-2.0/Makefile
+hello-2.0/README
+hello-2.0/hello.c
+],
+[])
+
+RPMTEST_CHECK([
+runroot --chdir hello-2.0 rpmbuild -bb --build-in-place ../hello.spec
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+runroot rpm -qp --qf "%{name}-%{version}-%{release}\n" /build/RPMS/*/*.rpm
+],
+[0],
+[hello-2.0-1
+hello-debuginfo-2.0-1
+],
+[])
+
+# finally, see that we left the tree intact 
+RPMTEST_CHECK([
+runroot_other find hello-2.0 | sort
+],
+[0],
+[hello-2.0
+hello-2.0/COPYING
+hello-2.0/FAQ
+hello-2.0/Makefile
+hello-2.0/README
+hello-2.0/debugfiles.list
+hello-2.0/debuglinks.list
+hello-2.0/debugsources.list
+hello-2.0/elfbins.list
+hello-2.0/hello
+hello-2.0/hello.c
+],
+[])
+RPMTEST_CLEANUP
+
 AT_SETUP([rpmbuild with %autosetup -C])
 AT_KEYWORDS([build])
 RPMDB_INIT

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -136,6 +136,7 @@ static void buildArgCallback( poptContext con,
     case POPT_BUILDINPLACE:
 	rpmDefineMacro(NULL, "_build_in_place 1", 0);
 	buildInPlace = 1;
+	nobuildAmount |= RPMBUILD_RMBUILD;
 	break;
     }
 }
@@ -431,13 +432,6 @@ static int buildForTarget(rpmts ts, const char * arg, BTA_t ba,
     rpmSpec spec = NULL;
     int rc = 1; /* assume failure */
     rpmSpecFlags specFlags = spec_flags;
-
-    /* Override default BUILD value for _builddir */
-    if (buildInPlace) {
-	char *cwd = rpmGetCwd();
-	rpmPushMacro(NULL, "_builddir", NULL, cwd, 0);
-	free(cwd);
-    }
 
     if (ba->buildRootOverride)
 	buildRootURL = rpmGenPath(NULL, ba->buildRootOverride, NULL);


### PR DESCRIPTION
Instead of skipping everything in %setup, take advantage of it: we shouldn't unpack any sources but otherwise we can just let it fall through it, defining buildsubdir and everything, if we let rpm do its normal %mkbuilddir thing and just symlink to the in-place tree from rpm's %builddir. This way it's not such an ugly duckling interfering with how normal rpms are built, and even honors %setup flags to a degree.

This fixes two regressions: one introduced when adding %mkbuilddir that nukes your current directory with no questions asked if --build-in-place is used before it even starts, and an earlier one from commit b34333fa021c0ee7215714eeef96d1a2843ea08e that would nuke your precious in-place directory afterwards. And as a side-effect of all this, debuginfo generation also now works with --build-in-place.

Fixes: #3122
Fixes: #3042