### PR TITLE
Support signing with Sequoia through a simple macro switch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ function(makemacros)
 	findutil(__AS as)
 	findutil(__CPP cpp)
 	findutil(__CXX c++)
+	findutil(__SQ sq)
 
 	list(GET db_backends 0 DB_BACKEND)
 

--- a/docs/man/rpmsign.8.md
+++ b/docs/man/rpmsign.8.md
@@ -97,31 +97,37 @@ SIGN OPTIONS
 CONFIGURING SIGNING KEYS
 ------------------------
 
-In order to sign packages, you need to create your own public and secret
-key pair (see the GnuPG manual). In addition, **rpm** must be configured to
-find GnuPG and the appropriate keys with the following macros:
+In order to sign packages, you need to create your own OpenPGP key pair
+(aka certificate) and configure **rpm** to use it. The following macros are
+available:
 
-**%\_gpg\_name**
+**%\_openpgp_sign_id**
 
-:   The name of the \"user\" whose key you wish to use to sign your
-    packages. Typically this is the only configuration needed.
+:   The fingerprint or keyid of the signing key to use. Typically
+    this is the only configuration needed. If omitted,
+    **--key-id** must be explicitly specified when signing.
+
+**%\_openpgp_sign**
+
+:   The OpenPGP implementation to use for signing. Supported values are
+    \"gpg\" for GnuPG (default and traditional) and \"sq\" for Sequoia PGP.
+
+Implementation specific macros:
 
 **%\_gpg\_path**
 
 :   The location of your GnuPG keyring if not the default **\$GNUPGHOME**.
 
+**%\_gpg\_name**
 
-**%\_\_gpg**
+:   Legacy macro for configuring user id with GnuPG. Use the implementation
+    independent and non-ambiguous **%\_openpgp_sign_id** instead.
 
-:   The path of the GnuPG executable. Normally pre-configured.
+For example, to configure rpm to sign with Sequoia PGP using a key with
+fingerprint of 7B36C3EE0CCE86EDBC3EFF2685B274E29F798E08 you would include
 
-For example, to be able to use GnuPG to sign packages as the user *\"John
-Doe \<jdoe\@foo.com\>\"* from the key rings located in */etc/rpm/.gpg*
-using the executable */opt/bin/gpg* you would include
-
-    %_gpg_path /etc/rpm/.gpg
-    %_gpg_name John Doe <jdoe@foo.com>
-    %__gpg /opt/bin/gpg
+%_openpgp_sign sq
+%_openpgp_signer 7B36C3EE0CCE86EDBC3EFF2685B274E29F798E08
 
 in a macro configuration file, typically ~/.config/rpm/macros.
 See **Macro Configuration** in **rpm**(8) for more details.

--- a/macros.in
+++ b/macros.in
@@ -30,7 +30,6 @@
 %__chown		@__CHOWN@
 %__cp			@__CP@
 %__file			@__FILE@
-%__gpg			@__GPG@
 %__grep			@__GREP@
 %__gzip			@__GZIP@
 %__id			@__ID@
@@ -325,10 +324,16 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	marked as %doc should be installed.
 #%_excludedocs
 
-#	The signature to use and the location of configuration files for
-#	signing packages with GNU gpg.
+# OpenPGP implementation to use: "sq" for Sequoia and "gpg" for GnuPG
+%_openpgp_sign gpg
+
+#	The signer ID (fingerprint or keyid) to use for signing
+#	Default to %_gpg_name for backwards compatibility
+%_openpgp_sign_id %{?_gpg_name}
+
+#	GnuPG signing additionally supports specifying the location of
+#	its configuration files (GNUPGHOME) via %_gpg_path if needed
 #
-#%_gpg_name
 #%_gpg_path
 
 #	The port and machine name of an HTTP proxy host (used for FTP/HTTP).
@@ -606,18 +611,30 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %_db_backend	      @DB_BACKEND@
 
 #==============================================================================
-# ---- GPG/PGP/PGP5 signature macros.
-#	Macro(s) to hold the arguments passed to GPG/PGP for package
+# ---- OpenPGP signature macros.
+#	Macro(s) to hold the arguments passed to the cmd implementing package
 #	signing.  Expansion result is parsed by popt, so be sure to use
 #	%{shescape} where needed.
 #
+%__gpg			@__GPG@
 %__gpg_sign_cmd			%{shescape:%{__gpg}} \
 	gpg --no-verbose --no-armor --no-secmem-warning \
 	%{?_gpg_digest_algo:--digest-algo=%{_gpg_digest_algo}} \
 	%{?_gpg_sign_cmd_extra_args} \
-	%{?_gpg_name:-u %{shescape:%{_gpg_name}}} \
+	%{?_openpgp_sign_id:-u %{shescape:%{_openpgp_sign_id}}} \
 	-sbo %{shescape:%{?__signature_filename}} \
 	%{?__plaintext_filename:-- %{shescape:%{__plaintext_filename}}}
