### PR TITLE
File trigger fixes

### DIFF
--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -10,6 +10,7 @@
 
 #include "rpmlua.h"
 #include "rpmscript.h"	/* script flags */
+#include "rpmtriggers.h" /* default priority */
 #include "rpmbuild_internal.h"
 #include "rpmbuild_misc.h"
 
@@ -86,7 +87,7 @@ int parseScript(rpmSpec spec, int parsePart)
     char *prog = xstrdup("/bin/sh");
     char *origprog = prog;
     char *file = NULL;
-    int priority = 1000000;
+    int priority = RPMTRIGGER_DEFAULT_PRIORITY;
     struct poptOption optionsTable[] = {
 	{ NULL, 'p', POPT_ARG_STRING, &prog, 'p',	NULL, NULL},
 	{ NULL, 'n', POPT_ARG_STRING, &name, 'n',	NULL, NULL},

--- a/lib/rpmtriggers.c
+++ b/lib/rpmtriggers.c
@@ -120,11 +120,12 @@ static void addTriggers(rpmts ts, Header trigH, rpmsenseFlags filter,
     rpmTagVal prioTag = RPMTAG_TRANSFILETRIGGERPRIORITIES;
 
     while ((ds = rpmdsFilterTi(triggers, tix))) {
-	if ((rpmdsNext(ds) >= 0) && (rpmdsFlags(ds) & filter) &&
-		strcmp(prefix, rpmdsN(ds)) == 0) {
-	    unsigned int priority = getTrigPriority(trigH, prioTag, tix);
-	    rpmtriggersAdd(ts->trigs2run, headerGetInstance(trigH),
-				tix, priority);
+	while (rpmdsNext(ds) >= 0) {
+	    if ((rpmdsFlags(ds) & filter) && strcmp(prefix, rpmdsN(ds)) == 0) {
+		unsigned int priority = getTrigPriority(trigH, prioTag, tix);
+		rpmtriggersAdd(ts->trigs2run, headerGetInstance(trigH),
+				    tix, priority);
+	    }
 	}
 	rpmdsFree(ds);
 	tix++;

--- a/lib/rpmtriggers.h
+++ b/lib/rpmtriggers.h
@@ -4,6 +4,8 @@
 #include <rpm/rpmutil.h>
 #include "rpmscript.h"
 
+#define RPMTRIGGER_DEFAULT_PRIORITY 1000000
+
 struct triggerInfo_s {
     unsigned int hdrNum;
     unsigned int tix;

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -548,7 +548,6 @@ RPMTEST_CLEANUP
 
 AT_SETUP([basic file triggers: prefix args])
 AT_KEYWORDS([filetrigger script])
-AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec


### PR DESCRIPTION
The first commit is just a consistency/safety thing spotted while looking for the second one, which is the main course here: fix %transfiletriggerpostun only matching on the first prefix even when the trigger has multiple.

Draft only for now due to lacking reproducer in the test-suite - we lack *any* tests for the multiple prefixes case, oops...