### PR TITLE
A more compatible kludge for #3278

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -46,7 +46,7 @@ RUN dnf -y install \
   tar unzip gzip bzip2 cpio xz p7zip \
   pkgconfig \
   /usr/bin/systemd-sysusers \
-  gdb-headless-14.2 \
+  "gdb-headless < 15" \
   dwz \
   fsverity-utils fsverity-utils-devel \
   pandoc \


### PR DESCRIPTION
The one from commit 8ce8afe4f9b303ddb347def7389676b5cf715b38 doesn't work on Fedora 39, but since dnf appears to merrily take a version range on the cli...