### PR TITLE
Specify the private key in "rpm --addsign"

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -917,7 +917,7 @@ AT_SETUP([rpmsign --addsign])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
-gpg2 --import ${RPMTEST}/data/keys/*.secret
+gpg2 --import ${RPMTEST}/data/keys/rpm.org-rsa-2048-test.secret
 # Our keys have no passphrases to be asked, silence GPG_TTY warning
 export GPG_TTY=""
 


### PR DESCRIPTION
Using "*.secret" may cause "rpm --addsign" to fail, and the testcase is actually related only to rpm.org-rsa-2048-test.secret.

Fix https://github.com/rpm-software-management/rpm/issues/3277