### PR TITLE
Disable private mounts in chroot'ed operation in the unshare plugin

### DIFF
--- a/docs/man/rpm-plugin-unshare.8.md
+++ b/docs/man/rpm-plugin-unshare.8.md
@@ -27,6 +27,11 @@ This plugin implements the following configurables:
     execution. Typical examples would be `/tmp` to protect against
     insecure temporary file usage inside scriptlets, and `/home` to
     prevent scriptlets from accessing user home directories.
+    When path unsharing is enabled, any mounts made from scriptlets
+    are also private to the scriptlet (and vice versa, mount changes
+    on the host are not visible to the scriptlet).
+
+    Private mounts in chroot-operations is unimplemented.
 
 `%__transaction_unshare_nonet`
 


### PR DESCRIPTION
Disable private mounts in chroot'ed operation in the unshare plugin

mount("/", "/", NULL, MS_REC | MS_PRIVATE, NULL) inside a chroot fails with EINVAL. Apparently this is because "/" inside the chroot is not (necessarily) an actual mount point and ... then it starts getting more complicated. It should be possible to handle but not something we want to attempt just before a release candidate.

Related: #3187
