### PR TITLE
Fix a subtle thinko in dbiIndexItem less-than comparison

### DIFF
--- a/lib/backend/dbiset.c
+++ b/lib/backend/dbiset.c
@@ -12,9 +12,9 @@ using std::vector;
 
 bool dbiIndexItem_s::operator < (const dbiIndexItem_s & other) const
 {
-    if (hdrNum < other.hdrNum)
-	return true;
-    return tagNum < other.tagNum;
+    if (hdrNum == other.hdrNum)
+	return tagNum < other.tagNum;
+    return hdrNum < other.hdrNum;
 }
 
 bool dbiIndexItem_s::operator == (const dbiIndexItem_s & other) const


### PR DESCRIPTION
This subtlety in commit 52f311e224254d7cb28bf2ced22db7b50e1a2653 resulted in not-so-subtle crash due to sort going out of bounds.