### PR TITLE
Fix(es) needed for moving to rpm-sequoia >= 1.7 

### DIFF
--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -648,6 +648,7 @@ static rpmRC rpmtsImportDBKey(rpmtxn txn, Header h, rpmFlags flags, int replace)
 	rpmdbFreeIterator(mi);
 	if (otherinstance)
 	    rpmdbRemove(rpmtsGetRdb(txn->ts), otherinstance);
+	free(label);
     }
 
     return rc;

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -18,7 +18,7 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/rpmio/rpmpgp_legacy/CMakeLists.txt)
 endif()
 
 if (WITH_SEQUOIA)
-	pkg_check_modules(RPMSEQUOIA REQUIRED IMPORTED_TARGET rpm-sequoia>=1.4.0)
+	pkg_check_modules(RPMSEQUOIA REQUIRED IMPORTED_TARGET rpm-sequoia>=1.7.0)
 	target_sources(librpmio PRIVATE rpmpgp_sequoia.c)
 	target_link_libraries(librpmio PRIVATE PkgConfig::RPMSEQUOIA)
 else()

--- a/rpmio/rpmpgp_sequoia.c
+++ b/rpmio/rpmpgp_sequoia.c
@@ -84,14 +84,10 @@ W(int, rpmDigestUpdate, (DIGEST_CTX ctx, const void * data, size_t len),
 W(int, rpmDigestFinal,
   (DIGEST_CTX ctx, void ** datap, size_t *lenp, int asAscii),
   (ctx, datap, lenp, asAscii))
-
-rpmRC pgpPubkeyMerge(const uint8_t *pkts1, size_t pkts1len, const uint8_t *pkts2, size_t pkts2len, uint8_t **pktsm, size_t *pktsmlen, int flags) {
-    /* just merge nothing for now */
-    *pktsm = memcpy(rmalloc(pkts1len), pkts1, pkts1len);
-    *pktsmlen = pkts1len;
-    return RPMRC_OK;
-}
-
+W(rpmRC, pgpPubkeyMerge,
+  (const uint8_t *pkts1, size_t pkts1len, const uint8_t *pkts2,
+   size_t pkts2len, uint8_t **pktsm, size_t *pktsmlen, int flags),
+  (pkts1, pkts1len, pkts2, pkts2len, pktsm, pktsmlen, flags))
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
#3202 is failing due to a memory leak in existing code previously not exercised by CI, lets see if there's more stuff needed...