### PR TITLE
Better warning for %autopatch without patches

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1276,10 +1276,11 @@ end}
 # introduced in the spec, but alternatively can be used to apply indvidual
 # patches in arbitrary order by passing them as arguments.
 # -v		Verbose
+# -q		Don't warn if there are no matching patches
 # -p<N>		Prefix strip (ie patch -p argument)
 # -m<min>       Apply patches with number >= min only (if no arguments)
 # -M<max>       Apply patches with number <= max only (if no arguments)
-%autopatch(vp:m:M:) %{lua:
+%autopatch(vqp:m:M:) %{lua:
 if #arg == 0 then
     local lo = tonumber(rpm.expand("%{-m:%{-m*}}"))
     local hi = tonumber(rpm.expand("%{-M:%{-M*}}"))
@@ -1289,8 +1290,8 @@ if #arg == 0 then
         end
     end
 end
-if #arg == 0 then
-   macros.warn({"autopatch: no matching patches in range"})
+if #arg == 0 and not opt.q then
+   macros.warn({rpm.expand("%{?__file_name:%{__file_name} line %{__file_lineno}}: autopatch: no matching patches in range")})
 end
 local options = rpm.expand("%{!-v:-q} %{-p:-p%{-p*}} ")
 local bynum = {}
@@ -1317,7 +1318,7 @@ end
 %setup %{-a} %{-b} %{-c} %{-C} %{-D} %{-n} %{-T} %{!-v:-q}\
 %{-S:%global __scm %{-S*}}\
 %{expand:%__scm_setup_%{__scm} %{!-v:-q}}\
-%{!-N:%autopatch %{-v} %{-p:-p%{-p*}}}
+%{!-N:%autopatch -q %{-v} %{-p:-p%{-p*}}}
 
 # Add a sysuser user/group to a package. Takes a sysusers.d(5) line as
 # arguments, eg `%add_sysuser g mygroup 515`.

--- a/tests/data/SPECS/hello-auto.spec
+++ b/tests/data/SPECS/hello-auto.spec
@@ -8,9 +8,13 @@ Summary: Simple rpm demonstration.
 %sourcelist
 hello-1.0.tar.gz
 
+%{!?nopatches:
+
 %patchlist
 hello-1.0-modernize.patch
 hello-1.0-install.patch
+
+}
 
 %description
 Simple rpm demonstration.

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -390,6 +390,19 @@ run rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
+AT_SETUP([rpmbuild -bp autosetup without patches])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+
+run rpmbuild -D="nopatches 1" \
+  -bp ${RPMDATA}/SPECS/hello-auto.spec 2> >(grep warning >&2)
+],
+[0],
+[ignore],
+[])
+RPMTEST_CLEANUP
+
 AT_SETUP([rpmbuild --build-in-place 1])
 AT_KEYWORDS([build])
 RPMDB_INIT

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -522,7 +522,7 @@ run rpmbuild \
 [0],
 [RPM build warnings:
 ],
-[warning: autopatch: no matching patches in range
+[warning: /data/SPECS/hello-autopatch.spec line 22: autopatch: no matching patches in range
 ])
 RPMTEST_CLEANUP
 


### PR DESCRIPTION
Add file and line number to the warning.

Suppress the warning when called from %autosetup and offer -q to
suppress the warning in general.

Resolves: https://github.com/rpm-software-management/rpm/issues/3230