### PR TITLE
Build: Add include dirs to exported lib targets

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -13,11 +13,15 @@ target_sources(librpmbuild PRIVATE
 	speclua.c
 )
 
-target_include_directories(librpmbuild PRIVATE
+target_include_directories(librpmbuild
+    PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_SOURCE_DIR}/rpmio
 	${CMAKE_SOURCE_DIR}/lib
 	${Intl_INCLUDE_DIRS}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_link_libraries(librpmbuild PUBLIC librpmio librpm)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,14 +12,18 @@ target_compile_definitions(librpm PRIVATE
 	LIBRPMALIAS_EXECPATH="${CMAKE_INSTALL_FULL_BINDIR}"
 )
 
-target_include_directories(librpm PRIVATE
+target_include_directories(librpm
+    PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_SOURCE_DIR}/rpmio
 	${CMAKE_CURRENT_BINARY_DIR}
 	${Intl_INCLUDE_DIRS}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        # This is needed for rpmcli.h
+        ${POPT_INCLUDE_DIRS}
 )
-# This is needed for rpmcli.h
-target_include_directories(librpm PUBLIC ${POPT_INCLUDE_DIRS})
 
 target_sources(librpm PRIVATE
 	backend/dbi.c backend/dbi.h backend/dummydb.c

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -8,9 +8,13 @@ target_sources(librpmio PRIVATE
 	rpmstrpool.c rpmmacro_internal.h rpmlua.c rpmlua.h lposix.c
 )
 target_compile_definitions(librpmio PRIVATE RPM_CONFIGDIR="${RPM_CONFIGDIR}")
-target_include_directories(librpmio PRIVATE
+target_include_directories(librpmio 
+    PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${Intl_INCLUDE_DIRS}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 if (EXISTS ${CMAKE_SOURCE_DIR}/rpmio/rpmpgp_legacy/CMakeLists.txt)

--- a/sign/CMakeLists.txt
+++ b/sign/CMakeLists.txt
@@ -5,11 +5,15 @@ set_target_properties(librpmsign PROPERTIES
 )
 target_sources(librpmsign PRIVATE rpmgensig.c)
 
-target_include_directories(librpmsign PRIVATE
+target_include_directories(librpmsign
+    PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_SOURCE_DIR}/rpmio
 	${CMAKE_SOURCE_DIR}/lib
 	${Intl_INCLUDE_DIRS}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_link_libraries(librpmsign PUBLIC librpmio librpm)


### PR DESCRIPTION
Each library target's exported `INTERFACE_INCLUDE_DIRECTORIES` list, as written into the `rpm-targets.cmake` export file, is controlled by the `PUBLIC` arguments supplied to `target_include_directories()` for the library target.

* Directories scoped with the `$<BUILD_INTERFACE>` generator expression will be included in the export file written to the build dir by `export(TARGETS...)`
* Directories scoped with `$<INSTALL_INTERFACE>` will be included in the `rpm-targets.cmake` file installed into the `${CMAKE_INSTALL_LIBDIR}/cmake/rpm/` configuration directory.

Providing `PUBLIC` include directory paths for both the build and install contexts is important, because without them the exported CMake configuration is useless to library consumers.

(If the build is installed into `/usr/` or `/usr/local` it won't matter, because the include directories required are the default `/usr/include` or `/usr/local/include/` paths. But an install targeted elsewhere with a `CMAKE_INSTALL_PREFIX` path needs an `INTERFACE_INCLUDE_DIRECTORIES` property of
`${CMAKE_INSTALL_INCLUDEDIR}` to correctly locate its installed includes.)


## Example build
```console
$ cmake -B _build -S . -DCMAKE_INSTALL_PREFIX=/tmp/rpm \
    -DENABLE_PYTHON=0 -DWITH_DBUS=0
$ cmake --build _build
$ cmake --install _build
```

### Without this change

#### In `_build/rpm-targets.cmake`
* The `rpm::librpm` target's `INTERFACE_INCLUDE_DIRECTORIES` contains only `/usr/include` (from the `${POPT_INCLUDE_DIRS}` variable).
* The other targets have no `INTERFACE_INCLUDE_DIRECTORIES` at all.

#### In `/tmp/rpm/lib64/cmake/rpm-targets.cmake`
* The `rpm::librpm` target's `INTERFACE_INCLUDE_DIRECTORIES` contains only `/usr/include`.
* The other targets have no `INTERFACE_INCLUDE_DIRECTORIES` at all.


### With this change

#### In `_build/rpm-targets.cmake`
* The `rpm::librpm` target's `INTERFACE_INCLUDE_DIRECTORIES` contains
  both `/usr/include` and (the expansion of) `${CMAKE_SOURCE_DIR}/include`.
* The other targets also all have `INTERFACE_INCLUDE_DIRECTORIES` set to
  the expansion of `${CMAKE_SOURCE_DIR}/include`.

#### In `/tmp/rpm/lib64/cmake/rpm-targets.cmake`
* The `rpm::librpm` target's `INTERFACE_INCLUDE_DIRECTORIES` contains
  both `/usr/include` and `${_IMPORT_PREFIX}/include`, which corresponds
  to `${CMAKE_INSTALL_PREFIX}/include` for the installed package.
* The other targets also all have `INTERFACE_INCLUDE_DIRECTORIES` set to
  `${_IMPORT_PREFIX}/include`.

This means that the CMake `CONFIG`-mode exports now match the `rpm.pc` configuration provided by `pkg-config`. A downstream consumer's CMake build can use `find_package(rpm CONFIG)` to discover the `IMPORTED` `rpm::` targets from either the package build dir, or its installed path (even if directed to a non-standard location), and properly compile against the RPM libraries present in either of those locations.
