### PR TITLE
Natively allocate database remaining backend layer structs

### DIFF
--- a/lib/backend/bdb_ro.c
+++ b/lib/backend/bdb_ro.c
@@ -150,7 +150,7 @@ static void bdb_close(struct bdb_db *db)
 {
     if (db->fd >= 0)
 	close(db->fd);
-    free(db);
+    delete db;
 }
 
 static struct bdb_db *bdb_open(const char *name)
@@ -163,7 +163,7 @@ static struct bdb_db *bdb_open(const char *name)
     if (fd == -1) {
 	return NULL;
     }
-    db = (struct bdb_db *)xcalloc(1, sizeof(*db));
+    db = new bdb_db {};
     db->fd = fd;
     if (pread(fd, meta, 512, 0) != 512) {
 	rpmlog(RPMLOG_ERR, "%s: pread: %s\n", name, strerror(errno));
@@ -485,7 +485,7 @@ static int btree_getval(struct bdb_cur *cur)
 
 static struct bdb_cur *cur_open(struct bdb_db *db)
 {
-    struct bdb_cur *cur = (struct bdb_cur *)xcalloc(1, sizeof(*cur));
+    struct bdb_cur *cur = new bdb_cur {};
     cur->db = db;
     cur->page = (unsigned char *)xmalloc(db->pagesize);
     return cur;
@@ -501,7 +501,7 @@ static void cur_close(struct bdb_cur *cur)
 	free(cur->keyov.kv);
     if (cur->valov.kv)
 	free(cur->valov.kv);
-    free(cur);
+    delete cur;
 }
 
 static int cur_next(struct bdb_cur *cur)

--- a/lib/backend/bdb_ro.c
+++ b/lib/backend/bdb_ro.c
@@ -16,6 +16,19 @@
 #define BDB_HASH 0
 #define BDB_BTREE 1
 
+union _dbswap {
+    unsigned int ui;
+    unsigned char uc[4];
+};
+
+#define	_DBSWAP(_a) \
+\
+  { unsigned char _b, *_c = (_a).uc; \
+    _b = _c[3]; _c[3] = _c[0]; _c[0] = _b; \
+    _b = _c[2]; _c[2] = _c[1]; _c[1] = _b; \
+\
+  }
+
 struct dbiCursor_s;
 
 struct bdb_kv {

--- a/lib/backend/dbi.c
+++ b/lib/backend/dbi.c
@@ -30,14 +30,14 @@ const struct rpmdbOps_s *backends[] = {
 dbiIndex dbiFree(dbiIndex dbi)
 {
     if (dbi) {
-	free(dbi);
+	delete dbi;
     }
     return NULL;
 }
 
 dbiIndex dbiNew(rpmdb rdb, rpmDbiTagVal rpmtag)
 {
-    dbiIndex dbi = (dbiIndex)xcalloc(1, sizeof(*dbi));
+    dbiIndex dbi = new dbiIndex_s {};
     /* FIX: figger lib/dbi refcounts */
     dbi->dbi_rpmdb = rdb;
     dbi->dbi_file = rpmTagGetName(rpmtag);

--- a/lib/backend/dbi.h
+++ b/lib/backend/dbi.h
@@ -105,19 +105,6 @@ struct dbiIndex_s {
     void * dbi_db;		/*!< Backend private handle */
 };
 
-union _dbswap {
-    unsigned int ui;
-    unsigned char uc[4];
-};
-
-#define	_DBSWAP(_a) \
-\
-  { unsigned char _b, *_c = (_a).uc; \
-    _b = _c[3]; _c[3] = _c[0]; _c[0] = _b; \
-    _b = _c[2]; _c[2] = _c[1]; _c[1] = _b; \
-\
-  }
-
 typedef rpmRC (*idxfunc)(dbiIndex dbi, dbiCursor dbc,
 			const char *keyp, size_t keylen, dbiIndexItem rec);
 

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -52,7 +52,7 @@ static void closeEnv(rpmdb rdb)
 	}
 	if (ndbenv->data)
 	    free(ndbenv->data);
-	free(ndbenv);
+	delete ndbenv;
 	rdb->db_dbenv = 0;
     }
 }
@@ -61,7 +61,7 @@ static struct ndbEnv_s *openEnv(rpmdb rdb)
 {
     struct ndbEnv_s *ndbenv = (struct ndbEnv_s *)rdb->db_dbenv;
     if (!ndbenv) {
-	rdb->db_dbenv = ndbenv = (struct ndbEnv_s *)xcalloc(1, sizeof(struct ndbEnv_s));
+	rdb->db_dbenv = ndbenv = new ndbEnv_s {};
 	ndbenv->dofsync = 1;
     }
     ndbenv->refs++;
@@ -280,7 +280,7 @@ static int ndb_Ctrl(rpmdb rdb, dbCtrlOp ctrl)
 
 static dbiCursor ndb_CursorInit(dbiIndex dbi, unsigned int flags)
 {
-    dbiCursor dbc = (dbiCursor)xcalloc(1, sizeof(*dbc));
+    dbiCursor dbc = new dbiCursor_s {};
     dbc->dbi = dbi;
     dbc->flags = flags;
     return dbc;
@@ -293,7 +293,7 @@ static dbiCursor ndb_CursorFree(dbiIndex dbi, dbiCursor dbc)
 	    free(dbc->list);
 	if (dbc->listdata)
 	    free(dbc->listdata);
-	free(dbc);
+	delete dbc;
     }
     return NULL;
 }

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -406,7 +406,7 @@ static int sqlite_Ctrl(rpmdb rdb, dbCtrlOp ctrl)
 
 static dbiCursor sqlite_CursorInit(dbiIndex dbi, unsigned int flags)
 {
-    dbiCursor dbc = (dbiCursor)xcalloc(1, sizeof(*dbc));
+    dbiCursor dbc = new dbiCursor_s {};
     dbc->sdb = (sqlite3 *)dbi->dbi_db;
     dbc->flags = flags;
     dbc->tag = rpmTagGetValue(dbi->dbi_file);
@@ -428,7 +428,7 @@ static dbiCursor sqlite_CursorFree(dbiIndex dbi, dbiCursor dbc)
 	    dbiCursorFree(dbi, dbc->subc);
 	if (dbc->flags & DBC_WRITE)
 	    sqlexec(dbc->sdb, "RELEASE '%s'", dbi->dbi_file);
-	free(dbc);
+	delete dbc;
     }
     return NULL;
 }


### PR DESCRIPTION
I thought I already did these but looks like got side-tracked by the dbiset stuff...