### PR TITLE
Make sequoia signing work with sequoia-sq >= 0.38

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -631,7 +631,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 	%{__sq} sign \
         %{?_openpgp_sign_id:--signer-key %{_openpgp_sign_id}} \
 	%{?_sq_sign_cmd_extra_args} \
-        --detached -o %{shescape:%{?__signature_filename}} \
+        --detached --output %{shescape:%{?__signature_filename}} \
         %{?__plaintext_filename:-- %{shescape:%{__plaintext_filename}}}
 
 %__openpgp_sign_path %{expand:%{__%{_openpgp_sign}}}


### PR DESCRIPTION
sequoia-sq 0.38 removed all short options, at least temporarily: https://gitlab.com/sequoia-pgp/sequoia-sq/-/commit/f7ce1fa2a172ae02171a3421bebf2a4aa3cfb8a5

As that version got supplied to Fedora 40 as an update, we started getting intermittent failures where every other CI run failed due to it having the newer version that didn't accept the -o usage we just added in d99186f2ef6fc0dfaaefe599a98492a84fd18940. What a timing.

There's no reason why we couldn't just use the long ones though, it's more readable that way anyhow. Shrug and move on.

Fixes: #3317