### PR TITLE
Add tests for multiple file trigger prefixes

### DIFF
--- a/tests/data/SPECS/filetriggers-prefix.spec
+++ b/tests/data/SPECS/filetriggers-prefix.spec
@@ -1,0 +1,39 @@
+Name:		filetriggers-prefix
+Version:	1.0
+Release:	1
+Summary:	Testing multiple file trigger prefixes
+BuildArch:	noarch
+License:	GPL
+
+%description
+%{summary}
+
+%filetriggerin -- /foo /usr/bin /etc
+echo "filetriggerin:"
+cat | xargs dirname | uniq
+echo
+
+%filetriggerun -- /etc /foo /usr/bin
+echo "filetriggerun:"
+cat | xargs dirname | uniq
+echo
+
+%filetriggerpostun -- /foo /usr/bin /etc
+echo "filetriggerpostun:"
+cat | xargs dirname | uniq
+echo
+
+%transfiletriggerin -- /foo /etc /usr/bin
+echo "transfiletriggerin:"
+cat | xargs dirname | uniq
+echo
+
+%transfiletriggerun -- /foo /usr/bin /etc
+echo "transfiletriggerun:"
+cat | xargs dirname | uniq
+echo
+
+%transfiletriggerpostun -- /usr/bin /foo /etc
+echo "transfiletriggerpostun"
+
+%files

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -293,7 +293,78 @@ scripts-1.0-2 POSTUNTRANS 0
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([basic trigger scripts and arguments])
+AT_SETUP([basic trigger scripts: package args])
+AT_KEYWORDS([trigger script])
+RPMDB_INIT
+
+runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
+runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
+runroot rpmbuild --quiet -bb /data/SPECS/hlinktest.spec
+runroot rpmbuild --quiet -bb \
+		 --define "rel 1" \
+		 --define "trigpkg hello-script hlinktest non-existent" \
+		 /data/SPECS/triggers.spec
+
+runroot rpm -U /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm
+runroot rpm -U /build/RPMS/noarch/triggers-1.0-1.noarch.rpm
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/hello-script-1.0-1.noarch.rpm
+runroot rpm -e hello-script
+],
+[0],
+[triggers-1.0-1 TRIGGERPREIN 1 0
+triggers-1.0-1 TRIGGERIN 1 1
+triggers-1.0-1 TRIGGERUN 1 0
+triggers-1.0-1 TRIGGERPOSTUN 1 0
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -e hlinktest
+],
+[0],
+[triggers-1.0-1 TRIGGERPREIN 1 0
+triggers-1.0-1 TRIGGERIN 1 1
+triggers-1.0-1 TRIGGERUN 1 0
+triggers-1.0-1 TRIGGERPOSTUN 1 0
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/hello-script-1.0-1.noarch.rpm \
+	       /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -e hello-script hlinktest
+],
+[0],
+[triggers-1.0-1 TRIGGERPREIN 1 0
+triggers-1.0-1 TRIGGERIN 1 1
+triggers-1.0-1 TRIGGERPREIN 1 0
+triggers-1.0-1 TRIGGERIN 1 1
+triggers-1.0-1 TRIGGERUN 1 0
+triggers-1.0-1 TRIGGERPOSTUN 1 0
+triggers-1.0-1 TRIGGERUN 1 0
+triggers-1.0-1 TRIGGERPOSTUN 1 0
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -e triggers
+runroot rpm -U /build/RPMS/noarch/hello-script-1.0-1.noarch.rpm \
+	       /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -U /build/RPMS/noarch/triggers-1.0-1.noarch.rpm
+runroot rpm -e triggers
+],
+[0],
+[triggers-1.0-1 TRIGGERPREIN 0 1
+triggers-1.0-1 TRIGGERIN 1 1
+triggers-1.0-1 TRIGGERUN 0 1
+],
+[])
+RPMTEST_CLEANUP
+
+AT_SETUP([basic trigger scripts: runtime args])
 AT_KEYWORDS([trigger script])
 RPMDB_INIT
 

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -475,7 +475,133 @@ transfiletriggerpostun(/foo*):
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([basic file triggers 2])
+AT_SETUP([basic file triggers: prefix args])
+AT_KEYWORDS([filetrigger script])
+AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
+RPMDB_INIT
+
+runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
+runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
+runroot rpmbuild --quiet -bb /data/SPECS/hlinktest.spec
+runroot rpmbuild --quiet -bb /data/SPECS/filetriggers-prefix.spec
+
+runroot rpm -U /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm
+runroot rpm -U /build/RPMS/noarch/filetriggers-prefix-1.0-1.noarch.rpm
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/hello-script-1.0-1.noarch.rpm
+runroot rpm -e hello-script
+],
+[0],
+[filetriggerin:
+/usr/bin
+
+transfiletriggerin:
+/usr/bin
+
+transfiletriggerun:
+/usr/bin
+
+filetriggerun:
+/usr/bin
+
+filetriggerpostun:
+/usr/bin
+
+transfiletriggerpostun
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -e hlinktest
+],
+[0],
+[filetriggerin:
+/foo
+
+transfiletriggerin:
+/foo
+
+transfiletriggerun:
+/foo
+
+filetriggerun:
+/foo
+
+filetriggerpostun:
+/foo
+
+transfiletriggerpostun
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/hello-script-1.0-1.noarch.rpm \
+	       /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -e hello-script hlinktest
+],
+[0],
+[filetriggerin:
+/foo
+
+filetriggerin:
+/usr/bin
+
+transfiletriggerin:
+/foo
+/usr/bin
+
+transfiletriggerun:
+/foo
+/usr/bin
+
+filetriggerun:
+/foo
+
+filetriggerpostun:
+/foo
+
+filetriggerun:
+/usr/bin
+
+filetriggerpostun:
+/usr/bin
+
+transfiletriggerpostun
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -e filetriggers-prefix
+runroot rpm -U /build/RPMS/noarch/hello-script-1.0-1.noarch.rpm \
+	       /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -U /build/RPMS/noarch/filetriggers-prefix-1.0-1.noarch.rpm
+runroot rpm -e filetriggers-prefix
+],
+[0],
+[filetriggerin:
+/foo
+/usr/bin
+
+transfiletriggerin:
+/foo
+/usr/bin
+
+transfiletriggerun:
+/foo
+/usr/bin
+
+filetriggerun:
+/foo
+/usr/bin
+
+],
+[])
+
+RPMTEST_CLEANUP
+
+AT_SETUP([basic file triggers: runtime args])
 AT_KEYWORDS([filetrigger script])
 RPMDB_INIT
 


### PR DESCRIPTION
Funnily enough, we never tested multiple prefixes.  No wonder there were some bugs lurking in the dark corners (see #3048 and #3267)!

- Add yet another test spec for triggers! (There's never enough of them)
- Have the scripts print the prefix(es) that triggered them
- Add an unused /etc prefix to test just that - an unused prefix
- Shuffle the prefixes randomly in some scripts, to make it more interesting (and to verify that the order doesn't affect anything)
- Rename the existing "basic file triggers 2" to make it better reflect its main goal (which is "runtime arguments") and to make it more consistent with the newly added one