### PR TITLE
Refactor ordering code to use STL containers

### DIFF
--- a/lib/order.c
+++ b/lib/order.c
@@ -4,6 +4,8 @@
 
 #include "system.h"
 
+#include <forward_list>
+
 #include <string.h>
 
 #include <rpm/rpmtag.h>
@@ -32,7 +34,6 @@ typedef struct scc_s * scc;
 struct relation_s {
     tsortInfo   rel_suc;  // pkg requiring this package
     rpmsenseFlags rel_flags; // accumulated flags of the requirements
-    struct relation_s * rel_next;
 };
 
 typedef struct relation_s * relation;
@@ -42,37 +43,19 @@ struct tsortInfo_s {
     int	     tsi_count;     // #pkgs this pkg requires
     int	     tsi_qcnt;      // #pkgs requiring this package
     int	     tsi_reqx;       // requires Idx/mark as (queued/loop)
-    struct relation_s * tsi_relations;
-    struct relation_s * tsi_forward_relations;
+    std::forward_list<relation_s> tsi_relations;
+    std::forward_list<relation_s> tsi_forward_relations;
     tsortInfo tsi_suc;        // used for queuing (addQ)
     int      tsi_SccIdx;     // # of the SCC the node belongs to
                              // (1 for trivial SCCs)
     int      tsi_SccLowlink; // used for SCC detection
 };
 
