### PR TITLE
Reset recursion depth for error message

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -447,9 +447,11 @@ static int mbInit(rpmMacroBuf mb, MacroExpansionData *med, size_t slen)
     if (slen > 0)
 	mb->buf.reserve(slen);
     if (++mb->depth > max_macro_depth) {
+	mb->depth--;
+	/* ensure error message can be rendered */
+	mb->mc->depth = 0;
 	rpmMacroBufErr(mb, 1,
 		_("Too many levels of recursion in macro expansion. It is likely caused by recursive macro declaration.\n"));
-	mb->depth--;
 	return -1;
     }
     med->tpos = mb->buf.size(); /* save expansion pointer for printExpand */

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -133,6 +133,28 @@ runroot rpm --define "this that" --define "that_that foo" --eval '%{expand:%{%{t
 ])
 RPMTEST_CLEANUP
 
+AT_SETUP([recursive macro])
+AT_KEYWORDS([macros])
+RPMTEST_CHECK([
+runroot rpm --define 'aaa %aaa' --eval '%aaa'
+],
+[1],
+[],
+[error: Too many levels of recursion in macro expansion. It is likely caused by recursive macro declaration.
+])
+RPMTEST_CLEANUP
+
+AT_SETUP([recursive expression])
+AT_KEYWORDS([macros])
+RPMTEST_CHECK([
+runroot rpm --define 'aaa %\\[%aaa\\]' --eval '%aaa'
+],
+[1],
+[],
+[error: Too many levels of recursion in macro expansion. It is likely caused by recursive macro declaration.
+])
+RPMTEST_CLEANUP
+
 AT_SETUP([parametrized macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([


### PR DESCRIPTION
$ rpm --define 'aaa %[%aaa]' --eval '%aaa'

let to a core dump due to a stack overflow. This was cause by the generation of the error message failing due to being too deep in the recursion of the macro expansion - creating more error messages.

Resetting the depth counter allows rendering the error message. As we are failing and breaking off the parse run this is fine to do.

Thanks to Miro Hrončok for reporting

Resolves: #3197