### PR TITLE
Properly quote REs in file attributes

### DIFF
--- a/fileattrs/debuginfo.attr
+++ b/fileattrs/debuginfo.attr
@@ -3,4 +3,4 @@
   local b1, b2 = file:match("/([0-9a-f]+)/([0-9a-f]+)\.debug$")
   print(string.format("debuginfo(build-id) = %s%s\\n", b1, b2))
 }
-%__debuginfo_path ^/usr/lib/debug/.build-id/[^/]+/[^/]+\\.debug$
+%__debuginfo_path ^/usr/lib/debug/\\.build-id/[^/]+/[^/]+\\.debug$

--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -1,5 +1,5 @@
 %__elf_provides		%{_rpmconfigdir}/elfdeps --provides --multifile
 %__elf_requires		%{_rpmconfigdir}/elfdeps --requires --multifile
 %__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
-%__elf_exclude_path	^/lib/modules/.*\.ko?(\.[[:alnum:]]*)$
+%__elf_exclude_path	^/lib/modules/.*\\.ko?(\\.[[:alnum:]]*)$
 %__elf_protocol		multifile

--- a/fileattrs/ocaml.attr
+++ b/fileattrs/ocaml.attr
@@ -1,5 +1,5 @@
 %__ocaml_provides	%{_rpmconfigdir}/ocamldeps.sh --provides
 %__ocaml_requires	%{_rpmconfigdir}/ocamldeps.sh --requires
 %__ocaml_magic		^(Objective caml|OCaml) .*$
-%__ocaml_path		.(cma|cmi|cmo|cmx|cmxa)$
+%__ocaml_path		\\.(cma|cmi|cmo|cmx|cmxa)$
 %__ocaml_flags		magic_and_path

--- a/fileattrs/pkgconfig.attr
+++ b/fileattrs/pkgconfig.attr
@@ -1,3 +1,3 @@
 %__pkgconfig_provides	%{_rpmconfigdir}/pkgconfigdeps.sh --provides
 %__pkgconfig_requires	%{_rpmconfigdir}/pkgconfigdeps.sh --requires
-%__pkgconfig_path	^((%{_libdir}|%{_datadir})/pkgconfig/.*\.pc|%{_bindir}/pkg-config)$
+%__pkgconfig_path	^((%{_libdir}|%{_datadir})/pkgconfig/.*\\.pc|%{_bindir}/pkg-config)$

--- a/fileattrs/rpm_lua.attr
+++ b/fileattrs/rpm_lua.attr
@@ -3,7 +3,7 @@
 # - /usr/lib/rpm/lua/fedora/common.lua -> rpm_lua(fedora.common)
 # - /usr/lib/rpm/lua/fedora/srpm/python.lua -> rpm_lua(fedora.srpm.python)
 
-%__rpm_lua_path ^%{_rpmluadir}/.+\.lua$
+%__rpm_lua_path ^%{_rpmluadir}/.+\\.lua$
 %__rpm_lua_provides() %{lua:
 -- Strip BUILDROOT + /usr/lib/rpm/lua/
 local idx = macros.buildroot:len() + macros._rpmluadir:len() + 2

--- a/fileattrs/rpm_macro.attr
+++ b/fileattrs/rpm_macro.attr
@@ -1,2 +1,2 @@
 %__rpm_macro_provides   %{_rpmconfigdir}/rpm_macros_provides.sh
-%__rpm_macro_path       %{_rpmmacrodir}/macros\..*
+%__rpm_macro_path       %{_rpmmacrodir}/macros\\..*


### PR DESCRIPTION
A literal dot needs to be quoted by two backslashes as the macro parsing already consumes one. This was done quite inconsistently. As a result several regular expressions were more permissive than they should have been.

Resolves: #3212