### PR TITLE
Add test for spurious %transfiletriggerpostun runs

### DIFF
--- a/tests/data/SPECS/filetriggers-prefix.spec
+++ b/tests/data/SPECS/filetriggers-prefix.spec
@@ -33,7 +33,14 @@ echo "transfiletriggerun:"
 cat | xargs dirname | uniq
 echo
 
-%transfiletriggerpostun -- /usr/bin /foo /etc
-echo "transfiletriggerpostun"
+%transfiletriggerpostun -- /usr/bin /etc
+echo "transfiletriggerpostun:"
+echo /usr/bin
+echo
+
+%transfiletriggerpostun -- /opt /foo
+echo "transfiletriggerpostun:"
+echo /foo
+echo
 
 %files

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -578,7 +578,9 @@ filetriggerun:
 filetriggerpostun:
 /usr/bin
 
-transfiletriggerpostun
+transfiletriggerpostun:
+/usr/bin
+
 ],
 [])
 
@@ -602,7 +604,9 @@ filetriggerun:
 filetriggerpostun:
 /foo
 
-transfiletriggerpostun
+transfiletriggerpostun:
+/foo
+
 ],
 [])
 
@@ -638,7 +642,12 @@ filetriggerun:
 filetriggerpostun:
 /usr/bin
 
-transfiletriggerpostun
+transfiletriggerpostun:
+/usr/bin
+
+transfiletriggerpostun:
+/foo
+
 ],
 [])
 


### PR DESCRIPTION
Commit 0988ccb53abf426587d228df5c60c4042da71999 fixed the case where any matching %transfiletriggerpostun would cause all of them to run.  Add a second trigger instance to the respective test spec to cover that.

To differentiate the instances, print the triggering prefix (this is not passed via stdin to this trigger type but we know which one it is here).

In the spirit of commit 3f1d05eae9079501ce94a106be40b9a18cd40018, add an unused prefix /opt so that /foo is the second argument.

Fixes: #3272