### PR TITLE
Add missing newline in sysusers Requires

### DIFF
--- a/fileattrs/sysusers.attr
+++ b/fileattrs/sysusers.attr
@@ -31,7 +31,7 @@
             table.insert(fields, w)
         end
         if #fields >= 3 and fields[1] == 'm' then
-	    print(string.format('user(%s)\\ngroup(%s)', fields[2], fields[3]))
+	    print(string.format('user(%s)\\ngroup(%s)\\n', fields[2], fields[3]))
         end
         ::continue::
     end


### PR DESCRIPTION
Without the newline, a sysusers file like

```
u saned - "SANE daemon user" /etc/sane.d /bin/false
m saned cdwriter
m saned usb
m saned scanner
```

Results in "funny" requirements
```
group(cdwriter)user(saned)
group(usb)user(saned)
```