### PR TITLE
Replace typedef's with using = for new internal C++ constructs

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -158,7 +158,7 @@ typedef struct specialDir_s {
     std::vector<FileEntries_s> entries;
 } * specialDir;
 
-typedef std::vector<FileListRec_s> FileRecords;
+using FileRecords = std::vector<FileListRec_s>;
 
 /**
  * Package file tree walk data.

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -11,7 +11,7 @@
 #include "rpmbuild_misc.h"
 #include "rpmlua.h"
 
-typedef std::unordered_multimap<std::string,std::string> fileRenameHash;
+using fileRenameHash = std::unordered_multimap<std::string,std::string>;
 
 #define ALLOWED_CHARS_NAME ".-_+%{}"
 #define ALLOWED_FIRSTCHARS_NAME "_%"

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -54,9 +54,8 @@ struct rpmfcFileDep {
     }
 };
 
-typedef vector<rpmfcFileDep> rpmfcFileDeps;
-
-typedef std::unordered_multimap<int,int> fattrHash;
+using rpmfcFileDeps = vector<rpmfcFileDep>;
+using fattrHash = std::unordered_multimap<int,int>;
 
 struct rpmfc_s {
     Package pkg;

--- a/lib/backend/dbi.h
+++ b/lib/backend/dbi.h
@@ -33,7 +33,7 @@ struct dbConfig_s {
     int	db_no_fsync;	/*!< no-op fsync for db */
 };
 
-typedef std::unordered_map<unsigned int,rpmRC> dbChk;
+using dbChk = std::unordered_map<unsigned int,rpmRC>;
 
 struct rpmdbOps_s;
 

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -34,9 +34,9 @@ const char * const rpmEVR = VERSION;
 
 const int rpmFLAGS = RPMSENSE_EQUAL;
 
-typedef std::unordered_map<std::string,int> depCache;
-typedef std::unordered_set<rpmsid> depexistsHash;
-typedef std::unordered_map<rpmsid,rpmsid> filedepHash;
+using depCache = std::unordered_map<std::string,int>;
+using depexistsHash = std::unordered_set<rpmsid>;
+using filedepHash = std::unordered_map<rpmsid,rpmsid>;
 
 /**
  * Check for supported payload format in header.

--- a/lib/rpmal.c
+++ b/lib/rpmal.c
@@ -46,8 +46,8 @@ typedef struct availableIndexFileEntry_s {
     unsigned int entryIx;	/*!< Dependency index. */
 } * availableIndexFileEntry;
 
-typedef std::unordered_multimap<rpmsid,availableIndexEntry_s> rpmalDepHash;
-typedef std::unordered_multimap<rpmsid,availableIndexFileEntry_s> rpmalFileHash;
+using rpmalDepHash = std::unordered_multimap<rpmsid,availableIndexEntry_s>;
+using rpmalFileHash = std::unordered_multimap<rpmsid,availableIndexFileEntry_s>;
 
 /** \ingroup rpmdep
  * Set of available packages, items, and directories.

--- a/lib/rpmdb_internal.h
+++ b/lib/rpmdb_internal.h
@@ -9,7 +9,7 @@
 #include <rpm/rpmutil.h>
 #include "backend/dbi.h"
 
-typedef std::unordered_map<unsigned int,rpmte> packageHash;
+using packageHash = std::unordered_map<unsigned int,rpmte>;
 
 enum rpmdbRebuildFlags_e {
     RPMDB_REBUILD_FLAG_SALVAGE	= (1 << 0),

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -29,8 +29,8 @@
 
 #include "debug.h"
 
-typedef std::vector<int> hardlinks;
-typedef std::unordered_map<int,std::shared_ptr<hardlinks>> nlinkHash;
+using hardlinks = std::vector<int>;
+using nlinkHash = std::unordered_map<int,std::shared_ptr<hardlinks>>;
 
 typedef int (*iterfunc)(rpmfi fi);
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -65,7 +65,7 @@ struct rpmMacroEntry_s {
     string sopts;
 };
 
-typedef std::map<string,std::stack<rpmMacroEntry_s>> macroTable;
+using macroTable = std::map<string,std::stack<rpmMacroEntry_s>>;
 
 /*! The structure used to store the set of macros in a context. */
 struct rpmMacroContext_s {

--- a/rpmio/rpmhook.c
+++ b/rpmio/rpmhook.c
@@ -17,7 +17,7 @@ struct rpmhookItem {
     void *data;
 };
 
-typedef std::multimap<std::string,rpmhookItem> rpmhookTable;
+using rpmhookTable = std::multimap<std::string,rpmhookItem>;
 
 rpmhookArgs rpmhookArgsNew(int argc)
 {


### PR DESCRIPTION
typedef's prevent const correctness and have various other issues, "using" is the native modern version. When in Rome...