### PR TITLE
Define --build-in-place in more clear and actually supportable way

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -430,7 +430,7 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 			"buildsubdir", NULL, "%{NAME}-%{VERSION}", RMIL_SPEC);
 	    if (didBuild)
 		what |= RPMBUILD_MKBUILDDIR;
-	    what &= ~(RPMBUILD_RMBUILD);
+	    what &= ~(RPMBUILD_PREP|RPMBUILD_RMBUILD);
 	}
 
 	if ((what & RPMBUILD_CHECKBUILDREQUIRES) &&

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -190,10 +190,6 @@ void doSetupMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
 	goto exit;
     }
 
-    if (rpmExpandNumeric("%{_build_in_place}")) {
-	goto exit;
-    }
-
     optCon = poptGetContext(NULL, argc, argv, optionsTable, 0);
     while ((arg = poptGetNextOpt(optCon)) > 0) {
 	char *optArg = poptGetOptArg(optCon);

--- a/docs/man/rpmbuild.8.md
+++ b/docs/man/rpmbuild.8.md
@@ -265,9 +265,10 @@ The following options may also be used:
 
 **\--build-in-place**
 
-:   Build from locally checked out sources. Sets \_builddir to current
-    working directory. Skips handling of -n and untar in the %setup and
-    the deletion of the buildSubdir.
+:   Build from locally checked out sources in the current working
+    directory. The build tree is set up as if %setup was used,
+    but %builddir/%buildsubdir points back to the current working
+    directory. %prep is skipped entirely.
 
 **\--target ***PLATFORM*
 


### PR DESCRIPTION
Defining in-place builds to skip %prep suddenly makes this feature start looking supportable, because it's no longer ambiguous every which way: %setup is supposed to have all manner of side-effects that in-place builds would skip, including cd'ing to %buildsubdir. It's not possible for calling %setup to both have and not have side-effects.

Besides %setup ambiguity, %prep typically contains patch applications and those cannot be meaningfully done on in-place build because then the build is no longer repeatable.

Update the man page description to describe the new %buildsubdir based behavior, and make %prep skipped on in-place builds no matter what other options got passed. This WILL break some existing users if they rely on %prep getting partially executed, but that's how it is with ambiguity. If there's another non-ambiguous way to solve this, I'm not seeing it.

Fixes: #3208