### PR TITLE
Fix doc strings

### DIFF
--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -116,6 +116,7 @@ pgpDigParams rpmPubkeyPgpDigParams(rpmPubkey key);
 
 /** \ingroup rpmkeyring
  * Lookup a pubkey in the keyring
+ * @param keyring      keyring handle
  * @param key          Pubkey to find in keyring
  * @return             pubkey handle, NULL if not found
  */
@@ -123,7 +124,7 @@ rpmPubkey rpmKeyringLookupKey(rpmKeyring keyring, rpmPubkey key);
 
 /** \ingroup rpmkeyring
  * Modify the keys in the keyring
- * @param key		Pubkey
+ * @param keyring      keyring handle
  * @param key		pubkey handle
  * @param mode          mode of operation
  * @return		0 on success, -1 on error, 1 if the operation did not

--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -519,8 +519,8 @@ char *pgpIdentItem(pgpDigParams digp);
  * @param pkts1len	length of the buffer with the first certificate
  * @param pkts2		OpenPGP pointer to a buffer with the second certificate
  * @param pkts2len	length of the buffer with the second certificate
- * @param pktsm[out]	merged certificate (malloced)
- * @param pktsmlen[out]	length of merged certificate
+ * @param pktsm         [out] merged certificate (malloced)
+ * @param pktsmlen      [out] length of merged certificate
  * @param flags		merge flags (currently not used, must be zero)
  * @return 		RPMRC_OK on success 
  */


### PR DESCRIPTION
Otherwise these create warnings which fail the build if treated as errors.