### PR TITLE
Report unsafe symlinks during installation as a specific case

### DIFF
--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -2426,7 +2426,7 @@ char * rpmfileStrerror(int rc)
     case RPMERR_DIGEST_MISMATCH: s = _("Digest mismatch");	break;
     case RPMERR_INTERNAL:	s = _("Internal error");	break;
     case RPMERR_UNMAPPED_FILE:	s = _("Archive file not in header"); break;
-    case RPMERR_INVALID_SYMLINK: s = _("Invalid symlink");	break;
+    case RPMERR_INVALID_SYMLINK: s = _("Unsafe symlink");	break;
     case RPMERR_ENOTDIR:	s = strerror(ENOTDIR);	break;
     case RPMERR_ENOENT:	s = strerror(ENOENT); break;
     case RPMERR_ENOTEMPTY:	s = strerror(ENOTEMPTY); break;

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1690,8 +1690,8 @@ runroot --setenv SOURCE_DATE_EPOCH 1699955855 rpm -U /build/RPMS/noarch/replacet
 ],
 [1],
 [],
-[error: failed to open dir opt of /opt/: cpio: Not a directory
-error: unpacking of archive failed on file /opt/foo;6553448f: cpio: Not a directory
+[error: failed to open dir opt of /opt/: cpio: Unsafe symlink
+error: unpacking of archive failed on file /opt/foo;6553448f: cpio: Unsafe symlink
 error: replacetest-1.0-1.noarch: install failed
 ])
 RPMTEST_CLEANUP

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1690,8 +1690,8 @@ runroot --setenv SOURCE_DATE_EPOCH 1699955855 rpm -U /build/RPMS/noarch/replacet
 ],
 [1],
 [],
-[error: failed to open dir opt of /opt/: Not a directory
-error: unpacking of archive failed on file /opt/foo;6553448f: cpio: open failed - Not a directory
+[error: failed to open dir opt of /opt/: cpio: Not a directory
+error: unpacking of archive failed on file /opt/foo;6553448f: cpio: Not a directory
 error: replacetest-1.0-1.noarch: install failed
 ])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Based on #3175 by @ffesti, main differences being:
- split the fsmOpenat() return change to a separate refactoring *and* update callers accordingly
- clean up the error handling in fsmOpenat() and ensureDir()