### PR TITLE
Fix memory leak in rpmsign

### DIFF
--- a/tools/rpmsign.c
+++ b/tools/rpmsign.c
@@ -152,6 +152,7 @@ static int doSign(poptContext optCon, struct rpmSignArgs *sargs)
 	char *key = rpmExpand("%{?_file_signing_key}", NULL);
 	if (rstreq(key, "")) {
 	    fprintf(stderr, _("You must set \"%%_file_signing_key\" in your macro file or on the command line with --fskpath\n"));
+	    free(key);
 	    goto exit;
 	}
 


### PR DESCRIPTION
Found by Coverity.

Fixes: RHEL-37564