### PR TITLE
Add .editorconfig, and note in CONTRIBUTING doc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+# XXX: Too common in existing source
+# trim_trailing_whitespace = true
+
+[*.{c,h,h.in,pc,pc.in}]
+indent_size = 4
+indent_style = tab
+tab_width = 8
+
+[*.md]
+indent_size = 4
+indent_style = space
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,9 @@ so keep on eye on the checks until you get all green.
 
 ### Indentation
 
-RPM uses 8-space tabs.  Indentation is 4 spaces, with each group of 8 or more
-leading spaces replaced by a tab. If in doubt, 'indent -kr' generally
-produces acceptable formatting.
+RPM code uses 8-space tabs.  Indentation is 4 spaces, with each group of
+8 or more leading spaces replaced by a tab. If in doubt, 'indent -kr'
+generally produces acceptable formatting.
 
 In Vim, this can be achieved with
 
@@ -78,6 +78,13 @@ In Emacs use
               indent-tabs-mode t)
 
 ```
+
+The Markdown documentation uses 4-space indents.
+
+An `.editorconfig` file is provided at the root of the repository with
+these settings defined. Any supporting editor should pick them up
+automatically. Editorconfig support is available (built-in or via
+the appropriate plugin/extension) for nearly all text editors.
 
 ### Comments
 


### PR DESCRIPTION
After reading the formatting instructions in [CONTRIBUTING](/CONTRIBUTING.md), I realized that the repo was crying out for an `.editorconfig` file to define the appropriate settings.

[EditorConfig](https://editorconfig.org/) enjoys _wide_ support across all text editors commonly used for coding (and plenty that aren't), either via built-in integration or through an appropriate extension/plugin. It uses an ini-style syntax to set formatting rules for various files (which can be named or wildcard-matched, typically by extension). Like `.gitignore` or other configuration files, `.editorconfig` files are hierarchical, meaning they can be installed at multiple levels in a directory tree to recursively merge rules at various levels. (A feature not currently used here.)

While the supported rules vary from editor to editor, there are certain "core" rules that all editors can be expected to honor.

The CONTRIBUTING.md doc is also updated to mention the existence of the `.editorconfig` file.

## Existing rules as submitted

### For all files
Charset is `utf-8`, line-endings are LF (not CRLF), and files should automatically end with a newline.

Commented out is a rule to remove trailing whitespace, because there is far too much trailing whitespace in the existing code so it would introduce too many spurious changes when editing existing files. Perhaps a later PR could clean these up and uncomment the rule for future editors.

### For .c, .h, .h.in, .pc, and .pc.in files
Additionally apply the code-formatting rules specified in the CONTRIBUTING file (4-column indentation, tab indents, and 8-column tabs).

### For .md files
Configure 4-space indents. (See #3218 for why tab indents and markdown don't really mix.)

## Possible enhancements

* Configure `Makefile` and `Makefile.*` for 8-column tab indents

* Add `CMakeLists.txt` rules (2-space indents are fairly common)

* Add other `.in` files to matches for code rules

* Add rules for `.yml` files
