### PR TITLE
Add rpm.spawn() Lua API

### DIFF
--- a/docs/manual/lua.md
+++ b/docs/manual/lua.md
@@ -170,6 +170,8 @@ by optional number of arguments to pass to the command.
 rpm.execute('ls', '-l', '/')
 ```
 
+For better control over the process execution and output, see rpm.spawn().
+
 #### expand(arg)
 
 Perform rpm macro expansion on argument string.
@@ -337,7 +339,28 @@ end
 ```
 
 This function is deprecated and scheduled for removal in 6.0,
-use `rpm.execute()` instead.
+use `rpm.spawn()` or `rpm.execute()` instead.
+
+#### spawn({command} [, {actions}])
+
+Spawn, aka execute, an external program. (rpm >= 4.20)
+
+`{command}` is a table consisting of the command and its arguments.
+An optional second table can be used to pass various actions related
+to the command execution, currently supported are:
+
+| Action  | Argument(s) | Description
+|---------|----------------------
+| `stdin` | path        | Redirect standard input to path
+| `stdout`| path        | Redirect standard output to path
+| `stderr`| path        | Redirect standard error to path
+
+Returns the command exit status: zero on success, or a tuplet
+of (nil, message, code) on failure.
+
+```
+rpm.spawn({'systemctl', 'restart', 'httpd'}, {stderr='/dev/null'})
+```
 
 #### undefine(name)
 
@@ -477,7 +500,7 @@ end
 Execute a program. This may only be performed after posix.fork().
 
 This function is deprecated and scheduled for removal in 6.0,
-use `rpm.execute()` instead.
+use `rpm.spawn()` or `rpm.execute()` instead.
 
 #### files([path])
 
@@ -495,7 +518,7 @@ end
 Fork a new process. 
 
 This function is deprecated and scheduled for removal in 6.0,
-use `rpm.execute()` instead.
+use `rpm.spawn()` or `rpm.execute()` instead.
 
 ```
 pid = posix.fork()
@@ -774,7 +797,7 @@ end
 ```
 
 This function is deprecated and scheduled for removal in 6.0,
-use `rpm.execute()` instead.
+use `rpm.spawn()` or `rpm.execute()` instead.
 
 #### setenv(name, value [, overwrite])
 

--- a/rpmio/lposix.c
+++ b/rpmio/lposix.c
@@ -47,7 +47,7 @@ extern int _rpmlua_have_forked;
 
 #define check_deprecated() \
     fprintf(stderr, \
-	"warning: posix.%s(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.execute() instead\n", __func__+1)
+	"warning: posix.%s(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead\n", __func__+1)
 
 static const char *filetype(mode_t m)
 {

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -881,8 +881,13 @@ static int rpm_execute(lua_State *L)
 	return pusherror(L, status, NULL);
     if (waitpid(pid, &status, 0) == -1)
 	return pusherror(L, errno, NULL);
-    if (status != 0)
-	return pusherror(L, status, "exit code");
+    if (status != 0) {
+	if (WIFSIGNALED(status)) {
+	    return pusherror(L, WTERMSIG(status), "exit signal");
+	} else {
+	    return pusherror(L, WEXITSTATUS(status), "exit code");
+	}
+    }
 
     return pushresult(L, status);
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1456,7 +1456,7 @@ runroot_other rpmlua -e "for i, v in ipairs({'true', 'false', 'grue'}) do print(
 ],
 [0],
 [0.0
-nil	exit code	256.0
+nil	exit code	1.0
 nil	No such file or directory	2.0
 ],
 [])

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1475,9 +1475,80 @@ RPMTEST_CHECK([
 cat stderr | sort
 ],
 [0],
-[warning: posix.fork(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.execute() instead
-warning: posix.wait(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.execute() instead
+[warning: posix.fork(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead
+warning: posix.wait(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead
 warning: runaway fork() in Lua script
+],
+[])
+RPMTEST_CLEANUP
+
+AT_SETUP([lua rpm spawn])
+AT_KEYWORDS([macros lua])
+RPMDB_INIT
+RPMTEST_CHECK([
+runroot_other rpmlua -e "rpm.spawn({'echo', '1', '2', '3'})"
+],
+[0],
+[1 2 3
+],
+[])
+
+RPMTEST_CHECK([
+runroot_other rpmlua \
+	-e "rpm.spawn({'echo', '1', '2', '3'}, {stdout='/dev/null'})"
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot_other rpmlua \
+	-e "rpm.spawn({'ls', '/notthere'})"
+],
+[0],
+[],
+[ls: cannot access '/notthere': No such file or directory
+])
+
+RPMTEST_CHECK([
+runroot_other rpmlua \
+	-e "rpm.spawn({'ls', '/notthere'}, {stderr='/dev/null'})"
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot_other rpmlua \
+	-e "rpm.spawn({'ls', '/notthere'}, {garbage='bbb'})"
+],
+[255],
+[],
+[[error: lua script failed: [string "<execute>"]:1: invalid spawn directive: garbage
+]])
+
+RPMTEST_CHECK([
+runroot_other rpmlua -e "rpm.spawn('echo', '1', '2', '3')"
+],
+[255],
+[],
+[[error: lua script failed: [string "<execute>"]:1: bad argument #1 to 'spawn' (table expected, got string)
+]])
+
+RPMTEST_CHECK([
+runroot_other rpmlua -e "print(rpm.spawn({'cat'}, {stdin='aaa'}))"
+],
+[0],
+[nil	No such file or directory	2.0
+],
+[])
+
+RPMTEST_CHECK([
+echo 1 2 3 > ${RPMTEST}/aaa
+runroot_other rpmlua -e "rpm.spawn({'cat'}, {stdin='aaa'})"
+],
+[0],
+[1 2 3
 ],
 [])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Turns out real-world usage needs more control than rpm.execute() delivers. This could be crammed into rpm.execute() but it'd be forward incompatible in a somewhat non-obvious way, we might just as well add a separate function for it.

Supports redirecting stdin, stdout and stderr to a given path, support for file descriptors, other actions and spawn attributes can be added later.

Fixes: #3192