### PR TITLE
Fix incomplete header on plain src.rpm build modes regression

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -26,6 +26,7 @@ RPMDB_INIT
 RPMTEST_CHECK([
 
 run rpmbuild \
+  --define "packager Iam" \
   -ba ${RPMDATA}/SPECS/hello.spec
 ],
 [0],
@@ -40,6 +41,38 @@ runroot rpm -qp --qf "%{license}\n" /build/RPMS/*/hello-1.0-1.*.rpm
 [0],
 [GPL, ASL 1.0
 GPL
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -qp --qf "%{packager}\n" /build/SRPMS/hello-1.0-1.src.rpm
+runroot rpm -qp --qf "%{packager}\n" /build/RPMS/*/hello-1.0-1.*.rpm
+],
+[0],
+[Iam
+Iam
+],
+[])
+RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild -bs spec])
+AT_KEYWORDS([build])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+runroot rpmbuild -bs \
+	--define "packager Iam" \
+	${RPMDATA}/SPECS/hello.spec
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-1.0-1.src.rpm
+],
+[0],
+[Iam
 ],
 [])
 RPMTEST_CLEANUP
@@ -471,11 +504,20 @@ RPMDB_INIT
 RPMTEST_CHECK([
 
 run rpmbuild \
+  --define "packager Iam" \
   --rebuild ${RPMDATA}/SRPMS/hello-1.0-1.src.rpm
 ],
 [0],
 [ignore],
 [ignore])
+
+RPMTEST_CHECK([
+runroot rpm -qp --qf "%{packager}\n" /build/RPMS/*/hello-1.0-1.*.rpm
+],
+[0],
+[Iam
+],
+[])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild --short-circuit -bl])
@@ -512,12 +554,22 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-runroot rpmbuild --quiet -ts /data/SOURCES/hello-2.0.tar.gz
+runroot rpmbuild --quiet \
+	--define "packager Iam" \
+	-ts /data/SOURCES/hello-2.0.tar.gz
 runroot rpm -qpl /build/SRPMS/hello-2.0-1.src.rpm
 ],
 [0],
 [hello-2.0.tar.gz
 hello.spec
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-2.0-1.src.rpm
+],
+[0],
+[Iam
 ],
 [])
 RPMTEST_CLEANUP

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -79,6 +79,14 @@ static void buildArgCallback( poptContext con,
     BTA_t rba = &rpmBTArgs;
 
     switch (opt->val) {
+    case POPT_BS:
+    case POPT_RS:
+    case POPT_TS:
+    case POPT_BR:
+    case POPT_RR:
+    case POPT_TR:
+	/* If only building src.rpm, there are no dynamic parts to include */
+	spec_flags &= ~RPMSPEC_NOFINALIZE;
     case POPT_REBUILD:
     case POPT_RECOMPILE:
     case POPT_BA:
@@ -89,8 +97,6 @@ static void buildArgCallback( poptContext con,
     case POPT_BI:
     case POPT_BL:
     case POPT_BP:
-    case POPT_BS:
-    case POPT_BR:
     case POPT_RA:
     /* case POPT_RB: same value as POPT_REBUILD */
     case POPT_RC:
@@ -99,8 +105,6 @@ static void buildArgCallback( poptContext con,
     case POPT_RI:
     case POPT_RL:
     case POPT_RP:
-    case POPT_RS:
-    case POPT_RR:
     case POPT_TA:
     case POPT_TB:
     case POPT_TC:
@@ -109,8 +113,6 @@ static void buildArgCallback( poptContext con,
     case POPT_TI:
     case POPT_TL:
     case POPT_TP:
-    case POPT_TS:
-    case POPT_TR:
 	if (opt->val == POPT_BS || opt->val == POPT_TS)
 	    noDeps = 1;
 	if (buildMode == '\0' && buildChar == '\0') {


### PR DESCRIPTION
Since 9165963de8bb5d5ad0a24ea4656d6d04d733f6bc, the main header wasn't getting properly filled on plain src.rpm build modes like -bs. So a lot of things was missing, but spotted in particular because %packager wasn't getting set as per macros in Koji. Fix by letting rpm finalize the spec after parse when no dynamic spec parts are to be executed.

Add a bunch of tests around this - we can't possibly test every single build scenario but this should cover at least the most common ones pretty well.

Reported-by: Miro Hrončok <miro@hroncok.cz>