### PR TITLE
Hammer in "no debuginfo for noarch packages, damn it" rule

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -386,6 +386,11 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
     spec->buildTime = getBuildTime();
     spec->buildHost = buildHost();
 
+    /* Don't generate debug packages on noarch no matter what --target says */
+    const char *arch = headerGetString(spec->packages->header, RPMTAG_ARCH);
+    if (rstreq(arch, "noarch"))
+	rpmPushMacro(spec->macros, "_enable_debug_packages", NULL, "0", RMIL_SPEC);
+
     /* XXX TODO: rootDir is only relevant during build, eliminate from spec */
     spec->rootDir = buildArgs->rootdir;
     if (!spec->recursing && spec->BACount) {

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2343,6 +2343,18 @@ runroot rpmbuild --quiet -bb \
 [0],
 [ignore],
 [ignore])
+
+RPMTEST_CHECK([
+# mock uses --target <hostarch> everywhere, even noarch packages
+target=$(runroot rpm --eval "%{_host_cpu}")
+runroot rpmbuild --quiet -bb \
+		--target ${target} \
+		--define "%_enable_debug_packages 1" \
+		/data/SPECS/hlinktest.spec
+],
+[0],
+[ignore],
+[ignore])
 RPMTEST_CLEANUP
 
 # ------------------------------


### PR DESCRIPTION
All the work we now do to get target platform right gets thrown away by mock apparently always passing "--target $(uname -m)" equivalent to rpmbuild, causing %_target_cpu and all that stuff be wrong during build scriptlet execution. Those are right during the initial spec parse so the old implementation just barely scraped through it all.

Hammer in a C-side test based on the package arch to disable debuginfo packages on noarch no matter what. Pfft.

Fixes: #3115