### PR TITLE
Support manual debuginfo packaging again

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2588,7 +2588,7 @@ static rpmRC processPackageFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 {
     /* Check build-ids and add build-ids links for files to package list. */
     const char *arch = headerGetString(pkg->header, RPMTAG_ARCH);
-    if (!rstreq(arch, "noarch")) {
+    if (rpmExpandNumeric("%{?__debug_package}") && !rstreq(arch, "noarch")) {
 	/* Go through the current package list and generate a files list. */
 	ARGV_t idFiles = NULL;
 	if (generateBuildIDs (&fl, &idFiles) != 0) {
@@ -3072,15 +3072,19 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
     Package deplink = NULL;		/* create requires to this package */
     /* The debugsource package, if it exists, that the debuginfo package(s)
        should Recommend.  */
-    Package dbgsrcpkg = findDebugsourcePackage(spec);
+    Package dbgsrcpkg = NULL;
+    int processDebug = rpmExpandNumeric("%{?__debug_package}");
     
 #ifdef HAVE_LIBDW
     elf_version (EV_CURRENT);
 #endif
     check_fileList = newStringBuf();
     buildroot = rpmGenPath(spec->rootDir, spec->buildRoot, NULL);
-    
-    if (rpmExpandNumeric("%{?_debuginfo_subpackages}")) {
+
+    if (processDebug)
+	dbgsrcpkg = findDebugsourcePackage(spec);
+
+    if (processDebug && rpmExpandNumeric("%{?_debuginfo_subpackages}")) {
 	maindbg = findDebuginfoPackage(spec);
 	if (maindbg) {
 	    /* move debuginfo package to back */

--- a/macros.in
+++ b/macros.in
@@ -194,9 +194,12 @@ package or when debugging this package.\
 %files debugsource -f debugsourcefiles.list\
 %{nil}
 
+# The duplicate __debug_package definition is needed to ensure matching
+# state when %install is skipped due to short-circuit.
 %debug_package \
 %ifnarch noarch\
 %global __debug_package 1\
+%%global __debug_package 1\
 %_debuginfo_template\
 %{?_debugsource_packages:%_debugsource_template}\
 %endif\

--- a/tests/data/SPECS/hello-debuginfo.spec
+++ b/tests/data/SPECS/hello-debuginfo.spec
@@ -1,0 +1,55 @@
+# To whom it may concern:
+# DO NOT COPY THIS SPEC or its derivates to your testcase. That is,
+# unless your test-case actually requires running a compiler and
+# inspecting it's output. Everybody else should use a simple noarch
+# package which can be built under runroot in the test-suite.
+
+Summary: hello -- hello, world rpm
+ Name: hello
+Version: 1.0
+	Release: 1
+ Group: Utilities
+License: GPL
+SourceLicense: GPL, ASL 1.0
+Distribution: RPM test suite.
+URL: http://rpm.org
+	Source0: hello-1.0.tar.gz
+ Patch0: hello-1.0-modernize.patch
+Prefix: /usr
+%global debug_package %{nil}
+
+%description
+Simple rpm demonstration.
+
+%prep
+%setup -q
+%patch -p1 -b .modernize 0
+
+%build
+make
+
+%install
+mkdir -p $RPM_BUILD_ROOT/usr/local/bin
+make DESTDIR=$RPM_BUILD_ROOT install
+mkdir -p %{buildroot}/usr/lib/debug
+touch %{buildroot}/usr/lib/debug/test.txt
+
+%files
+%defattr(-,root,root)
+%doc	FAQ
+#%readme README
+#%license COPYING
+%attr(0751,root,root)	/usr/local/bin/hello
+
+%package debuginfo
+Summary: debuginfo
+
+%description debuginfo
+description
+
+%files debuginfo
+/usr/lib/debug/test.txt
+
+%changelog
+* Tue Oct 20 1998 Jeff Johnson <jbj@redhat.com>
+- create.

--- a/tests/data/SPECS/hello-debuginfo.spec
+++ b/tests/data/SPECS/hello-debuginfo.spec
@@ -4,6 +4,8 @@
 # inspecting it's output. Everybody else should use a simple noarch
 # package which can be built under runroot in the test-suite.
 
+%bcond customdebug 1
+
 Summary: hello -- hello, world rpm
  Name: hello
 Version: 1.0
@@ -16,7 +18,10 @@ URL: http://rpm.org
 	Source0: hello-1.0.tar.gz
  Patch0: hello-1.0-modernize.patch
 Prefix: /usr
+
+%if %{with customdebug}
 %global debug_package %{nil}
+%endif
 
 %description
 Simple rpm demonstration.

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2460,6 +2460,27 @@ runroot rpm -qpl /build/RPMS/*/hello-debuginfo-1.0-1.*.rpm
 /usr/lib/debug/test.txt
 ],
 [ignore])
+
+RPMTEST_CHECK([
+runroot rpmbuild --quiet -bb \
+		--define "_prefix /usr/local" \
+		--without customdebug \
+		--define "_enable_debug_packages 0" \
+		/data/SPECS/hello-debuginfo.spec
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+runroot rpmbuild --quiet -bb \
+		--define "_prefix /usr/local" \
+		--without customdebug \
+		/data/SPECS/hello-debuginfo.spec
+],
+[1],
+[ignore],
+[ignore])
 RPMTEST_CLEANUP
 
 AT_SETUP([explicit %_enable_debug_package on noarch])

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2435,6 +2435,33 @@ No hello.debug
 [ignore])
 RPMTEST_CLEANUP
 
+AT_SETUP([manual debuginfo package])
+AT_KEYWORDS([build debuginfo])
+RPMTEST_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild --quiet -bb \
+		--define "_prefix /usr/local" \
+		/data/SPECS/hello-debuginfo.spec
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+
+runroot rpm -qpl /build/RPMS/*/hello-1.0-1.*.rpm
+runroot rpm -qpl /build/RPMS/*/hello-debuginfo-1.0-1.*.rpm
+],
+[0],
+[/usr/local/bin/hello
+/usr/local/share/doc/hello-1.0
+/usr/local/share/doc/hello-1.0/FAQ
+/usr/lib/debug/test.txt
+],
+[ignore])
+RPMTEST_CLEANUP
+
 AT_SETUP([explicit %_enable_debug_package on noarch])
 AT_KEYWORDS([build debuginfo])
 RPMTEST_CHECK([


### PR DESCRIPTION
This is @ffesti's fix from #3061, with an added fix needed for %__debug_package to be consistent enough to be used for the purpose. The benefit is that it supports both the de-facto "%global debug_package %{nil}" method in existing packages and the more formal %_enable_debug_packages switch. Delightful details in commit messages.

This fixes what must be a years old regression that prevents manual creation of -debuginfo subpackage.