### PR TITLE
Another attempt at stabilizing posix.fork() and url retrieve tests

### DIFF
--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -411,12 +411,19 @@ EOF
 chmod a+x "${RPMTEST}"/tmp/fakecurl
 
 RPMTEST_CHECK([
-runroot rpm --define "_urlhelper /tmp/fakecurl" --root /srv/test -qp https://example.com/foo-0.1-1.noarch.rpm 2> >(sed 's| /.*rpm-tmp.* https| rpm-tmp https|' >&2)
+runroot rpm --define "_urlhelper /tmp/fakecurl" --root /srv/test -qp https://example.com/foo-0.1-1.noarch.rpm
 ],
 [1],
 [],
+[stderr])
+
+RPMTEST_CHECK([
+cat stderr | sed 's| /.*rpm-tmp.* https| rpm-tmp https|' | sort
+],
+[0],
 [/tmp/fakecurl: failed to retrieve https://example.com/foo-0.1-1.noarch.rpm
 error: Executing url helper "/tmp/fakecurl rpm-tmp https://example.com/foo-0.1-1.noarch.rpm" failed with status 7
 error: open of https://example.com/foo-0.1-1.noarch.rpm failed: No such file or directory
-])
+],
+[])
 RPMTEST_CLEANUP

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1467,10 +1467,19 @@ runroot_other rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect
 [0],
 [nil	Bad file descriptor	9.0
 ],
+[stderr])
+
+# stderr output from the above is flaky due to the fork, post-processing
+# ought to be more reliable
+RPMTEST_CHECK([
+cat stderr | sort
+],
+[0],
 [warning: posix.fork(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.execute() instead
 warning: posix.wait(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.execute() instead
-warning: runaway fork() in Lua script]
-)
+warning: runaway fork() in Lua script
+],
+[])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmlua hooks])


### PR DESCRIPTION
Both these tests (currently 12 and 90) are flaky and sometimes fail with the trailing newline at the front, eg test stderr showing:

    +
     warning: posix.fork(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.execute() instead
     warning: posix.wait(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.execute() instead
     warning: runaway fork() in Lua script
    -

It's all the more bizarre since we're NOT expecting that trailing an empty line after the messages in the first place.

Let's try another trick from autotest: just grab the stderr into a file that we process in the next test. Autoconf manual says "This action is often used when it is desired to use grep to look for a substring in the output, or when the output must be post-processed to normalize error messages into a common form." Which is exactly what we're doing here.

Time will tell, but at least we're now seeing the last newline on both tests as I would expect.