### PR TITLE
Refactor dbiset and callers to hide implementation

### DIFF
--- a/lib/backend/bdb_ro.c
+++ b/lib/backend/bdb_ro.c
@@ -665,13 +665,14 @@ static void appenddbt(dbiCursor dbc, unsigned char *val, unsigned int vallen, db
     struct bdb_cur *cur = (struct bdb_cur *)dbc;
     dbiIndexSet set;
     unsigned int i;
+    unsigned int nrecs = vallen / (2 * sizeof(uint32_t));
 
-    set = dbiIndexSetNew(vallen / (2 * sizeof(uint32_t)));
-    set->count = vallen / (2 * sizeof(uint32_t));
+    set = dbiIndexSetNew(nrecs);
 
-    for (i = 0; i < set->count; i++, val += 8) {
-	set->recs[i].hdrNum = getui32(val, cur->db->swapped);
-	set->recs[i].tagNum = getui32(val + 4, cur->db->swapped);
+    for (i = 0; i < nrecs; i++, val += 8) {
+	unsigned int hdrNum = getui32(val, cur->db->swapped);
+	unsigned int tagNum = getui32(val + 4, cur->db->swapped);
+	dbiIndexSetAppendOne(set, hdrNum, tagNum, 0);
     }
     if (*setp == NULL) {
 	*setp = set;

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -4,6 +4,13 @@
 #include "dbiset.h"
 #include "debug.h"
 
+/* Items retrieved from the index database.*/
+struct dbiIndexSet_s {
+    dbiIndexItem recs;			/*!< array of records */
+    unsigned int count;			/*!< number of records */
+    size_t alloced;			/*!< alloced size */
+};
+
 dbiIndexSet dbiIndexSetNew(unsigned int sizehint)
 {
     dbiIndexSet set = (dbiIndexSet)xcalloc(1, sizeof(*set));

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -145,24 +145,22 @@ int dbiIndexSetPruneSet(dbiIndexSet set, dbiIndexSet oset, int sorted)
     return (numCopied == num);
 }
 
-static
-int dbiIndexSetFilter(dbiIndexSet set, dbiIndexItem recs,
-                        unsigned int nrecs, int sorted)
+int dbiIndexSetFilterSet(dbiIndexSet set, dbiIndexSet oset, int sorted)
 {
     unsigned int from;
     unsigned int to = 0;
     unsigned int num = set->count;
     unsigned int numCopied = 0;
-    size_t recsize = sizeof(*recs);
+    size_t recsize = sizeof(*oset->recs);
 
-    if (num == 0 || nrecs == 0) {
+    if (num == 0 || oset->count == 0) {
 	set->count = 0;
 	return num ? 0 : 1;
     }
-    if (nrecs > 1 && !sorted)
-	qsort(recs, nrecs, recsize, hdrNumCmp);
+    if (oset->count > 1 && !sorted)
+	dbiIndexSetSort(oset);
     for (from = 0; from < num; from++) {
-	if (!bsearch(&set->recs[from], recs, nrecs, recsize, hdrNumCmp)) {
+	if (!bsearch(&set->recs[from], oset->recs, oset->count, recsize, hdrNumCmp)) {
 	    set->count--;
 	    continue;
 	}
@@ -172,11 +170,6 @@ int dbiIndexSetFilter(dbiIndexSet set, dbiIndexItem recs,
 	numCopied++;
     }
     return (numCopied == num);
-}
-
-int dbiIndexSetFilterSet(dbiIndexSet set, dbiIndexSet oset, int sorted)
-{
-    return dbiIndexSetFilter(set, oset->recs, oset->count, sorted);
 }
 
 unsigned int dbiIndexSetCount(dbiIndexSet set)

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -113,7 +113,7 @@ int dbiIndexSetAppendOne(dbiIndexSet set, unsigned int hdrNum,
     set->count += 1;
 
     if (sortset && set->count > 1)
-	qsort(set->recs, set->count, sizeof(*(set->recs)), hdrNumCmp);
+	dbiIndexSetSort(set);
 
     return 0;
 }

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -118,24 +118,22 @@ int dbiIndexSetAppendOne(dbiIndexSet set, unsigned int hdrNum,
     return 0;
 }
 
-static
-int dbiIndexSetPrune(dbiIndexSet set, dbiIndexItem recs,
-		     unsigned int nrecs, int sorted)
+int dbiIndexSetPruneSet(dbiIndexSet set, dbiIndexSet oset, int sorted)
 {
     unsigned int from;
     unsigned int to = 0;
     unsigned int num = set->count;
     unsigned int numCopied = 0;
-    size_t recsize = sizeof(*recs);
+    size_t recsize = sizeof(*oset->recs);
 
-    if (num == 0 || nrecs == 0)
+    if (num == 0 || oset->count == 0)
 	return 1;
 
-    if (nrecs > 1 && !sorted)
-	qsort(recs, nrecs, recsize, hdrNumCmp);
+    if (oset->count > 1 && !sorted)
+	dbiIndexSetSort(oset);
 
     for (from = 0; from < num; from++) {
-	if (bsearch(&set->recs[from], recs, nrecs, recsize, hdrNumCmp)) {
+	if (bsearch(&set->recs[from], oset->recs, oset->count, recsize, hdrNumCmp)) {
 	    set->count--;
 	    continue;
 	}
@@ -145,13 +143,6 @@ int dbiIndexSetPrune(dbiIndexSet set, dbiIndexItem recs,
 	numCopied++;
     }
     return (numCopied == num);
-}
-
-int dbiIndexSetPruneSet(dbiIndexSet set, dbiIndexSet oset, int sortset)
-{
-    if (oset == NULL)
-	return 1;
-    return dbiIndexSetPrune(set, oset->recs, oset->count, sortset);
 }
 
 static

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -84,30 +84,21 @@ void dbiIndexSetUniq(dbiIndexSet set, int sorted)
     }
 }
 
-static
-int dbiIndexSetAppend(dbiIndexSet set, dbiIndexItem recs,
-		      unsigned int nrecs, int sortset)
+int dbiIndexSetAppendSet(dbiIndexSet set, dbiIndexSet oset, int sortset)
 {
-    if (set == NULL || recs == NULL)
+    if (set == NULL || oset == NULL)
 	return 1;
 
-    if (nrecs) {
-	dbiIndexSetGrow(set, nrecs);
-	memcpy(set->recs + set->count, recs, nrecs * sizeof(*(set->recs)));
-	set->count += nrecs;
+    if (oset->count) {
+	dbiIndexSetGrow(set, oset->count);
+	memcpy(set->recs + set->count, oset->recs, oset->count * sizeof(*(set->recs)));
+	set->count += oset->count;
     }
     
     if (sortset && set->count > 1)
-	qsort(set->recs, set->count, sizeof(*(set->recs)), hdrNumCmp);
+	dbiIndexSetSort(set);
 
     return 0;
-}
-
-int dbiIndexSetAppendSet(dbiIndexSet set, dbiIndexSet oset, int sortset)
-{
-    if (oset == NULL)
-	return 1;
-    return dbiIndexSetAppend(set, oset->recs, oset->count, sortset);
 }
 
 int dbiIndexSetAppendOne(dbiIndexSet set, unsigned int hdrNum,

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -78,6 +78,7 @@ void dbiIndexSetUniq(dbiIndexSet set, int sorted)
     }
 }
 
+static
 int dbiIndexSetAppend(dbiIndexSet set, dbiIndexItem recs,
 		      unsigned int nrecs, int sortset)
 {
@@ -120,6 +121,7 @@ int dbiIndexSetAppendOne(dbiIndexSet set, unsigned int hdrNum,
     return 0;
 }
 
+static
 int dbiIndexSetPrune(dbiIndexSet set, dbiIndexItem recs,
 		     unsigned int nrecs, int sorted)
 {
@@ -155,6 +157,7 @@ int dbiIndexSetPruneSet(dbiIndexSet set, dbiIndexSet oset, int sortset)
     return dbiIndexSetPrune(set, oset->recs, oset->count, sortset);
 }
 
+static
 int dbiIndexSetFilter(dbiIndexSet set, dbiIndexItem recs,
                         unsigned int nrecs, int sorted)
 {

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -31,6 +31,12 @@ void dbiIndexSetGrow(dbiIndexSet set, unsigned int nrecs)
     }
 }
 
+void dbiIndexSetClear(dbiIndexSet set)
+{
+    if (set)
+	set->count = 0;
+}
+
 static int hdrNumCmp(const void * one, const void * two)
 {
     const struct dbiIndexItem_s *a = (const struct dbiIndexItem_s *)one;
@@ -215,4 +221,3 @@ dbiIndexSet dbiIndexSetFree(dbiIndexSet set)
     }
     return NULL;
 }
-

--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -13,7 +13,7 @@ struct dbiIndexSet_s {
 
 dbiIndexSet dbiIndexSetNew(unsigned int sizehint)
 {
-    dbiIndexSet set = (dbiIndexSet)xcalloc(1, sizeof(*set));
+    dbiIndexSet set = new dbiIndexSet_s {};
     if (sizehint > 0)
 	dbiIndexSetGrow(set, sizehint);
     return set;
@@ -192,8 +192,7 @@ dbiIndexSet dbiIndexSetFree(dbiIndexSet set)
 {
     if (set) {
 	free(set->recs);
-	memset(set, 0, sizeof(*set)); /* trash and burn */
-	free(set);
+	delete set;
     }
     return NULL;
 }

--- a/lib/backend/dbiset.h
+++ b/lib/backend/dbiset.h
@@ -24,6 +24,9 @@ dbiIndexSet dbiIndexSetNew(unsigned int sizehint);
 RPM_GNUC_INTERNAL
 void dbiIndexSetGrow(dbiIndexSet set, unsigned int nrecs);
 
+RPM_GNUC_INTERNAL
+void dbiIndexSetClear(dbiIndexSet set);
+
 /* Sort an index set */
 RPM_GNUC_INTERNAL
 void dbiIndexSetSort(dbiIndexSet set);
@@ -83,5 +86,4 @@ unsigned int dbiIndexRecordFileNumber(dbiIndexSet set, unsigned int recno);
 /* Destroy set of index database items */
 RPM_GNUC_INTERNAL
 dbiIndexSet dbiIndexSetFree(dbiIndexSet set);
-
 #endif

--- a/lib/backend/dbiset.h
+++ b/lib/backend/dbiset.h
@@ -37,18 +37,6 @@ RPM_GNUC_INTERNAL
 int dbiIndexSetAppendSet(dbiIndexSet set, dbiIndexSet oset, int sortset);
 
 /**
- * Append element(s) to set of index database items.
- * @param set		set of index database items
- * @param recs		array of items to append to set
- * @param nrecs		number of items
- * @param sortset	should resulting set be sorted?
- * @return		0 success, 1 failure (bad args)
- */
-RPM_GNUC_INTERNAL
-int dbiIndexSetAppend(dbiIndexSet set, dbiIndexItem recs,
-		      unsigned int nrecs, int sortset);
-
-/**
   * Append a single element to a set of index database items.
   * @param set          set of index database items
   * @param hdrNum       header instance in db
@@ -61,18 +49,6 @@ int dbiIndexSetAppendOne(dbiIndexSet set, unsigned int hdrNum,
 			 unsigned int tagNum, int sortset);
 
 /**
- * Remove element(s) from set of index database items.
- * @param set		set of index database items
- * @param recs		array of items to remove from set
- * @param nrecs		number of items
- * @param sorted	array is already sorted?
- * @return		0 success, 1 failure (no items found)
- */
-RPM_GNUC_INTERNAL
-int dbiIndexSetPrune(dbiIndexSet set, dbiIndexItem recs,
-		     unsigned int nrecs, int sorted);
-
-/**
  * Remove an index set from another.
  * @param set          set of index database items
  * @param oset         set of entries that should be removed
@@ -81,18 +57,6 @@ int dbiIndexSetPrune(dbiIndexSet set, dbiIndexItem recs,
  */
 RPM_GNUC_INTERNAL
 int dbiIndexSetPruneSet(dbiIndexSet set, dbiIndexSet oset, int sorted);
-
-/**
- * Filter element(s) from set of index database items.
- * @param set          set of index database items
- * @param recs         array of items to remove from set
- * @param nrecs                number of items
- * @param sorted       recs array is already sorted?
- * @return             0 success, 1 failure (no items removed)
- */
-RPM_GNUC_INTERNAL
-int dbiIndexSetFilter(dbiIndexSet set, dbiIndexItem recs,
-		      unsigned int nrecs, int sorted);
 
 /**
  * Filter (intersect) an index set with another.

--- a/lib/backend/dbiset.h
+++ b/lib/backend/dbiset.h
@@ -9,12 +9,7 @@ typedef struct dbiIndexItem_s {
     unsigned int tagNum;		/*!< tag index in header */
 } * dbiIndexItem;
 
-/* Items retrieved from the index database.*/
-typedef struct dbiIndexSet_s {
-    dbiIndexItem recs;			/*!< array of records */
-    unsigned int count;			/*!< number of records */
-    size_t alloced;			/*!< alloced size */
-} * dbiIndexSet;
+typedef struct dbiIndexSet_s * dbiIndexSet;
 
 /* Create an empty index set, optionally with sizehint reservation for recs */
 RPM_GNUC_INTERNAL

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -402,14 +402,11 @@ static unsigned int ndb_pkgdbKey(dbiIndex dbi, dbiCursor dbc)
 
 static void addtoset(dbiIndexSet *set, unsigned int *pkglist, unsigned int pkglistn)
 {
-    unsigned int i, j;
+    unsigned int i;
     dbiIndexSet newset = dbiIndexSetNew(pkglistn / 2);
-    for (i = j = 0; i < pkglistn; i += 2) {
-	newset->recs[j].hdrNum = pkglist[i];
-	newset->recs[j].tagNum = pkglist[i + 1];
-	j++;
+    for (i = 0; i < pkglistn; i += 2) {
+	dbiIndexSetAppendOne(newset, pkglist[i], pkglist[i + 1], 0);
     }
-    newset->count = j;
     if (pkglist)
 	free(pkglist);
     if (*set) {

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -1879,9 +1879,10 @@ const unsigned int *rpmdbIndexIteratorPkgOffsets(rpmdbIndexIterator ii)
     if (!ii || !ii->ii_set)
 	return NULL;
 
-    ii->ii_hdrNums.resize(ii->ii_set->count);
-    for (int i = 0; i < ii->ii_set->count; i++) {
-	ii->ii_hdrNums[i] = ii->ii_set->recs[i].hdrNum;
+    unsigned int count = dbiIndexSetCount(ii->ii_set);
+    ii->ii_hdrNums.resize(count);
+    for (int i = 0; i < count; i++) {
+	ii->ii_hdrNums[i] = dbiIndexRecordOffset(ii->ii_set, i);
     }
 
     return ii->ii_hdrNums.data();

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -977,7 +977,7 @@ unsigned int rpmdbGetIteratorFileNum(rpmdbMatchIterator mi)
 
 int rpmdbGetIteratorCount(rpmdbMatchIterator mi)
 {
-    return (mi && mi->mi_set ?  mi->mi_set->count : 0);
+    return (mi ? dbiIndexSetCount(mi->mi_set) : 0);
 }
 
 int rpmdbGetIteratorIndex(rpmdbMatchIterator mi)
@@ -993,8 +993,8 @@ void rpmdbSetIteratorIndex(rpmdbMatchIterator mi, unsigned int ix)
 
 unsigned int rpmdbGetIteratorOffsetFor(rpmdbMatchIterator mi, unsigned int ix)
 {
-    if (mi && mi->mi_set && ix < mi->mi_set->count)
-	return mi->mi_set->recs[ix].hdrNum;
+    if (mi && mi->mi_set && ix < dbiIndexSetCount(mi->mi_set))
+	return dbiIndexRecordOffset(mi->mi_set, ix);
     return 0;
 }
 
@@ -1393,7 +1393,7 @@ top:
 
     do {
 	if (mi->mi_set) {
-	    if (!(mi->mi_setx < mi->mi_set->count))
+	    if (!(mi->mi_setx < dbiIndexSetCount(mi->mi_set)))
 		return NULL;
 	    mi->mi_offset = dbiIndexRecordOffset(mi->mi_set, mi->mi_setx);
 	    mi->mi_filenum = dbiIndexRecordFileNumber(mi->mi_set, mi->mi_setx);

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2869,6 +2869,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmbuild spec tag])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
+RPMDB_INIT
 RPMTEST_SETUP
 runroot rpmbuild -bs --quiet /data/SPECS/foo.spec
 runroot rpm -qp --qf "%{spec}" /build/SRPMS/foo-1.0-1.src.rpm


### PR DESCRIPTION
Force all callers through the internal API instead of mucking with internals - preliminary heave to make moving it to C++ easier.