### PR TITLE
Require %{buildsubdir} to be defined to get debuginfo packages again

### DIFF
--- a/platform.in
+++ b/platform.in
@@ -59,7 +59,7 @@
 
 %__spec_install_template\
 %{__spec_install_pre}\
-%[ 0%{?_enable_debug_packages} > 0 ? "%(echo "%{debug_package}" > %{specpartsdir}/rpm-debuginfo.specpart)" : "" ]\
+%[ 0%{?_enable_debug_packages} > 0 ? "%{?buildsubdir:%(echo "%{debug_package}" > %{specpartsdir}/rpm-debuginfo.specpart)}" : "" ]\
 %{nil}
 
 %__spec_install_pre %{___build_pre}\

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3173,10 +3173,24 @@ runroot rpm -qp --qf "%{name}\n" /build/RPMS/*/*.rpm|sort
 ],
 [0],
 [caps
-caps-debuginfo
 ],
 [])
 
+RPMTEST_CHECK([
+runroot rpmbuild --quiet -bb --define "buildsubdir ." /data/SPECS/caps.spec
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -qp --qf "%{name}\n" /build/RPMS/*/*.rpm|sort
+],
+[0],
+[caps
+caps-debuginfo
+],
+[])
 RPMTEST_CHECK([
 runroot rpm -q --filecaps /build/RPMS/*/caps-1.0-1.*.rpm | grep -v build-id
 ],


### PR DESCRIPTION
One of the intentions with the debuginfo enablement rework in 4.20 was to allow debuginfo generation on packages that don't use %setup, or in other words, don't have %{buildsubdir} defined. Turns out there's just so many things out there, relying on all these exact bits and pieces to be JUST SO, this causes more harm than its worth.

So bring back the requirement of %{buildsubdir} macro to be defined for debuginfo generation to take place, update the caps testcase to cover both. At least we can now just define buildsubdir from the spec or even command line, so the promise to have debuginfo without %setup still holds, it's just not automatic everywhere.