### PR TITLE
Don't let plugins fail due to read-only fs

### DIFF
--- a/plugins/fsverity.c
+++ b/plugins/fsverity.c
@@ -96,10 +96,10 @@ static rpmRC fsverity_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 
     /*
      * Enable fsverity on the file.
-     * fsverity not supported by file system (ENOTTY) and fsverity not
-     * enabled on file system are expected and not considered
-     * errors. Every other non-zero error code will result in the
-     * installation failing.
+     * fsverity not supported by file system (ENOTTY), fsverity not enabled on
+     * file system and read-only file system are expected and not considered
+     * errors. Every other non-zero error code will result in the installation
+     * failing.
      */
     if (ioctl(fd, FS_IOC_ENABLE_VERITY, &arg) != 0) {
 	switch(errno) {
@@ -141,6 +141,10 @@ static rpmRC fsverity_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 	case EOPNOTSUPP:
 	    rpmlog(RPMLOG_DEBUG, "fsverity not enabled on file system for %s\n",
 		   path);
+	    break;
+	case EROFS:
+	    rpmlog(RPMLOG_DEBUG, "fsverity not applicable on read-only "
+				 "file system for %s\n", path);
 	    break;
 	default:
 	    rpmlog(RPMLOG_DEBUG, "failed to enable verity (errno %i) for %s\n",

--- a/plugins/ima.c
+++ b/plugins/ima.c
@@ -71,7 +71,13 @@ static rpmRC ima_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 	    else
 		xx = lsetxattr(path, XATTR_NAME_IMA, fsig, len, 0);
 	    if (xx < 0) {
-		int is_err = errno != EOPNOTSUPP;
+		int is_err = 1;
+		switch (errno) {
+		    case EOPNOTSUPP:
+		    case EROFS:
+			is_err = 0;
+			break;
+		}
 
 	        rpmlog(is_err?RPMLOG_ERR:RPMLOG_DEBUG,
 			"ima: could not apply signature on '%s': %s\n",

--- a/plugins/selinux.c
+++ b/plugins/selinux.c
@@ -166,8 +166,16 @@ static rpmRC selinux_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 	    else
 		conrc = lsetfilecon(path, scon);
 
-	    if (conrc == 0 || (conrc < 0 && errno == EOPNOTSUPP))
+	    if (conrc == 0)
 		rc = RPMRC_OK;
+	    else if (conrc < 0) {
+		switch (errno) {
+		    case EOPNOTSUPP:
+		    case EROFS:
+			rc = RPMRC_OK;
+			break;
+		}
+	    }
 
 	    rpmlog(loglvl(rc != RPMRC_OK), "lsetfilecon: (%d %s, %s) %s\n",
 		       fd, path, scon, (conrc < 0 ? strerror(errno) : ""));


### PR DESCRIPTION
Read-only file systems fall into the same category as unsupported ones (i.e. writing the desired file metadata to them is meaningless) so handle those gracefully in the plugin hooks, too.

This is useful e.g. when preparing a system for IMA by reinstalling the desired packages with the IMA plugin enabled, including ones that own paths such as /mnt which are meant to be used as mount points, often read-only (e.g. when mounting an ISO).

Fixes: RHEL-33726