### PR TITLE
Fix regression on subpackage debuginfo RPMTAG_SOURCERPM missing

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2805,6 +2805,7 @@ static rpmTagVal copyTagsFromMainDebug[] = {
     RPMTAG_OS,
     RPMTAG_PLATFORM,
     RPMTAG_OPTFLAGS,
+    RPMTAG_SOURCERPM,
     0
 };
 


### PR DESCRIPTION
Didn't bisect but this is probably due to mucking around with the src.rpm name generation in dc47a50c6345a25b861305d8aa8ae464098834ff, but it's also much saner this way: the info should be copied from the main debuginfo package along with all the other similar stuff.