### PR TITLE
Set errno to EPERM for dangerous symlinks

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -328,8 +328,13 @@ static int fsmOpenat(int dirfd, const char *path, int flags, int dir)
     }
 
     /* O_DIRECTORY equivalent */
-    if (dir && ((fd != ffd) || (fd >= 0 && fstat(fd, &sb) == 0 && !S_ISDIR(sb.st_mode)))) {
+    if (dir && fd >= 0 && fstat(fd, &sb) == 0 && !S_ISDIR(sb.st_mode)) {
 	errno = ENOTDIR;
+	fsmClose(&fd);
+    }
+    /* Symlink with non matching owners */
+    if (dir && (fd != ffd)) {
+	errno = EPERM;
 	fsmClose(&fd);
     }
     return fd;

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1630,8 +1630,8 @@ runroot --setenv SOURCE_DATE_EPOCH 1699955855 rpm -U /build/RPMS/noarch/replacet
 ],
 [1],
 [],
-[error: failed to open dir opt of /opt/: Not a directory
-error: unpacking of archive failed on file /opt/foo;6553448f: cpio: open failed - Not a directory
+[error: failed to open dir opt of /opt/: Operation not permitted
+error: unpacking of archive failed on file /opt/foo;6553448f: cpio: open failed - Operation not permitted
 error: replacetest-1.0-1.noarch: install failed
 ])
 RPMTEST_CLEANUP


### PR DESCRIPTION
RPM refuses to follow non root owned symlinks pointing to files owned by another user for security reasons. This case was lumped in with other issues resulting in us setting errno to ENOTDIR. This led to confusing as the symlink often indeed points at a directory. Using EPERM is still not 100% right but points at least roughly into the right direction.

May be we should catch EPERM further up the call stack and use it to give a more meaningfull error message.

Resolves: #3100