### PR TITLE
Another attempt at restoring + sanitizing --build-in-place

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -409,11 +409,16 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	int didBuild = (what & (RPMBUILD_PREP|RPMBUILD_CONF|RPMBUILD_BUILD|RPMBUILD_INSTALL));
 	int sourceOnly = ((what & RPMBUILD_PACKAGESOURCE) &&
 	   !(what & (RPMBUILD_CONF|RPMBUILD_BUILD|RPMBUILD_INSTALL|RPMBUILD_PACKAGEBINARY)));
+	int inPlace = (rpmExpandNumeric("%{?_build_in_place}") > 0);
 
 	if (!rpmSpecGetSection(spec, RPMBUILD_BUILDREQUIRES) && sourceOnly) {
 		/* don't run prep if not needed for source build */
 		/* with(out) dynamic build requires*/
 	    what &= ~(RPMBUILD_PREP|RPMBUILD_MKBUILDDIR);
+	}
+
+	if (inPlace) {
+	    what &= ~(RPMBUILD_RMBUILD);
 	}
 
 	if ((what & RPMBUILD_CHECKBUILDREQUIRES) &&

--- a/build/build.c
+++ b/build/build.c
@@ -319,7 +319,7 @@ static int doCheckBuildRequires(rpmts ts, rpmSpec spec, int test)
     return rc;
 }
 
-static rpmRC doBuildDir(rpmSpec spec, int test, StringBuf *sbp)
+static rpmRC doBuildDir(rpmSpec spec, int test, int inPlace, StringBuf *sbp)
 {
     char *doDir = rpmExpand("test -d '", spec->buildDir, "' && ",
 			   "%{_fixperms} '", spec->buildDir, "'\n",
@@ -327,6 +327,13 @@ static rpmRC doBuildDir(rpmSpec spec, int test, StringBuf *sbp)
 			   "%{__mkdir_p} '", spec->buildDir, "'\n",
 			   "%{__mkdir_p} '%{specpartsdir}'\n",
 			   NULL);
+
+    if (inPlace) {
+	/* note that pwd needs to be from parse, not build time */
+	char *buf = rpmExpand("%{__ln} -s %(pwd) %{builddir}/%{buildsubdir}", NULL);
+	doDir = rstrcat(&doDir, buf);
+	free(buf);
+    }
 
     rpmRC rc = doScript(spec, RPMBUILD_MKBUILDDIR, "%mkbuilddir",
 			doDir, test, sbp);
@@ -418,6 +425,9 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	}
 
 	if (inPlace) {
+	    /* in-place builds counter-intuitively always have buildsubdir */
+	    rpmPushMacro(spec->macros,
+			"buildsubdir", NULL, "%{NAME}-%{VERSION}", RMIL_SPEC);
 	    what &= ~(RPMBUILD_RMBUILD);
 	}
 
@@ -425,7 +435,7 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	    (rc = doCheckBuildRequires(ts, spec, test)))
 		goto exit;
 
