### PR TITLE
Check for mandatory tags after parsing the Spec the first time

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -677,13 +677,14 @@ static const rpmTagVal sourceTags[] = {
     0
 };
 
-static void initSourceHeader(rpmSpec spec)
+static int initSourceHeader(rpmSpec spec)
 {
     Package sourcePkg = spec->sourcePackage;
     struct Source *srcPtr;
+    int rc = 0;
 
     if (headerIsEntry(sourcePkg->header, RPMTAG_NAME))
-	return;
+	return rc;
 
     char *os = rpmExpand("%{_target_os}", NULL);
     headerPutString(sourcePkg->header, RPMTAG_OS, os);
@@ -739,6 +740,10 @@ static void initSourceHeader(rpmSpec spec)
 		spec->noSource ? "no" : "");
 	free(nvr);
     }
+
+    rc = checkForRequired(spec->sourcePackage->header);
+
+    return rc;
 }
 
 static void finalizeSourceHeader(rpmSpec spec)
@@ -1320,7 +1325,8 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 	goto errxit;
 
     /* Assemble source header from parsed components */
-    initSourceHeader(spec);
+    if (initSourceHeader(spec))
+	goto errxit;
     return spec;
 
 errxit:

--- a/tests/data/SPECS/autosetup-noroot.spec
+++ b/tests/data/SPECS/autosetup-noroot.spec
@@ -2,6 +2,7 @@ Summary:       Test Spec file
 Name:          autosetup-test
 Version:       1.2.3
 Release:       4
+License:       GPL
 
 Source:        source-noroot.tar.gz
 

--- a/tests/data/SPECS/autosetup-singleroot.spec
+++ b/tests/data/SPECS/autosetup-singleroot.spec
@@ -2,6 +2,7 @@ Summary:       Test Spec file
 Name:          autosetup-test
 Version:       1.2.3
 Release:       4
+License:       GPL
 
 Source:        source-singleroot.tar.gz
 

--- a/tests/data/SPECS/dynamic.spec
+++ b/tests/data/SPECS/dynamic.spec
@@ -29,6 +29,7 @@ echo "License: GPL" >> %{specpartsdir}/mainpkg.specpart
 echo "Distribution: RPM test suite." >> %{specpartsdir}/mainpkg.specpart
 echo "URL: http://rpm.org" >> %{specpartsdir}/mainpkg.specpart
 echo "Summary: dynamic hello -- hello, world rpm" >> %{specpartsdir}/mainpkg.specpart
+}
 %{?DOUBLESUMMARY:
 echo "Summary: dynamic hello -- hello, world again" >> %{specpartsdir}/mainpkg.specpart
 }
@@ -36,7 +37,6 @@ echo "Summary: dynamic hello -- hello, world again" >> %{specpartsdir}/mainpkg.s
 echo "LicenseToKill: True" >> %{specpartsdir}/mainpkg.specpart
 }
 
-}
 
 echo "%package docs" >> %{specpartsdir}/docs.specpart
 %{?!FAIL:echo "Summary: Documentation for dynamic spec" >> %{specpartsdir}/docs.specpart}

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2959,8 +2959,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if dynamic spec generation works for main package, too
+# Fails now as feature is disbled
 AT_SETUP([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
+AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMDB_INIT
 RPMTEST_CHECK([
 
@@ -2970,6 +2972,7 @@ runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -ba /data/SPEC
 [ignore],
 [ignore])
 
+AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMTEST_CHECK([
 
 runroot rpm -qp --qf "%{Summary}\n" /build/RPMS/noarch/dynamic-docs-1.0-1.noarch.rpm
@@ -2981,6 +2984,37 @@ runroot rpm -ql /build/RPMS/noarch/dynamic-docs-1.0-1.noarch.rpm
 /usr/local/share/doc/dynamic-docs-1.0/FAQ
 ],
 [])
+RPMTEST_CLEANUP
+
+# ------------------------------
+# Check if dynamic spec generation works for main package, too
+# Check for failure as feature is disabled. Remove tests when enabled
+AT_SETUP([rpmbuild with dynamic spec generation for main package])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+
+runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -ba /data/SPECS/dynamic.spec
+],
+[1],
+[],
+[error: Summary field must be present in package: dynamic
+error: License field must be present in package: dynamic
+])
+RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild with dynamic spec generation for main package])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+
+runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -bs /data/SPECS/dynamic.spec
+],
+[1],
+[],
+[error: Summary field must be present in package: dynamic
+error: License field must be present in package: dynamic
+])
 RPMTEST_CLEANUP
 
 # ------------------------------
@@ -3007,11 +3041,11 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-runroot rpmbuild --quiet -D "FULLDYNAMIC 1" -D "DOUBLESUMMARY 1" -ba /data/SPECS/dynamic.spec
+runroot rpmbuild --quiet -D "DOUBLESUMMARY 1" -ba /data/SPECS/dynamic.spec
 ],
 [0],
 [],
-[warning: line 6: second Summary
+[warning: line 1: second Summary
 ])
 
 RPMTEST_CLEANUP
@@ -3023,11 +3057,11 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-runroot rpmbuild --quiet -D "FULLDYNAMIC 1" -D "WRONGTAG 1" -ba /data/SPECS/dynamic.spec
+runroot rpmbuild --quiet -D "WRONGTAG 1" -ba /data/SPECS/dynamic.spec
 ],
 [1],
 [],
-[error: line 6: Unknown tag: LicenseToKill: True
+[error: line 1: Unknown tag: LicenseToKill: True
 error: parsing failed
 ])
 
@@ -3040,7 +3074,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-runroot rpmbuild --quiet -D "FULLDYNAMIC 1" -D "FORBIDDENSECTION 1" -ba /data/SPECS/dynamic.spec
+runroot rpmbuild --quiet -D "FORBIDDENSECTION 1" -ba /data/SPECS/dynamic.spec
 ],
 [1],
 [],
@@ -3057,7 +3091,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-runroot rpmbuild --quiet -D "FULLDYNAMIC 1" -D "FORBIDDENTAG 1" -ba /data/SPECS/dynamic.spec
+runroot rpmbuild --quiet -D "FORBIDDENTAG 1" -ba /data/SPECS/dynamic.spec
 ],
 [1],
 [],


### PR DESCRIPTION

Generating mandatory tags dynamically has them missing in SRPMs if build with rpmbuid -bs or such. To prevent this from happening check the source header right after the initial parse rn of the spec file. This is more strict than before relaxing this for dynamic spec feature as now errors can come up even if no package is actually build.