### PR TITLE
Add an alternative, enhanceable form of rpm.execute() with io redirect capabilities

### DIFF
--- a/docs/manual/lua.md
+++ b/docs/manual/lua.md
@@ -170,14 +170,22 @@ by optional number of arguments to pass to the command.
 rpm.execute('ls', '-l', '/')
 ```
 
-#### execute({table})
+#### execute({table} [, stdout [, stderr]])
 
 Execute an external command (rpm >= 4.20)
 This is an alternative form of rpm.execute() that takes the command and any
 arguments as a single Lua table.
 
+Standard output and/or error can be optionally redirected to named path,
+such as commonly `/dev/null` to suppress output.
+
 ```
 rpm.execute({'ls', '-l', '/''})
+```
+
+Redirect standard error to `/dev/null`:
+```
+rpm.execute({'systemctl', 'restart', 'httpd'}, nil, '/dev/null')
 ```
 
 #### expand(arg)

--- a/docs/manual/lua.md
+++ b/docs/manual/lua.md
@@ -170,6 +170,16 @@ by optional number of arguments to pass to the command.
 rpm.execute('ls', '-l', '/')
 ```
 
+#### execute({table})
+
+Execute an external command (rpm >= 4.20)
+This is an alternative form of rpm.execute() that takes the command and any
+arguments as a single Lua table.
+
+```
+rpm.execute({'ls', '-l', '/''})
+```
+
 #### expand(arg)
 
 Perform rpm macro expansion on argument string.

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -838,7 +838,7 @@ static int rpm_execute(lua_State *L)
     if (waitpid(pid, &status, 0) == -1)
 	return pusherror(L, errno, NULL);
     if (status != 0)
-	return pusherror(L, status, "exit code");
+	return pusherror(L, WEXITSTATUS(status), "exit code");
 
     return pushresult(L, status);
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1462,6 +1462,24 @@ nil	No such file or directory	2.0
 [])
 
 RPMTEST_CHECK([
+runroot_other rpmlua -e "print(rpm.execute('echo', '3', '2', '1'))"
+],
+[0],
+[3 2 1
+0.0
+],
+[])
+
+RPMTEST_CHECK([
+runroot_other rpmlua -e "print(rpm.execute({'echo', '3', '2', '1'}))"
+],
+[0],
+[3 2 1
+0.0
+],
+[])
+
+RPMTEST_CHECK([
 runroot_other rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect2null(-1); print(string.format("%s\t%s\t%s", a,b,c)); io.flush() else posix.wait(pid) end' 2> >(sort >&2)
 ],
 [0],

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1456,7 +1456,7 @@ runroot_other rpmlua -e "for i, v in ipairs({'true', 'false', 'grue'}) do print(
 ],
 [0],
 [0.0
-nil	exit code	256.0
+nil	exit code	1.0
 nil	No such file or directory	2.0
 ],
 [])


### PR DESCRIPTION
The problem with the original rpm.execute() syntax is that it cannot be enhanced in any way, because all the arguments are treated as options to be passed to the command.

Add an alternative form where the command and it's options are passed as a single Lua table, thus allowing other types of (optional) arguments to be added later.