### PR TITLE
Declare signCmd() static

### DIFF
--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -191,7 +191,7 @@ exit:
     return sigtd;
 }
 
-char ** signCmd(const char *sigfile)
+static char ** signCmd(const char *sigfile)
 {
     int argc = 0;
     char **argv = NULL;


### PR DESCRIPTION
Commit 2c9ad2bbc1d00010880076cd5c73e97ffcb946ed added this new helper function for internal use and depite a missing declaration, the compiler defaulting to WITH_CXX=ON on master chugged along just fine... only until porting the same commit to a C-only branch (hello rpm-4.20.x) where it now produces a warning.