### PR TITLE
>() redirects considered harmful, part 1.5

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1462,7 +1462,7 @@ nil	No such file or directory	2.0
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect2null(-1); print(string.format("%s\t%s\t%s", a,b,c)); io.flush() else posix.wait(pid) end' 2> >(sort >&2)
+runroot_other rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect2null(-1); print(string.format("%s\t%s\t%s", a,b,c)); io.flush() else posix.wait(pid) end'
 ],
 [0],
 [nil	Bad file descriptor	9.0


### PR DESCRIPTION
Argh, commit 2931cbd7b1281395d18ff88e40e024659b4cfbf5 forgot to remove the redirect. This new combo also evoked new tricks: now the entire stderr output goes missing sometimes.