### PR TITLE
Make Buildsystem %conf section optional

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -931,7 +931,7 @@ exit:
 
 struct sectname_s sectList[] = {
     { "prep", SECT_PREP, PART_PREP, 0 },
-    { "conf", SECT_CONF, PART_CONF, 1 },
+    { "conf", SECT_CONF, PART_CONF, 0 },
     { "generate_buildrequires", SECT_BUILDREQUIRES, PART_BUILDREQUIRES, 0 },
     { "build", SECT_BUILD, PART_BUILD, 1 },
     { "install", SECT_INSTALL, PART_INSTALL, 1 },

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -176,18 +176,6 @@ runroot rpmbuild -bb \
 
 RPMTEST_CHECK([
 runroot rpmbuild -bb \
-	--define 'buildsystem_autotools_conf %nil' \
-	--define 'buildsystem_autotools_build %nil' \
-	--define 'buildsystem_autotools_install %nil' \
-	--quiet /data/SPECS/amhello.spec
-],
-[1],
-[],
-[error: line 11: Required parametric macro %buildsystem_autotools_conf not defined for buildsystem autotools
-])
-
-RPMTEST_CHECK([
-runroot rpmbuild -bb \
 	--define 'buildsystem_autotools_build %nil' \
 	--define 'buildsystem_autotools_check %nil' \
 	--quiet /data/SPECS/amhello.spec


### PR DESCRIPTION
The idea behind making it mandatory was that surely every real buildsystem implements a configuration step, right? Well, at least Python setuptools only has build and install, and for our purposes it certainly qualifies as a buildsystem. And where there's one, there'll be more.

Suggested-by: Miro Hrončok <miro@hroncok.cz>

Fixes: #3244