### PR TITLE
Restore --build-in-place with --noprep functionality

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -428,6 +428,8 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	    /* in-place builds counter-intuitively always have buildsubdir */
 	    rpmPushMacro(spec->macros,
 			"buildsubdir", NULL, "%{NAME}-%{VERSION}", RMIL_SPEC);
+	    if (didBuild)
+		what |= RPMBUILD_MKBUILDDIR;
 	    what &= ~(RPMBUILD_RMBUILD);
 	}
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -461,6 +461,27 @@ hello-2.0/hello.c
 [])
 RPMTEST_CLEANUP
 
+AT_SETUP([rpmbuild --build-in-place --noprep])
+AT_KEYWORDS([build])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
+runroot_other mv hello-2.0/hello.spec .
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot --chdir hello-2.0 rpmbuild -bb --quiet \
+	--noprep --build-in-place ../hello.spec
+],
+[0],
+[],
+[ignore])
+RPMTEST_CLEANUP
+
 AT_SETUP([rpmbuild --build-in-place --short-circuit])
 AT_KEYWORDS([build])
 RPMDB_INIT


### PR DESCRIPTION
In rpm >= 4.20 we always have to have the build directory. Commit c74ab58f081937eefd0f79af8d0310495d321864 linked its creation to --noprep but that was under the assumption of normal builds where %prep has already been executed, and we're re-entering the already created directory structure for another build stage.

--build-in-place being what it is, there's basically nothing to do at %prep so it seems natural that this should work. The linux kernel upstream packaging uses this to allow quickly building "dirty" rpm from a git repo directly, but faciliate a full regular rpmbuild from an src.rpm built this way. It seems like a reasonable thing, in fact this makes me think that --build-in-place should imply skipping %prep, but lets not go there yet...

Make sure %mkbuilddir gets run if we execute any build steps, this is fairly subtle to preserve --short-circuit too.

Fixes: #3216