### PR TITLE
Make the urlhelper test prefix-agnostic

### DIFF
--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -402,11 +402,11 @@ AT_SETUP([urlhelper fails])
 AT_KEYWORDS([urlhelper])
 RPMDB_INIT
 RPMTEST_CHECK([
-runroot rpm --define "_urlhelper /bin/false" --root /srv/test -qp https://example.com/foo-0.1-1.noarch.rpm 2> >(sed 's|rpm-tmp.* https|rpm-tmp https|' >&2)
+runroot rpm --define "_urlhelper /bin/false" --root /srv/test -qp https://example.com/foo-0.1-1.noarch.rpm 2> >(sed 's| /.*rpm-tmp.* https| rpm-tmp https|' >&2)
 ],
 [1],
 [],
-[error: Executing url helper "/bin/false /usr/local/var/tmp/rpm-tmp https://example.com/foo-0.1-1.noarch.rpm" failed with status 1
+[error: Executing url helper "/bin/false rpm-tmp https://example.com/foo-0.1-1.noarch.rpm" failed with status 1
 error: open of https://example.com/foo-0.1-1.noarch.rpm failed: No such file or directory
 ])
 RPMTEST_CLEANUP


### PR DESCRIPTION
In some cases like the default /usr/local the build prefix leaks to %_tmppath. /usr/local/var looks rather wrong anyhow but that's another issue, just strip it out of the test result to avoid bogus build failures with other prefixes.

Fixes: 4c1f71ec9e171dcf29079ff80bab68d86d7d1856