-static void rpmTSIFree(tsortInfo tsi)
-{
-    relation rel;
-
-    while (tsi->tsi_relations != NULL) {
-	rel = tsi->tsi_relations;
-	tsi->tsi_relations = tsi->tsi_relations->rel_next;
-	free(rel);
-    }
-    while (tsi->tsi_forward_relations != NULL) {
-	rel = tsi->tsi_forward_relations;
-	tsi->tsi_forward_relations = \
-	    tsi->tsi_forward_relations->rel_next;
-	free(rel);
-    }
-}
-
 static inline int addSingleRelation(rpmte p,
 				    rpmte q,
 				    rpmds dep)
 {
     struct tsortInfo_s *tsi_p, *tsi_q;
-    relation rel;
     rpmElementType teType = rpmteType(p);
     rpmsenseFlags dsflags = rpmdsFlags(dep);
     int reversed = rpmdsIsReverse(dep);
@@ -122,15 +105,15 @@ static inline int addSingleRelation(rpmte p,
     tsi_q = rpmteTSI(q);
 
     /* if relation got already added just update the flags */
-    if (!reversed &&
-	tsi_q->tsi_relations && tsi_q->tsi_relations->rel_suc == tsi_p) {
+    if (!reversed && tsi_q->tsi_relations.empty() == false &&
+	    tsi_q->tsi_relations.front().rel_suc == tsi_p)
+    {
 	/* must be latest one added to q as we add all rels to p at once */
-	tsi_q->tsi_relations->rel_flags |= flags;
+	tsi_q->tsi_relations.front().rel_flags |= flags;
 	/* search entry in p */
-	for (struct relation_s * tsi = tsi_p->tsi_forward_relations;
-	     tsi; tsi = tsi->rel_next) {
-	    if (tsi->rel_suc == tsi_q) {
-		tsi->rel_flags |= flags;
+	for (auto & tsi : tsi_p->tsi_forward_relations) {
+	    if (tsi.rel_suc == tsi_q) {
+		tsi.rel_flags |= flags;
 		return 0;
 	    }
 	}
@@ -138,15 +121,15 @@ static inline int addSingleRelation(rpmte p,
     }
 
     /* if relation got already added just update the flags */
-    if (reversed && tsi_q->tsi_forward_relations &&
-	tsi_q->tsi_forward_relations->rel_suc == tsi_p) {
+    if (reversed && tsi_q->tsi_forward_relations.empty() == false &&
+	tsi_q->tsi_forward_relations.front().rel_suc == tsi_p)
+    {
 	/* must be latest one added to q as we add all rels to p at once */
-	tsi_q->tsi_forward_relations->rel_flags |= flags;
+	tsi_q->tsi_forward_relations.front().rel_flags |= flags;
 	/* search entry in p */
-	for (struct relation_s * tsi = tsi_p->tsi_relations;
-	     tsi; tsi = tsi->rel_next) {
-	    if (tsi->rel_suc == tsi_q) {
-		tsi->rel_flags |= flags;
+	for (auto & tsi : tsi_p->tsi_relations) {
+	    if (tsi.rel_suc == tsi_q) {
+		tsi.rel_flags |= flags;
 		return 0;
 	    }
 	}
@@ -157,24 +140,11 @@ static inline int addSingleRelation(rpmte p,
 
     /* bump p predecessor count */
     tsi_p->tsi_count++;
-
-    rel = (relation)xcalloc(1, sizeof(*rel));
-    rel->rel_suc = tsi_p;
-    rel->rel_flags = flags;
-
-    rel->rel_next = tsi_q->tsi_relations;
-    tsi_q->tsi_relations = rel;
-
+    tsi_q->tsi_relations.push_front({ tsi_p, flags});
     
     /* bump q successor count */
     tsi_q->tsi_qcnt++;
-
-    rel = (relation)xcalloc(1, sizeof(*rel));
-    rel->rel_suc = tsi_q;
-    rel->rel_flags = flags;
-
-    rel->rel_next = tsi_p->tsi_forward_relations;
-    tsi_p->tsi_forward_relations = rel;
+    tsi_p->tsi_forward_relations.push_front({ tsi_q, flags});
 
     return 0;
 }
@@ -295,7 +265,6 @@ typedef struct sccData_s {
 static void tarjan(sccData sd, tsortInfo tsi)
 {
     tsortInfo tsi_q;
-    relation rel;
 
     /* use negative index numbers */
     sd->index--;
@@ -304,9 +273,9 @@ static void tarjan(sccData sd, tsortInfo tsi)
     tsi->tsi_SccLowlink = sd->index;
 
     sd->stack[sd->stackcnt++] = tsi;                   /* Push p on the stack */
-    for (rel=tsi->tsi_relations; rel != NULL; rel=rel->rel_next) {
+    for (auto & rel : tsi->tsi_relations) {
 	/* Consider successors of p */
-	tsi_q = rel->rel_suc;
+	tsi_q = rel.rel_suc;
 	if (tsi_q->tsi_SccIdx > 0)
 	    /* Ignore already found SCCs */
 	    continue;
@@ -343,10 +312,9 @@ static void tarjan(sccData sd, tsortInfo tsi)
 		/* Calculate count for the SCC */
 		sd->SCCs[sd->sccCnt].count += tsi_q->tsi_count;
 		/* Subtract internal relations */
-		for (rel=tsi_q->tsi_relations; rel != NULL;
-						    rel=rel->rel_next) {
-		    if (rel->rel_suc != tsi_q &&
-			    rel->rel_suc->tsi_SccIdx == sd->sccCnt)
+		for (auto const & rel : tsi_q->tsi_relations) {
+		    if (rel.rel_suc != tsi_q &&
+			    rel.rel_suc->tsi_SccIdx == sd->sccCnt)
 			sd->SCCs[sd->sccCnt].count--;
 		}
 	    } while (tsi_q != tsi);
@@ -394,12 +362,11 @@ static scc detectSCCs(std::vector<tsortInfo_s> & orderInfo, int debugloops)
 		tsortInfo member = SCCs[i].members[j];
 		rpmlog(msglvl, "\t%s\n", rpmteNEVRA(member->te));
 		/* show relations between members */
-		relation rel = member->tsi_forward_relations;
-		for (; rel != NULL; rel=rel->rel_next) {
-		    if (rel->rel_suc->tsi_SccIdx!=i) continue;
+		for (auto const & rel : member->tsi_forward_relations) {
+		    if (rel.rel_suc->tsi_SccIdx!=i) continue;
 		    rpmlog(msglvl, "\t\t%s %s\n",
-			   rel->rel_flags ? "=>" : "->",
-			   rpmteNEVRA(rel->rel_suc->te));
+			   rel.rel_flags ? "=>" : "->",
+			   rpmteNEVRA(rel.rel_suc->te));
 		}
 	    }
 	}
@@ -429,8 +396,8 @@ static void collectTE(rpm_color_t prefcolor, tsortInfo q,
     newOrder.push_back(q->te);
 
     /* T6. Erase relations. */
-    for (relation rel = q->tsi_relations; rel != NULL; rel = rel->rel_next) {
-	tsortInfo p = rel->rel_suc;
+    for (auto & rel : q->tsi_relations) {
+	tsortInfo p = rel.rel_suc;
 	/* ignore already collected packages */
 	if (p->tsi_SccIdx == 0) continue;
 	if (p == q) continue;
@@ -466,7 +433,6 @@ static void collectTE(rpm_color_t prefcolor, tsortInfo q,
 static void dijkstra(const struct scc_s *SCC, int sccNr)
 {
     int start, end;
-    relation rel;
 
     /* can use a simple queue as edge weights are always 1 */
     tsortInfo * queue = (tsortInfo *)xmalloc((SCC->size+1) * sizeof(*queue));
@@ -479,9 +445,9 @@ static void dijkstra(const struct scc_s *SCC, int sccNr)
     for (int i = 0; i < SCC->size; i++) {
 	tsortInfo tsi = SCC->members[i];
 	tsi->tsi_SccLowlink = INT_MAX;
-	for (rel=tsi->tsi_forward_relations; rel != NULL; rel=rel->rel_next) {
-	    if (rel->rel_flags && rel->rel_suc->tsi_SccIdx == sccNr) {
-		if (rel->rel_suc != tsi) {
+	for (auto & rel : tsi->tsi_forward_relations) {
+	    if (rel.rel_flags && rel.rel_suc->tsi_SccIdx == sccNr) {
+		if (rel.rel_suc != tsi) {
 		    tsi->tsi_SccLowlink =  0;
 		    queue[end++] = tsi;
 		} else {
@@ -504,12 +470,12 @@ static void dijkstra(const struct scc_s *SCC, int sccNr)
     /* Do Dijkstra */
     while (start != end) {
 	tsortInfo tsi = queue[start++];
-	for (rel=tsi->tsi_forward_relations; rel != NULL; rel=rel->rel_next) {
-	    tsortInfo next_tsi = rel->rel_suc;
+	for (auto & rel : tsi->tsi_forward_relations) {
+	    tsortInfo next_tsi = rel.rel_suc;
 	    if (next_tsi->tsi_SccIdx != sccNr) continue;
 	    if (next_tsi->tsi_SccLowlink > tsi->tsi_SccLowlink+1) {
 		next_tsi->tsi_SccLowlink = tsi->tsi_SccLowlink + 1;
-		queue[end++] = rel->rel_suc;
+		queue[end++] = rel.rel_suc;
 	    }
 	}
     }
@@ -670,7 +636,6 @@ int rpmtsOrder(rpmts ts)
     /* Clean up tsort data */
     for (int i = 0; i < nelem; i++) {
 	rpmteSetTSI(tsmem->order[i], NULL);
-	rpmTSIFree(&sortInfo[i]);
     }
 
     assert(newOrder.size() == tsmem->order.size());


### PR DESCRIPTION
This is all a rather crude, mechanical conversion, I bet there's tonnes of further sanity + cleanup possible.
The main point here is to get rid of C-side allocations.