### PR TITLE
Pull in the main p7zip package to CI image instead of p7zip-plugins

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -43,7 +43,7 @@ RUN dnf -y install \
   which \
   elfutils binutils \
   findutils sed grep gawk diffutils file patch \
-  tar unzip gzip bzip2 cpio xz p7zip-plugins \
+  tar unzip gzip bzip2 cpio xz p7zip \
   pkgconfig \
   /usr/bin/systemd-sysusers \
   gdb-headless-14.2 \


### PR DESCRIPTION
The main convoluted reason for this change is that our build process primarily looks for 7za and falls back to 7z if not found. Which is all fine except when running the test-suite locally with p7zip installed, which will causes the uncompress tests to fail for no good reason.

p7zip-plugins contains the command 7z but we 7za from the main package handles this format just fine AFAICS, and is slightly smaller too so there's an additional reason to favor it in CI.