### PR TITLE
Fix signfiles regression from 13a02b15d6552bc8e440235b846ea5257514d397

### DIFF
--- a/sign/rpmsignfiles.c
+++ b/sign/rpmsignfiles.c
@@ -23,6 +23,7 @@ static const char *hash_algo_name[] = {
     "md5", 	/* RPM_HASH_MD5 */
     "sha1", 	/* RPM_HASH_SHA1 */
     "rmd160",	/* RPM_HASH_RIPEMD160 */
+    "reserved1",/* reserved */
     "md2",	/* RPM_HASH_MD2 */
     "tgr192", 	/* RPM_HASH_TIGER192 */
     "haval5160",/* RPM_HASH_HAVAL_5_160 */


### PR DESCRIPTION
The sneaky construct hid more than just values starting from 1: there's no value 4 in rpmHashAlgo enum, so skipping that causes all the later hash names to be off by one.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2291183