### PR TITLE
Explicitly enable Doxygen on our CI builds

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -85,6 +85,7 @@ RUN cmake \
 	-DENABLE_BDB_RO=ON \
 	-DWITH_FSVERITY=ON \
 	-DWITH_IMAEVM=ON \
+	-DWITH_DOXYGEN=ON \
 	-DMKTREE_BACKEND=rootfs \
 	../rpm
 RUN make -j$(nproc) tree


### PR DESCRIPTION
Doxygen is present in the CI image but no longer automatically enabled since commit 26a1ccf2819ab148aef3cd354e1cbdb70a9fe5b7.