### PR TITLE
Fix division by zero in elfdeps (RhBug:2299414)

### DIFF
--- a/tools/elfdeps.c
+++ b/tools/elfdeps.c
@@ -196,6 +196,8 @@ static void processVerNeed(Elf_Scn *scn, GElf_Shdr *shdr, elfInfo *ei)
 static void processDynamic(Elf_Scn *scn, GElf_Shdr *shdr, elfInfo *ei)
 {
     Elf_Data *data = NULL;
+    if (shdr->sh_entsize == 0)
+	return;
     while ((data = elf_getdata(scn, data)) != NULL) {
 	for (int i = 0; i < (shdr->sh_size / shdr->sh_entsize); i++) {
 	    const char *s = NULL;


### PR DESCRIPTION
Assume that the section does not hold a table if sh_entsize is 0 (as specified in the elf(5) man page) and just skip it if that's the case.