### PR TITLE
Force older gdb version in CI due to index create regression in 15.1

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -46,7 +46,7 @@ RUN dnf -y install \
   tar unzip gzip bzip2 cpio xz p7zip-plugins \
   pkgconfig \
   /usr/bin/systemd-sysusers \
-  /usr/bin/gdb-add-index \
+  gdb-headless-14.2 \
   dwz \
   fsverity-utils fsverity-utils-devel \
   pandoc \


### PR DESCRIPTION
gdb 15.1 causes our "rpmbuild debuginfo gdb index included" to fail because no index is created. Reported to Fedora bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2310156

Related: #3278