### PR TITLE
Make the second urlhelper test much less racy

### DIFF
--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -401,12 +401,22 @@ RPMTEST_CLEANUP
 AT_SETUP([urlhelper fails])
 AT_KEYWORDS([urlhelper])
 RPMDB_INIT
+
+cat << EOF > "${RPMTEST}"/tmp/fakecurl
+#!/bin/sh
+sleep 1
+>&2 echo \$0: failed to retrieve \$2
+exit 7
+EOF
+chmod a+x "${RPMTEST}"/tmp/fakecurl
+
 RPMTEST_CHECK([
-runroot rpm --define "_urlhelper /bin/false" --root /srv/test -qp https://example.com/foo-0.1-1.noarch.rpm 2> >(sed 's| /.*rpm-tmp.* https| rpm-tmp https|' >&2)
+runroot rpm --define "_urlhelper /tmp/fakecurl" --root /srv/test -qp https://example.com/foo-0.1-1.noarch.rpm 2> >(sed 's| /.*rpm-tmp.* https| rpm-tmp https|' >&2)
 ],
 [1],
 [],
-[error: Executing url helper "/bin/false rpm-tmp https://example.com/foo-0.1-1.noarch.rpm" failed with status 1
+[/tmp/fakecurl: failed to retrieve https://example.com/foo-0.1-1.noarch.rpm
+error: Executing url helper "/tmp/fakecurl rpm-tmp https://example.com/foo-0.1-1.noarch.rpm" failed with status 7
 error: open of https://example.com/foo-0.1-1.noarch.rpm failed: No such file or directory
 ])
 RPMTEST_CLEANUP


### PR DESCRIPTION
/bin/false exits so fast that racing with the parent output order is a fifty-sixty situation at best. Use a purpose-made shell script that does a bit of IO and even sleeps a bit, which together with shell startup time should be plenty enough to guarantee stable output for most practical purposes. If it *still* bugs us after this, we can always sort the output.

Fixes: #3210