+
+%__sq @__SQ@
+%__sq_sign_cmd		%{shescape:%{__sq}} \
+	%{__sq} sign \
+        %{?_openpgp_sign_id:--signer-key %{_openpgp_sign_id}} \
+	%{?_sq_sign_cmd_extra_args} \
+        --detached -o %{shescape:%{?__signature_filename}} \
+        %{?__plaintext_filename:-- %{shescape:%{__plaintext_filename}}}
+
+%__openpgp_sign_path %{expand:%{__%{_openpgp_sign}}}
+%__openpgp_sign_cmd %{expand:%{__%{_openpgp_sign}_sign_cmd}}
 
 #==============================================================================
 # ---- Transaction macros.

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -199,7 +199,7 @@ char ** signCmd(const char *sigfile)
     rpmPushMacro(NULL, "__plaintext_filename", NULL, "-", -1);
     rpmPushMacro(NULL, "__signature_filename", NULL, sigfile, -1);
 
-    char *cmd = rpmExpand("%{?__gpg_sign_cmd}", NULL);
+    char *cmd = rpmExpand("%{?__openpgp_sign_cmd}", NULL);
 
     rpmPopMacro(NULL, "__plaintext_filename");
     rpmPopMacro(NULL, "__signature_filename");
@@ -797,7 +797,7 @@ int rpmPkgSign(const char *path, const struct rpmSignArgs * args)
 	    free(algo);
 	}
 	if (args->keyid) {
-	    rpmPushMacro(NULL, "_gpg_name", NULL, args->keyid, RMIL_GLOBAL);
+	    rpmPushMacro(NULL, "_opengpg_sign_id", NULL, args->keyid, RMIL_GLOBAL);
 	}
     }
 
@@ -808,7 +808,7 @@ int rpmPkgSign(const char *path, const struct rpmSignArgs * args)
 	    rpmPopMacro(NULL, "_gpg_digest_algo");
 	}
 	if (args->keyid) {
-	    rpmPopMacro(NULL, "_gpg_name");
+	    rpmPopMacro(NULL, "_openpgp_sign_id");
 	}
     }
 

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -50,6 +50,7 @@ RUN dnf -y install \
   dwz \
   fsverity-utils fsverity-utils-devel \
   pandoc \
+  sequoia-sq \
   libasan \
   libubsan \
   && dnf clean all

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1052,6 +1052,51 @@ echo $?
 gpgconf --kill gpg-agent
 RPMTEST_CLEANUP
 
+# Signing test(s) using Sequoia
+# stderr is ignored due to noisy failures from gpgconf which we don't
+# care about in this test...
+AT_SETUP([rpmsign --addsign sequoia])
+AT_KEYWORDS([rpmsign signature])
+AT_SKIP_IF([test x$PGP = xdummy])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+cat << EOF > ${HOME}/.rpmmacros
+%_openpgp_sign sq
+%_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
+EOF
+
+runroot_other sq key import /data/keys/rpm.org-rsa-2048-test.secret
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
+runroot rpmsign --addsign /tmp/hello-2.0-1.x86_64.rpm > /dev/null
+echo PRE-IMPORT
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+echo POST-IMPORT
+runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+run rpmsign --delsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+echo POST-DELSIGN
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+],
+[0],
+[PRE-IMPORT
+/tmp/hello-2.0-1.x86_64.rpm:
+    Header V4 RSA/SHA512 Signature, key ID 1964c5fc: NOKEY
+POST-IMPORT
+/tmp/hello-2.0-1.x86_64.rpm:
+    Header V4 RSA/SHA512 Signature, key ID 1964c5fc: OK
+POST-DELSIGN
+/tmp/hello-2.0-1.x86_64.rpm:
+],
+[ignore])
+RPMTEST_CLEANUP
+
 # ------------------------------
 # Test --delsign
 AT_SETUP([rpmsign --delsign])
@@ -1162,6 +1207,6 @@ POST-IMPORT
     Header V4 ECDSA/SHA256 Signature, key ID 5f65bbe8: OK
 ],
 [])
+
 gpgconf --kill gpg-agent
 RPMTEST_CLEANUP
-

--- a/tools/rpmsign.c
+++ b/tools/rpmsign.c
@@ -126,10 +126,10 @@ exit:
 static int doSign(poptContext optCon, struct rpmSignArgs *sargs)
 {
     int rc = EXIT_FAILURE;
-    char * name = rpmExpand("%{?_gpg_name}", NULL);
+    char * name = rpmExpand("%{?_openpgp_sign_id}", NULL);
 
     if (rstreq(name, "")) {
-	fprintf(stderr, _("You must set \"%%_gpg_name\" in your macro file\n"));
+	fprintf(stderr, _("You must set \"%%_openpgp_sign_id\" in your macro file\n"));
 	goto exit;
     }
 


### PR DESCRIPTION
Add new %_openpgp_sign macro to select between implementations, currently "gpg" for GnuPG and "sq" for Sequoia are supported. Also introduced is a new macro for specifying the signing key in the configuration: %_openpgp_signer. Whereas GnuPG allows arbitrary string match to be used for key selection, Sequoia requires a keyid or fingerprint to be specified. So %_gpg_name is an ill-fitting name for the configuration, both for being GPG-centric and "name" being misleading. Explicitly specifying the keyid/fingerprint is less ambiguous anyhow.

Minimally preserve backwards compatibility for %_gpg_name (the only configuration people normally need) by setting %_openpgp_signer to %_gpg_name by default, and still defaulting to the gpg implementation.

Update rpmsign manual to cover the new macros and remove obsolete details - manually specifying the paths and all still works but is not something users are expected to muck with. It was different in the nineties when this was originally added...

Fixes: #3248