### PR TITLE
Eliminate hardcoded GPG references from user visible messages

### DIFF
--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -235,23 +235,29 @@ static int runGPG(sigTarget sigt, const char *sigfile)
     }
 
     if (!(pid = fork())) {
-	const char *tty = ttyname(STDIN_FILENO);
-	const char *gpg_path = NULL;
+	/* GnuPG needs extra setup, try to see if that's what we're running */
+	char *out = rpmExpand("%(", argv[0], " --version 2> /dev/null)", NULL);
+	int using_gpg = (strstr(out, "GnuPG") != NULL);
+	if (using_gpg) {
+	    const char *tty = ttyname(STDIN_FILENO);
+	    const char *gpg_path = NULL;
 
-	if (!getenv("GPG_TTY") && (!tty || setenv("GPG_TTY", tty, 0)))
-	    rpmlog(RPMLOG_WARNING, _("Could not set GPG_TTY to stdin: %m\n"));
+	    if (!getenv("GPG_TTY") && (!tty || setenv("GPG_TTY", tty, 0)))
+		rpmlog(RPMLOG_WARNING, _("Could not set GPG_TTY to stdin: %m\n"));
 
-	gpg_path = rpmExpand("%{?_gpg_path}", NULL);
-	if (gpg_path && *gpg_path != '\0')
-	    (void) setenv("GNUPGHOME", gpg_path, 1);
+	    gpg_path = rpmExpand("%{?_gpg_path}", NULL);
+	    if (gpg_path && *gpg_path != '\0')
+		(void) setenv("GNUPGHOME", gpg_path, 1);
+	}
+	free(out);
 
 	dup2(pipefd[0], STDIN_FILENO);
 	close(pipefd[1]);
 
 	rc = execve(argv[0], argv+1, environ);
 
-	rpmlog(RPMLOG_ERR, _("Could not exec %s: %s\n"), "gpg",
-			strerror(errno));
+	rpmlog(RPMLOG_ERR, _("Could not exec %s: %s\n"), argv[0],
+		strerror(errno));
 	_exit(EXIT_FAILURE);
     }
 
@@ -298,9 +304,11 @@ exit:
     } while (reaped == -1 && errno == EINTR);
 
     if (reaped == -1) {
-	rpmlog(RPMLOG_ERR, _("gpg waitpid failed (%s)\n"), strerror(errno));
+	rpmlog(RPMLOG_ERR, _("%s waitpid failed (%s)\n"), argv[0],
+		strerror(errno));
     } else if (!WIFEXITED(status) || WEXITSTATUS(status)) {
-	rpmlog(RPMLOG_ERR, _("gpg exec failed (%d)\n"), WEXITSTATUS(status));
+	rpmlog(RPMLOG_ERR, _("%s exec failed (%d)\n"), argv[0],
+		WEXITSTATUS(status));
     } else {
 	rc = 0;
     }
@@ -331,13 +339,13 @@ static rpmtd makeGPGSignature(Header sigh, int ishdr, sigTarget sigt)
 	goto exit;
 
     if (stat(sigfile, &st)) {
-	/* GPG failed to write signature */
-	rpmlog(RPMLOG_ERR, _("gpg failed to write signature\n"));
+	/* External command failed to write signature */
+	rpmlog(RPMLOG_ERR, _("failed to write signature\n"));
 	goto exit;
     }
 
     pktlen = st.st_size;
-    rpmlog(RPMLOG_DEBUG, "GPG sig size: %zd\n", pktlen);
+    rpmlog(RPMLOG_DEBUG, "OpenPGP sig size: %zd\n", pktlen);
     pkt = (uint8_t *)xmalloc(pktlen);
 
     {	FD_t fd;
@@ -354,7 +362,7 @@ static rpmtd makeGPGSignature(Header sigh, int ishdr, sigTarget sigt)
 	}
     }
 
-    rpmlog(RPMLOG_DEBUG, "Got %zd bytes of GPG sig\n", pktlen);
+    rpmlog(RPMLOG_DEBUG, "Got %zd bytes of OpenPGP sig\n", pktlen);
 
     /* Parse the signature, change signature tag as appropriate. */
     sigtd = makeSigTag(sigh, ishdr, pkt, pktlen);

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -996,6 +996,14 @@ cmp -s ${ORIG} ${NEW}; echo $?
 ],
 [])
 
+RPMTEST_CHECK([
+run rpmsign --define "__gpg_sign_cmd mumble" --key-id 1964C5FC --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+],
+[1],
+[],
+[error: Invalid sign command: mumble
+])
+
 # rpmsign --addsign <signed>
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1004,6 +1004,15 @@ run rpmsign --define "__gpg_sign_cmd mumble" --key-id 1964C5FC --addsign "${RPMT
 [error: Invalid sign command: mumble
 ])
 
+RPMTEST_CHECK([
+run rpmsign --define "__gpg /gnus/not/here" --key-id 1964C5FC --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+],
+[1],
+[],
+[error: Could not exec /gnus/not/here: No such file or directory
+error: /gnus/not/here exec failed (1)
+])
+
 # rpmsign --addsign <signed>
 RPMTEST_CHECK([
 RPMDB_INIT


### PR DESCRIPTION
More details in commit messages, executive summary:
Use the OpenPGP standard name or the configured+parsed signing command in messages as appropriate.
Refactor a bit to make that possible + add some error checks + tests while at it.

Fixes: #3274