### PR TITLE
>() redirects considered harmful, part II

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -396,10 +396,17 @@ RPMDB_INIT
 RPMTEST_CHECK([
 
 run rpmbuild -D="nopatches 1" \
-  -bp ${RPMDATA}/SPECS/hello-auto.spec 2> >(grep warning >&2)
+  -bp ${RPMDATA}/SPECS/hello-auto.spec
 ],
 [0],
 [ignore],
+[stderr])
+
+RPMTEST_CHECK([
+grep warning: stderr
+],
+[1],
+[],
 [])
 RPMTEST_CLEANUP
 
@@ -517,13 +524,19 @@ RPMDB_INIT
 RPMTEST_CHECK([
 
 run rpmbuild \
-  -ba ${RPMDATA}/SPECS/hello-autopatch.spec 2> >(grep warning >&2) | grep warning
+  -ba --quiet ${RPMDATA}/SPECS/hello-autopatch.spec
 ],
 [0],
-[RPM build warnings:
+[],
+[stderr])
+
+RPMTEST_CHECK([
+grep warning: stderr
 ],
+[0],
 [warning: /data/SPECS/hello-autopatch.spec line 22: autopatch: no matching patches in range
-])
+],
+[])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild -ba find-lang])


### PR DESCRIPTION
Turns out it's not just the two fork-related tests mentioned in commit 2931cbd7b1281395d18ff88e40e024659b4cfbf5 that are unreliable, it's the bash-specific >() subshell redirect that causes those unexpected extra newlines moving around in the test-suite, and here are two more tests that occasionally now fail.

Adjust the tests to avoid that construct, which should be considered banned in the test-suite from here on...