### PR TITLE
Fix rpm.execute() exit code reporting

### DIFF
--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -803,7 +803,7 @@ static int rpm_execute(lua_State *L)
     if (waitpid(pid, &status, 0) == -1)
 	return pusherror(L, errno, NULL);
     if (status != 0)
-	return pusherror(L, status, "exit code");
+	return pusherror(L, WEXITSTATUS(status), "exit code");
 
     return pushresult(L, status);
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1456,7 +1456,7 @@ runroot_other rpmlua -e "for i, v in ipairs({'true', 'false', 'grue'}) do print(
 ],
 [0],
 [0.0
-nil	exit code	256.0
+nil	exit code	1.0
 nil	No such file or directory	2.0
 ],
 [])


### PR DESCRIPTION
The status returned by waitpid() is not a simple integer, one needs the various W* macros to examine it.