### PR TITLE
sysusers.sh: Create /etc/login.defs if missing

### DIFF
--- a/scripts/sysusers.sh
+++ b/scripts/sysusers.sh
@@ -148,6 +148,7 @@ mkdir -p "$ROOT"/etc/
 [ -e "$ROOT"/etc/passwd ] || touch "$ROOT"/etc/passwd
 [ -e "$ROOT"/etc/shadow ] || touch "$ROOT"/etc/shadow
 [ -e "$ROOT"/etc/group ] || touch "$ROOT"/etc/group
+[ -e "$ROOT"/etc/login.defs ] || touch "$ROOT"/etc/login.defs
 
 # read files from command line
 for fn in "$@"; do


### PR DESCRIPTION
useradd needs both /etc/group and /etc/login.defs to work. It does chroot into a new system and then looks for these files. While this is technically correct it is a bit inconvenient for RPM. Creating etc/login.defs as an empty file make this work but still runs useradd without  proper configuration until the shadow-utils package gets installed. There isn't really anything RPM can do about that and distribution need to ahndle the situation to make installations to an empty directory with rpm --roo work.

Resolves: #3186