### PR TITLE
Add warning for %autopatch not applying anything

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1289,6 +1289,9 @@ if #arg == 0 then
         end
     end
 end
+if #arg == 0 then
+   macros.warn({"autopatch: no matching patches in range"})
+end
 local options = rpm.expand("%{!-v:-q} %{-p:-p%{-p*}} ")
 local bynum = {}
 for i, p in ipairs(patches) do

--- a/tests/data/SPECS/hello-autopatch.spec
+++ b/tests/data/SPECS/hello-autopatch.spec
@@ -19,6 +19,7 @@ Simple rpm demonstration.
 %autosetup -N
 %autopatch 0
 %autopatch -m 1
+%autopatch -m 2
 
 %build
 %make_build CFLAGS="$RPM_OPT_FLAGS"

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -468,11 +468,13 @@ RPMDB_INIT
 RPMTEST_CHECK([
 
 run rpmbuild \
-  -ba ${RPMDATA}/SPECS/hello-autopatch.spec
+  -ba ${RPMDATA}/SPECS/hello-autopatch.spec 2> >(grep warning >&2) | grep warning
 ],
 [0],
-[ignore],
-[ignore])
+[RPM build warnings:
+],
+[warning: autopatch: no matching patches in range
+])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild -ba find-lang])


### PR DESCRIPTION
It is possible that the range given to %autopatch is not matching any actual patches. Issue an warning to give the packager a chance to realize that there is something fishy. Not turnng this into an error to not break existing builds.

Resolves: #3093