### PR TITLE
Issue deprecation warnings for rpm.redirect2null() too, oops

### DIFF
--- a/rpmio/lposix.c
+++ b/rpmio/lposix.c
@@ -45,10 +45,6 @@
 
 extern int _rpmlua_have_forked;
 
-#define check_deprecated() \
-    fprintf(stderr, \
-	"warning: posix.%s(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead\n", __func__+1)
-
 static const char *filetype(mode_t m)
 {
 	if (S_ISREG(m))		return "regular";
@@ -337,7 +333,7 @@ static int Pmkfifo(lua_State *L)		/** mkfifo(path) */
 
 static int Pexec(lua_State *L)			/** exec(path,[args]) */
 {
-	check_deprecated();
+	check_deprecated(L, "posix.exec");
 
 	const char *path = luaL_checkstring(L, 1);
 	int i,n=lua_gettop(L);
@@ -358,7 +354,7 @@ static int Pexec(lua_State *L)			/** exec(path,[args]) */
 
 static int Pfork(lua_State *L)			/** fork() */
 {
-	check_deprecated();
+	check_deprecated(L, "posix.fork");
 
 	pid_t pid = fork();
 	if (pid == 0) {
@@ -370,7 +366,7 @@ static int Pfork(lua_State *L)			/** fork() */
 
 static int Pwait(lua_State *L)			/** wait([pid]) */
 {
-	check_deprecated();
+	check_deprecated(L, "posix.wait");
 
 	pid_t pid = luaL_optinteger(L, 1, -1);
 	return pushresult(L, waitpid(pid, NULL, 0), NULL);

--- a/rpmio/lposix.h
+++ b/rpmio/lposix.h
@@ -4,6 +4,9 @@
 #include <rpm/rpmutil.h>
 
 RPM_GNUC_INTERNAL
+void check_deprecated(lua_State *L, const char *func);
+
+RPM_GNUC_INTERNAL
 int luaopen_posix (lua_State *L);
 
 #endif

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -759,6 +759,8 @@ static int rpm_redirect2null(lua_State *L)
 {
     int target_fd, fd, r, e;
 
+    check_deprecated(L, "rpm.redirect2null");
+
     if (!_rpmlua_have_forked)
 	return luaL_error(L, "redirect2null not permitted in this context");
 
@@ -1361,4 +1363,10 @@ static int luaopen_rpm(lua_State *L)
 
     luaL_newlib(L, rpmlib);
     return 1;
+}
+
+void check_deprecated(lua_State *L, const char *func)
+{
+    fprintf(stderr,
+	"warning: %s(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead\n", func);
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1092,7 +1092,8 @@ runroot rpm \
 ],
 [1],
 [],
-[error: lua script failed: [[string "<lua>"]]:1: redirect2null not permitted in this context]
+[warning: rpm.redirect2null(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead
+error: lua script failed: [[string "<lua>"]]:1: redirect2null not permitted in this context]
 )
 RPMTEST_CLEANUP
 
@@ -1565,6 +1566,7 @@ cat stderr | sort
 [0],
 [warning: posix.fork(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead
 warning: posix.wait(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead
+warning: rpm.redirect2null(): .fork(), .exec(), .wait() and .redirect2null() are deprecated, use rpm.spawn() or rpm.execute() instead
 warning: runaway fork() in Lua script
 ],
 [])


### PR DESCRIPTION
Commit 46bd0ed2a9e70f942e7c58f953f30a66d30a5142 did document rpm.redirect2null() as deprecated but failed to add an actual warning on it. Meaning no existing user will notice it being deprecated, unless they were also using some of the other deprecated items too.

Turn check_deprecated() into an actual function for better control, we'll have use for that later on.