### PR TITLE
Fix regression preventing manual %debug_package usage

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -195,11 +195,12 @@ package or when debugging this package.\
 %{nil}
 
 # The duplicate __debug_package definition is needed to ensure matching
-# state when %install is skipped due to short-circuit.
+# state when %install is skipped due to short-circuit, IFF buildsubdir
+# is defined (indicating use of automatic debuginfo generation)
 %debug_package \
 %ifnarch noarch\
 %global __debug_package 1\
-%%global __debug_package 1\
+%{?buildsubdir:%%global __debug_package 1}\
 %_debuginfo_template\
 %{?_debugsource_packages:%_debugsource_template}\
 %endif\

--- a/tests/data/SPECS/manualdebug.spec
+++ b/tests/data/SPECS/manualdebug.spec
@@ -1,0 +1,31 @@
+%global __os_install_post %{nil}
+Name: manualdebug
+Version: 0.1
+Release: 1
+License: GPL
+Summary: Testing manual debug_package use
+
+%description
+%{summary}
+
+%prep
+cat << EOF > main.c
+#include <stdio.h>
+int main(int argc, char *argv[])
+{
+	printf("hello\n");
+	return 0;
+}
+EOF
+
+%build
+gcc -g main.c
+
+%install
+mkdir -p $RPM_BUILD_ROOT/usr/bin
+cp a.out $RPM_BUILD_ROOT/usr/bin/hello-world
+
+%files
+/usr/bin/hello-world
+
+%debug_package

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2499,6 +2499,18 @@ runroot rpmbuild --quiet -bb \
 [ignore])
 RPMTEST_CLEANUP
 
+AT_SETUP([manual %debug_package use])
+AT_KEYWORDS([build debuginfo])
+RPMDB_INIT
+RPMTEST_CHECK([
+runroot rpmbuild -bb \
+		/data/SPECS/manualdebug.spec
+],
+[0],
+[ignore],
+[ignore])
+RPMTEST_CLEANUP
+
 AT_SETUP([explicit %_enable_debug_package on noarch])
 AT_KEYWORDS([build debuginfo])
 RPMTEST_CHECK([


### PR DESCRIPTION
Apparently rpmfluff creates specs that invoke the %debug_package macro directly, and commit 1a9803d0f8daf15bb706dc17783ab19589906487 broke that: when the literal unexpanded %global ends up inside a spec, it'll trigger various errors depending on the exact context.

rpmfluff is using this manual method because there's no %setup in the produced spec and so, no %buildsubdir is defined and so, no debuginfo packages produced. Conditionalize writing the escaped %global on %buildsubdir being defined, a condition where automatic debuginfo packages normally would be generated anyhow. It may not be ideal but I think it'll do for now.

Fixes: #3290