### PR TITLE
Better error for build system issues

### DIFF
--- a/tests/data/macros.buildsystem
+++ b/tests/data/macros.buildsystem
@@ -2,6 +2,7 @@
 %buildsystem_autotools_conf() %configure %*
 %buildsystem_autotools_build() %make_build %*
 %buildsystem_autotools_install() %make_install %*
+%buildsystem_autotools_check() echo Not checking, sorry!
 
 # Example buildsystem for cmake
 %buildsystem_cmake_conf() cmake %* -B __rpmbuild -S .

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -161,6 +161,42 @@ runroot rpmbuild -bb \
 [error: line 11: Unknown buildsystem: bogons
 ])
 
+RPMTEST_CHECK([
+runroot rpmbuild -bb \
+	--define 'buildsystem_autotools_conf %nil' \
+	--define 'buildsystem_autotools_build %nil' \
+	--define 'buildsystem_autotools_install %nil' \
+	--define 'buildsystem_autotools_check %nil' \
+	--quiet /data/SPECS/amhello.spec
+],
+[1],
+[],
+[error: line 11: Unknown buildsystem: autotools
+])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bb \
+	--define 'buildsystem_autotools_conf %nil' \
+	--define 'buildsystem_autotools_build %nil' \
+	--define 'buildsystem_autotools_install %nil' \
+	--quiet /data/SPECS/amhello.spec
+],
+[1],
+[],
+[error: line 11: Required parametric macro %buildsystem_autotools_conf not defined for buildsystem autotools
+])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bb \
+	--define 'buildsystem_autotools_build %nil' \
+	--define 'buildsystem_autotools_check %nil' \
+	--quiet /data/SPECS/amhello.spec
+],
+[1],
+[],
+[error: line 11: Required parametric macro %buildsystem_autotools_build not defined for buildsystem autotools
+])
+
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild -b steps])


### PR DESCRIPTION
Give different errors depending on a build system not existing at all or not be defined properly. This makes it easier to detect issues in the build system declaration and no longer requires developers of new build system macros to pass --verbose to get meaningful messages.

Resolves: #3190