### PR TITLE
Fix crash on Lua file trigger exiting with return'ed data (#3029)

### DIFF
--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -303,6 +303,8 @@ int rpmluaRunScript(rpmlua lua, const char *script, const char *name,
 
 exit:
     free(buf);
+    /* discard any unhandled return data from the script */
+    lua_settop(L, otop);
     return ret;
 }
 

--- a/tests/data/SPECS/filetriggers.spec
+++ b/tests/data/SPECS/filetriggers.spec
@@ -52,6 +52,17 @@ end
 print("")
 io.flush()
 
+%filetriggerun -p <lua> -- /usr/bin
+print("filetriggerun(/usr/bin*)<lua>: "..arg[2].." "..arg[3])
+a = rpm.next_file()
+while a do
+    print(a)
+    a = rpm.next_file()
+end
+print("")
+io.flush()
+return 0
+
 %filetriggerin -- /foo
 echo "filetriggerin(/foo*):"
 cat

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -461,6 +461,9 @@ filetriggerpostun(/foo*):
 filetriggerun(/usr/bin*): 1 0
 /usr/bin/hello
 
+filetriggerun(/usr/bin*)<lua>: 1 0
+/usr/bin/hello
+
 filetriggerpostun(/usr/bin*): 1 0
 /usr/bin/hello
 


### PR DESCRIPTION
Reset the Lua stack on return from rpmluaRunScript() to discard any unhandled returned data from the scriptlet. This may happen if there's eg "return 0" from a non-macro scriptlet.

We could check for a numeric return value here and treat it as an exit code, but then what to do with other kinds of returned data? Our documentation states errors in Lua scriptlets should be signaled with Lua error() function, it seems better to stick with that and avoid introducing ambiguities and incompatibilities.

Update the existing file trigger tests to cover this case.

Fixes: #3029