-	if ((what & RPMBUILD_MKBUILDDIR) && (rc = doBuildDir(spec, test, sbp)))
+	if ((what & RPMBUILD_MKBUILDDIR) && (rc = doBuildDir(spec, test, inPlace, sbp)))
 		goto exit;
 
 	if ((what & RPMBUILD_PREP) &&

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -171,7 +171,6 @@ void doSetupMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
     int leaveDirs = 0, skipDefaultAction = 0;
     int createDir = 0, quietly = 0, autoPath = 0;
     char * dirName = NULL;
-    int buildInPlace = rpmExpandNumeric("%{?_build_in_place}");
     struct poptOption optionsTable[] = {
 	    { NULL, 'a', POPT_ARG_STRING, NULL, 'a',	NULL, NULL},
 	    { NULL, 'b', POPT_ARG_STRING, NULL, 'b',	NULL, NULL},
@@ -191,6 +190,10 @@ void doSetupMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
 	goto exit;
     }
 
+    if (rpmExpandNumeric("%{_build_in_place}")) {
+	goto exit;
+    }
+
     optCon = poptGetContext(NULL, argc, argv, optionsTable, 0);
     while ((arg = poptGetNextOpt(optCon)) > 0) {
 	char *optArg = poptGetOptArg(optCon);
@@ -203,8 +206,7 @@ void doSetupMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
 	    goto exit;
 	}
 
-	if (!buildInPlace) {
-	    char *chptr = doUntar(spec, num, quietly, 0);
+	{   char *chptr = doUntar(spec, num, quietly, 0);
 	    if (chptr == NULL)
 		goto exit;
 
@@ -233,15 +235,6 @@ void doSetupMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
 	free(buildSubdir);
     }
     
-    if (buildInPlace) {
-	skipDefaultAction = 1;
-	leaveDirs = 1;
-	/* note that pwd needs to be from parse, not build time */
-	char *buf = rpmExpand("ln -s %(pwd) %{buildsubdir}", NULL);
-	appendMb(mb, buf, 1);
-	free(buf);
-    }
-
     /* cd to the build dir */
     {	char * buildDir = rpmGenPath(spec->rootDir, "%{_builddir}", "");
 

--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -211,6 +211,8 @@ rpmbuild alias --trace		--eval '%trace' \
 	--POPTdesc=$"trace macro expansion"
 rpmbuild alias --nodebuginfo	--define 'debug_package %{nil}' \
 	--POPTdesc=$"do not generate debuginfo for this package"
+rpmbuild alias --build-in-place --define '_build_in_place 1' \
+	--POPTdesc=$"run build in current directory on checked out sources"
 
 rpmsign alias --key-id  --define '_gpg_name !#:+' \
 	--POPTdesc=$"key id/name to sign with" \

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -354,7 +354,7 @@ run rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild --build-in-place])
+AT_SETUP([rpmbuild --build-in-place 1])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -374,6 +374,14 @@ hello-2.0/hello.c
 [])
 
 RPMTEST_CHECK([
+runroot --chdir hello-2.0 rpmbuild -bb --build-in-place ../hello.spec
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+runroot_other sed -i -e "/%setup.*/d" hello.spec
 runroot --chdir hello-2.0 rpmbuild -bb --build-in-place ../hello.spec
 ],
 [0],
@@ -405,6 +413,29 @@ hello-2.0/debugsources.list
 hello-2.0/elfbins.list
 hello-2.0/hello
 hello-2.0/hello.c
+],
+[])
+RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild --build-in-place --short-circuit])
+AT_KEYWORDS([build])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
+runroot --chdir hello-2.0 rpmbuild -bi --build-in-place hello.spec
+runroot --chdir hello-2.0 rpmbuild -bb --build-in-place --short-circuit hello.spec
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+runroot rpm -qp --qf "%{name}-%{version}-%{release}\n" /build/RPMS/*/*.rpm
+],
+[0],
+[hello-2.0-1
+hello-debuginfo-2.0-1
 ],
 [])
 RPMTEST_CLEANUP

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -26,7 +26,6 @@ static struct rpmBuildArguments_s rpmBTArgs;
 #define	POPT_NOBUILD		-1017
 #define	POPT_RMSPEC		-1019
 #define POPT_NODIRTOKENS	-1020
-#define POPT_BUILDINPLACE	-1021
 
 #define	POPT_REBUILD		0x4262 /* Bb */
 #define	POPT_RECOMPILE		0x4369 /* Ci */
@@ -70,7 +69,6 @@ static char buildMode = 0;		/*!< Build mode (one of "btBC") */
 static char buildChar = 0;		/*!< Build stage (one of "abcdfilps ") */
 static rpmBuildFlags nobuildAmount = 0;	/*!< Build stage disablers */
 static ARGV_t build_targets = NULL;	/*!< Target platform(s) */
-static int buildInPlace = 0;		/*!< from --build-in-place */
 
 static void buildArgCallback( poptContext con,
 	enum poptCallbackReason reason,
@@ -141,12 +139,6 @@ static void buildArgCallback( poptContext con,
 
     case RPMCLI_POPT_FORCE:
 	spec_flags |= RPMSPEC_FORCE;
-	break;
-
-    case POPT_BUILDINPLACE:
-	rpmDefineMacro(NULL, "_build_in_place 1", 0);
-	buildInPlace = 1;
-	nobuildAmount |= RPMBUILD_RMBUILD;
 	break;
     }
 }
@@ -256,8 +248,6 @@ static struct poptOption rpmBuildPoptTable[] = {
 
  { "buildroot", '\0', POPT_ARG_STRING, 0,  POPT_BUILDROOT,
 	N_("override build root (DEPRECATED)"), "DIRECTORY" },
- { "build-in-place", '\0', 0, 0, POPT_BUILDINPLACE,
-	N_("run build in current directory"), NULL },
  { "clean", '\0', 0, 0, POPT_RMBUILD,
 	N_("remove build tree when done"), NULL},
  { "force", '\0', POPT_ARGFLAG_DOC_HIDDEN, 0, RPMCLI_POPT_FORCE,
@@ -587,10 +577,6 @@ static int build(rpmts ts, const char * arg, BTA_t ba, const char * rcfile)
 
 	/* Read in configuration for target. */
 	rpmFreeMacros(NULL);
-	if (buildInPlace) {
-		/* Need to redefine this after freeing all the macros */
-		rpmDefineMacro(NULL, "_build_in_place 1", 0);
-	}
 	rpmFreeRpmrc();
 	(void) rpmReadConfigFiles(rcfile, *target);
 	rc = buildForTarget(ts, arg, ba, NULL);


### PR DESCRIPTION
See commit messages for details, but this partially reverts d1075106bb315913574e1acac921058d23dd5130 to avoid a dependency on %setup that seems ... wrong for what --build-in-place is. Also, take advantage of rpm macro setup to handle this, so the rpmbuild command doesn't need any logic in it. Which also means %_build_in_place can be set from a spec directly.

Related: #3123