### PR TITLE
Fix a %buildroot regression on an early %__spec_install_pre %global o…

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -770,8 +770,8 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
   unset CDPATH DISPLAY ||:\
   unset DEBUGINFOD_URLS ||:\
   unset RPM_CONFIG_DIR ||:\
-  %{?buildroot:RPM_BUILD_ROOT=\"%{buildroot}\"\
-  export RPM_BUILD_ROOT}\
+  RPM_BUILD_ROOT=\"%{buildroot}\"\
+  export RPM_BUILD_ROOT\
   %{?_javaclasspath:CLASSPATH=\"%{_javaclasspath}\"\
   export CLASSPATH}\
   PKG_CONFIG_PATH=\"${PKG_CONFIG_PATH}:%{_libdir}/pkgconfig:%{_datadir}/pkgconfig\"\

--- a/tests/data/SPECS/install-hack.spec
+++ b/tests/data/SPECS/install-hack.spec
@@ -1,0 +1,20 @@
+# Mimic what fedora kernel.spec does. Whether this is a legitimate
+# thing for a package to or not is another question, but at least we'll
+# be aware if the behavior changes.
+%global __spec_install_pre %{___build_pre}
+
+Summary: install scriptlet section override hack
+Name: install-hack
+Version: 1.0
+Release: 1
+License: GPL
+Buildarch: noarch
+
+%description
+%{summary}
+
+%install
+mkdir -p $RPM_BUILD_ROOT/usr/local/bin
+
+%files
+/usr/local/bin/

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3277,3 +3277,15 @@ BUILD_POST noarch noarch noarch
 ],
 [])
 RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild install_pre override])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+runroot rpmbuild -bb /data/SPECS/install-hack.spec
+],
+[0],
+[ignore],
+[ignore])
+RPMTEST_CLEANUP
+


### PR DESCRIPTION
…verride

The Fedora kernel.spec overrides %__spec_install_pre with this very early in the spec:

	%global __spec_install_pre %{___build_pre}

This happens long before Name and all that is defined, so half of the environment setup in %___build_pre just falls through with unexpanded macros as the values (eg RPM_PACKAGE_NAME=%{NAME}) at this stage, and get their real values on the re-expansion before the actual scriptlet execution. But, due to pre-historical reasons, RPM_BUILD_ROOT setting is conditional, depending on whether %buildroot is defined or not. It used to be defined in the main macros file, so RPM_BUILD_ROOT would also get that template-style value at this point in the spec, but since 9d35c8df497534e1fbd806a4dc78802bcf35d7cb it no longer is. And that causes RPM_BUILD_ROOT to be *dropped* from the pre-environment "template" at this early stage of spec parsing.

Add a simple reproducer test, this level of meddling in packages is of playing with fire and we may not be able to guarantee it always stays this way, but at least we'll be aware of possible changes in behavior.

Commit 0a4e182e4003be1497452658b7b3327975694641 from 1998 is the first macro version of this conditional that came back to bite us.

Reported in https://bugzilla.redhat.com/show_bug.cgi?id=2284036