### PR TITLE
Sort output for test case to avoid race condition

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1440,7 +1440,7 @@ nil	No such file or directory	2.0
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect2null(-1); print(string.format("%s\t%s\t%s", a,b,c)); io.flush() else posix.wait(pid) end'
+runroot_other rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect2null(-1); print(string.format("%s\t%s\t%s", a,b,c)); io.flush() else posix.wait(pid) end' 2> >(sort >&2)
 ],
 [0],
 [nil	Bad file descriptor	9.0


### PR DESCRIPTION
Solves #3106

We should probably understand why the urlhelper tests are racy before merging. 