### PR TITLE
Fix root relocation regression

### DIFF
--- a/lib/relocation.c
+++ b/lib/relocation.c
@@ -181,8 +181,9 @@ void rpmRelocateFileList(rpmRelocation *relocations, int numRelocations,
 	rpmFileTypes ft;
 	int fnlen;
 
+	size_t baselen = strlen(baseNames[i]);
 	size_t len = maxlen +
-		strlen(dirNames[dirIndexes[i]]) + strlen(baseNames[i]) + 1;
+		strlen(dirNames[dirIndexes[i]]) + baselen + 1;
 	if (len >= fileAlloced) {
 	    fileAlloced = len * 2;
 	    fn = xrealloc(fn, fileAlloced);
@@ -244,8 +245,9 @@ assert(fn != NULL);		/* XXX can't happen */
 	    continue;
 	}
 
-	/* Relocation on full paths only, please. */
-	if (fnlen != len) continue;
+	/* Relocation on '/' and full paths only, please. */
+	if (baselen && fnlen != len)
+	    continue;
 
 	rpmlog(RPMLOG_DEBUG, "relocating %s to %s\n",
 	       fn, relocations[j].newPath);

--- a/lib/relocation.c
+++ b/lib/relocation.c
@@ -124,7 +124,7 @@ void rpmRelocateFileList(rpmRelocation *relocations, int numRelocations,
     char ** baseNames;
     char ** dirNames;
     uint32_t * dirIndexes;
-    rpm_count_t fileCount, dirCount;
+    rpm_count_t fileCount, dirCount, dirCountOrig;
     int nrelocated = 0;
     int fileAlloced = 0;
     char * fn = NULL;
@@ -163,7 +163,7 @@ void rpmRelocateFileList(rpmRelocation *relocations, int numRelocations,
     baseNames = (char **)bnames.data;
     dirIndexes = (uint32_t *)dindexes.data;
     fileCount = rpmtdCount(&bnames);
-    dirCount = rpmtdCount(&dnames);
+    dirCount = dirCountOrig = rpmtdCount(&dnames);
     /* XXX TODO: use rpmtdDup() instead */
     dirNames = duparray((char **)dnames.data, dirCount);
     dnames.data = dirNames;
@@ -297,7 +297,7 @@ assert(fn != NULL);		/* XXX can't happen */
     }
 
     /* Finish off by relocating directories. */
-    for (i = dirCount - 1; i >= 0; i--) {
+    for (i = dirCountOrig - 1; i >= 0; i--) {
 	for (j = numRelocations - 1; j >= 0; j--) {
 
 	    if (relocations[j].oldPath == NULL) /* XXX can't happen */

--- a/tests/README.md
+++ b/tests/README.md
@@ -146,5 +146,12 @@ as well as the existing tests.  Below are the specifics of RPM's test-suite:
       environment with only a handful of variables preset.  To pass your own
       variable(s), use `--setenv` (once for each variable), e.g. `runroot
       --setenv FOO "foo" rpm ...`
+* Use `RPMTEST_USER` to create a regular UNIX user in a mutable snapshot
+    * The username is stored in the `$RPMUSER` environment variable
+    * To run a binary as `$RPMUSER` inside the snapshot, use `runroot_user`
+      (this calls `sudo(8)` underneath)
+    * You can create a custom user (or users) by supplying a list of usernames
+      to the macro, e.g. `RPMTEST_USER([user1, user2])`.  Then, use
+      `runroot_user -n <name>` to run a binary as a specific user
 * If no snapshot was used, just call the RPM binaries normally
 * Store any working files in the current directory (it's always writable)

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -9,6 +9,9 @@ RPMTREE=${RPMTREE:-/}
 RPMTEST=/
 RPMDATA="/data/"
 
+# Default UNIX username for use in tests
+RPMUSER=klang
+
 RPM_CONFIGDIR_PATH="@RPM_CONFIGDIR@"
 
 DBFORMAT=$(awk '/^%_db_backend/{print $2}' \
@@ -138,6 +141,18 @@ runroot_other()
 {
     setup_env
     snapshot exec "$@"
+}
+
+runroot_user()
+{
+    case $1 in
+        -n|--name)
+            RPMUSER=$2
+            shift 2
+        ;;
+    esac
+    setup_env
+    runroot_other --new-session sudo -iu $RPMUSER "$@"
 }
 
 snapshot prune rpmtests.dir/*/tree

--- a/tests/data/SPECS/rootfs.spec
+++ b/tests/data/SPECS/rootfs.spec
@@ -1,0 +1,17 @@
+Name:           rootfs
+Version:        1.0
+Release:        1
+Summary:        Package owning top-level root directory
+License:        GPL
+BuildArch:      noarch
+Prefix:         /
+
+%description
+%{summary}.
+
+%install
+mkdir -p $RPM_BUILD_ROOT/foo
+touch $RPM_BUILD_ROOT/foo/bar
+
+%files
+/

--- a/tests/local.at
+++ b/tests/local.at
@@ -66,6 +66,12 @@ RPMPY_CHECK([$2], [$3], [$4])
 RPMTEST_CLEANUP
 ])
 
+m4_define([RPMTEST_USER],[
+RPMTEST_SETUP
+[[ $# != 0 ]] && export RPMUSER=$1
+useradd -m -R $RPMTEST $RPMUSER
+])
+
 # Enable colored test output if available
 m4_ifdef([AT_COLOR_TESTS], [AT_COLOR_TESTS])
 

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1170,6 +1170,31 @@ runroot rpm -ql reloc
 [])
 RPMTEST_CLEANUP
 
+AT_SETUP([rpm -i relocatable package 3])
+AT_KEYWORDS([install relocate])
+RPMTEST_USER
+RPMDB_INIT
+
+runroot rpmbuild --quiet -bb /data/SPECS/rootfs.spec
+
+RPMTEST_CHECK([
+runroot_user \
+  rpm -U --prefix \$PWD/root --dbpath \$PWD/rpmdb \
+  /build/RPMS/noarch/rootfs-1.0-1.noarch.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot_user rpm -e --dbpath \$PWD/rpmdb rootfs
+runroot_user test ! -d \$PWD/root
+],
+[0],
+[],
+[])
+RPMTEST_CLEANUP
+
 AT_SETUP([rpm -i with/without --excludedocs])
 AT_KEYWORDS([install excludedocs])
 RPMTEST_CHECK([

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1135,6 +1135,41 @@ runroot rpm -U --relocate /opt/bin=/bin \
 [])
 RPMTEST_CLEANUP
 
+AT_SETUP([rpm -i relocatable package 2])
+AT_KEYWORDS([install relocate])
+RPMDB_INIT
+
+runroot rpmbuild --quiet -bb /data/SPECS/reloc.spec
+runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
+
+runroot rpm -U /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm
+
+RPMTEST_CHECK([
+runroot rpm -U \
+  --relocate /opt/bin=/opt/bin/foo/bar \
+  --relocate /opt/etc=/opt/etc/foo/bar \
+  --relocate /opt/lib=/opt/lib/foo/bar \
+  /build/RPMS/noarch/reloc-1.0-1.noarch.rpm
+runroot rpm -ql reloc
+],
+[0],
+[1: /opt/bin/foo/bar
+2: /opt/etc/foo/bar
+3: /opt/lib/foo/bar
+0: /opt/bin/foo/bar
+1: /opt/etc/foo/bar
+2: /opt/lib/foo/bar
+/opt
+/opt/bin/foo/bar
+/opt/bin/foo/bar/typo
+/opt/etc/foo/bar
+/opt/etc/foo/bar/conf
+/opt/lib/foo/bar
+/opt/lib/foo/bar/notlib
+],
+[])
+RPMTEST_CLEANUP
+
 AT_SETUP([rpm -i with/without --excludedocs])
 AT_KEYWORDS([install excludedocs])
 RPMTEST_CHECK([


### PR DESCRIPTION
Unbreak installation and removal of relocatable packages that own the `/` path (like in [RHEL-28967](https://issues.redhat.com/browse/RHEL-28967)). This happened to work before #1919 but just by "accident", see the commit messages for details.

Fixes: #3173