### PR TITLE
Fix sinfoCmp to order signatures correctly

### DIFF
--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -440,9 +440,9 @@ static int sinfoCmp(const void *a, const void *b)
 	rc = sb->type - sa->type;
     /* strongest (in the "newer is better" sense) algos first */
     if (rc == 0)
-	rc = sb->sigalgo - sb->sigalgo;
+	rc = sb->sigalgo - sa->sigalgo;
     if (rc == 0)
-	rc = sb->hashalgo - sb->hashalgo;
+	rc = sb->hashalgo - sa->hashalgo;
     /* last resort, these only makes sense from consistency POV */
     if (rc == 0)
 	rc = sb->id - sa->id;

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -309,7 +309,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [1],
 [],
 [warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: no signature
+	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
 ])
 RPMTEST_CLEANUP
 
@@ -442,9 +442,9 @@ error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 INSTALL 3
 warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: no signature
+	package hello-2.0-1.x86_64 does not verify: Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != 3129d507d00b1dc60745d9637010b5d82059ebeff2318b2db75b26272b823586)
 INSTALL 4
-	package hello-2.0-1.x86_64 does not verify: no signature
+	package hello-2.0-1.x86_64 does not verify: Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != 3129d507d00b1dc60745d9637010b5d82059ebeff2318b2db75b26272b823586)
 INSTALL 5
 warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
 error: unpacking of archive failed: cpio: Bad magic

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -309,7 +309,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [1],
 [],
 [warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: no signature
 ])
 RPMTEST_CLEANUP
 
@@ -442,7 +442,7 @@ error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 INSTALL 3
 warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: no signature
 INSTALL 4
 	package hello-2.0-1.x86_64 does not verify: no signature
 INSTALL 5

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -308,13 +308,13 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [[Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
     Header DSA signature: NOTFOUND
+    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
     MD5 digest: OK
 1
 Importing key:
@@ -334,8 +334,8 @@ Checking package after importing key, no digest:
     Header V4 RSA/SHA512 Signature, key ID 15217ee0: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -372,13 +372,13 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
     Header DSA signature: NOTFOUND
+    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
     MD5 digest: OK
 1
 Importing key:
@@ -392,13 +392,13 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
     Header DSA signature: NOTFOUND
+    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
     MD5 digest: OK
 1
 Checking package after importing key, no digest:
@@ -408,10 +408,10 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
     Header DSA signature: NOTFOUND
-    RSA signature: NOTFOUND
+    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -448,13 +448,13 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
     Header DSA signature: NOTFOUND
+    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
     MD5 digest: OK
 1
 Importing key:
@@ -466,13 +466,13 @@ Checking package after importing key:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
     Header DSA signature: NOTFOUND
+    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
     MD5 digest: OK
 1
 Checking package after importing key, no digest:
@@ -480,10 +480,10 @@ Checking package after importing key, no digest:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
     Header DSA signature: NOTFOUND
-    RSA signature: NOTFOUND
+    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -864,8 +864,8 @@ runroot rpmkeys -Kv /tmp/${pkg}
     Header SHA1 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
     DSA signature: NOTFOUND
+    V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
     MD5 digest: BAD (Expected 137ca1d8b35cca02a1854ba301c5432e != d662cd0d81601a7107312684ad1ddf38)
 ],
 [])
@@ -904,8 +904,8 @@ dorpm -Kv
     Header SHA256 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
     MD5 digest: OK
 ]],
 [])

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -332,8 +332,8 @@ noplds
     Header SHA1 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
     MD5 digest: OK
 1
 nohdrs
@@ -346,13 +346,13 @@ nohdrs
 0
 nosig
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header RSA signature: NOTFOUND
     Header DSA signature: NOTFOUND
+    Header RSA signature: NOTFOUND
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
     DSA signature: NOTFOUND
+    RSA signature: NOTFOUND
     MD5 digest: OK
 1
 ],


### PR DESCRIPTION
This requires adjusting a number of test that reflect the ordering. The changes in tests/rpmsigdig.at look straight forward and correct - just changing the order in which the signatures and checksums are presented.

The changes in tests/rpmi.at seem to drop the relevant information. This might be accidental as the code just returns the first issue found. But "no signature" seems kinda weird result when before it complaint about a specific signature. May be someone  with more clue about this should ahve a second look before merging.

Resolves: #3185,#1057