### PR TITLE
Add Key Fingerprints to rpmsinfoMsg()

### DIFF
--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -72,12 +72,12 @@ rpmKeyring rpmKeyringLink(rpmKeyring keyring);
 rpmPubkey rpmPubkeyNew(const uint8_t *pkt, size_t pktlen);
 
 /** \ingroup rpmkeyring
- * Return array of subkeys belonging to mainkey
- * param mainkey	main rpmPubkey
+ * Return array of subkeys belonging to primarykey
+ * param primarykey	primary rpmPubkey
  * param count		count of returned subkeys
  * @return		an array of subkey's handles
  */
-rpmPubkey *rpmGetSubkeys(rpmPubkey mainkey, int *count);
+rpmPubkey *rpmGetSubkeys(rpmPubkey primarykey, int *count);
 
 /** \ingroup rpmkeyring
  * Create a new rpmPubkey from ASCII-armored pubkey file
@@ -106,6 +106,22 @@ rpmPubkey rpmPubkeyLink(rpmPubkey key);
  * @return              base64 encoded pubkey (malloced), NULL on error
  */
 char * rpmPubkeyBase64(rpmPubkey key);
+
+/** \ingroup rpmkeyring
+ * Return fingerprint of primary key
+ * @param key		Pubkey
+ * @param fp		Fingerprint data
+ * @param fplen		Length of Fingerprint
+ * @return		0 on success
+ */
+int rpmPubkeyFingerprint(rpmPubkey key, uint8_t **fp, size_t *fplen);
+
+/** \ingroup rpmkeyring
+ * Return fingerprint of primary key as hex string
+ * @param key		Pubkey
+ * @ return		string or NULL on failure
+ */
+char * rpmPubkeyFingerprintAsHex(rpmPubkey key);
 
 /** \ingroup rpmkeyring
  * Return pgp params of key

--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -57,6 +57,16 @@ int rpmKeyringAddKey(rpmKeyring keyring, rpmPubkey key);
 rpmRC rpmKeyringVerifySig(rpmKeyring keyring, pgpDigParams sig, DIGEST_CTX ctx);
 
 /** \ingroup rpmkeyring
+ * Perform combined keyring lookup and signature verification
+ * @param keyring	keyring handle
+ * @param sig		OpenPGP signature parameters
+ * @param ctx		signature hash context
+ * @param keyptr	matching key (refcounted)
+ * @return		RPMRC_OK / RPMRC_FAIL / RPMRC_NOKEY
+ */
+rpmRC rpmKeyringVerifySig2(rpmKeyring keyring, pgpDigParams sig, DIGEST_CTX ctx,  rpmPubkey * keyptr);
+
+/** \ingroup rpmkeyring
  * Reference a keyring.
  * @param keyring	keyring handle
  * @return		new keyring reference

--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -143,6 +143,7 @@ static void rpmsinfoInit(const struct vfyinfo_s *vinfo,
     *sinfo = vinfo->vi; /* struct assignment */
     sinfo->wrapped = (vinfo->sigh == 0);
     sinfo->strength = sinfo->type;
+    sinfo->key = NULL;
 
     if (td == NULL) {
 	rc = RPMRC_NOTFOUND;
@@ -246,6 +247,7 @@ static void rpmsinfoFini(struct rpmsinfo_s *sinfo)
 	else if (sinfo->type == RPMSIG_DIGEST_TYPE)
 	    free(sinfo->dig);
 	rpmDigestFinal(sinfo->ctx, NULL, NULL, 0);
+	rpmPubkeyFree(sinfo->key);
 	free(sinfo->msg);
 	free(sinfo->descr);
 	memset(sinfo, 0, sizeof(*sinfo));
@@ -590,9 +592,9 @@ static rpmRC
 verifySignature(rpmKeyring keyring, struct rpmsinfo_s *sinfo)
 {
     rpmRC res = RPMRC_FAIL;
-    if (pgpSignatureType(sinfo->sig) == PGPSIGTYPE_BINARY)
-	res = rpmKeyringVerifySig(keyring, sinfo->sig, sinfo->ctx);
-
+    if (pgpSignatureType(sinfo->sig) == PGPSIGTYPE_BINARY) {
+	res = rpmKeyringVerifySig2(keyring, sinfo->sig, sinfo->ctx, &sinfo->key);
+    }
     return res;
 }
 

--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -306,13 +306,25 @@ const char *rpmsinfoDescr(struct rpmsinfo_s *sinfo)
 char *rpmsinfoMsg(struct rpmsinfo_s *sinfo)
 {
     char *msg = NULL;
-    if (sinfo->msg) {
-	rasprintf(&msg, "%s: %s (%s)",
-		rpmsinfoDescr(sinfo), rpmSigString(sinfo->rc), sinfo->msg);
-    } else {
-	rasprintf(&msg, "%s: %s",
-		rpmsinfoDescr(sinfo), rpmSigString(sinfo->rc));
+    char *fphex = NULL;
+    char *fpmsg = NULL;
+    if (sinfo->rc == RPMRC_OK && sinfo->key) {
+	fphex = rpmPubkeyFingerprintAsHex(sinfo->key);
     }
+    if (fphex)
+	rasprintf(&fpmsg, _(", key fingerprint: %s"), fphex);
+    else
+	rstrcat(&fpmsg, "");
+
+    if (sinfo->msg) {
+	rasprintf(&msg, "%s%s: %s (%s)",
+		  rpmsinfoDescr(sinfo), fpmsg, rpmSigString(sinfo->rc), sinfo->msg);
+    } else {
+	rasprintf(&msg, "%s%s: %s",
+		  rpmsinfoDescr(sinfo), fpmsg, rpmSigString(sinfo->rc));
+    }
+    free(fphex);
+    free(fpmsg);
     return msg;
 }
 

--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -309,7 +309,7 @@ char *rpmsinfoMsg(struct rpmsinfo_s *sinfo)
     char *fphex = NULL;
     char *fpmsg = NULL;
     char * descr = xstrdup(rpmsinfoDescr(sinfo));
-    if (sinfo->rc == RPMRC_OK && sinfo->key) {
+    if (sinfo->key) {
 	fphex = rpmPubkeyFingerprintAsHex(sinfo->key);
     }
     if (fphex) {

--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -308,21 +308,27 @@ char *rpmsinfoMsg(struct rpmsinfo_s *sinfo)
     char *msg = NULL;
     char *fphex = NULL;
     char *fpmsg = NULL;
+    char * descr = xstrdup(rpmsinfoDescr(sinfo));
     if (sinfo->rc == RPMRC_OK && sinfo->key) {
 	fphex = rpmPubkeyFingerprintAsHex(sinfo->key);
     }
-    if (fphex)
-	rasprintf(&fpmsg, _(", key fingerprint: %s"), fphex);
-    else
+    if (fphex) {
+	rasprintf(&fpmsg, _(", Key Fingerprint: %s"), fphex);
+	char * pos = strstr(descr, ", key ID");
+	if (pos)
+	    *pos = '\0';
+    } else {
 	rstrcat(&fpmsg, "");
+    }
 
     if (sinfo->msg) {
 	rasprintf(&msg, "%s%s: %s (%s)",
-		  rpmsinfoDescr(sinfo), fpmsg, rpmSigString(sinfo->rc), sinfo->msg);
+		  descr, fpmsg, rpmSigString(sinfo->rc), sinfo->msg);
     } else {
 	rasprintf(&msg, "%s%s: %s",
-		  rpmsinfoDescr(sinfo), fpmsg, rpmSigString(sinfo->rc));
+		  descr, fpmsg, rpmSigString(sinfo->rc));
     }
+    free(descr);
     free(fphex);
     free(fpmsg);
     return msg;

--- a/lib/rpmvs.h
+++ b/lib/rpmvs.h
@@ -23,6 +23,7 @@ struct rpmsinfo_s {
     int id;
     int wrapped;
     int strength;
+    rpmPubkey key;
     unsigned int keyid;
     union {
 	pgpDigParams sig;

--- a/rpmio/rpmkeyring.c
+++ b/rpmio/rpmkeyring.c
@@ -321,7 +321,7 @@ static rpmPubkey findbySig(rpmKeyring keyring, pgpDigParams sig)
     return key;
 }
 
-rpmRC rpmKeyringVerifySig(rpmKeyring keyring, pgpDigParams sig, DIGEST_CTX ctx)
+rpmRC rpmKeyringVerifySig2(rpmKeyring keyring, pgpDigParams sig, DIGEST_CTX ctx, rpmPubkey * keyptr)
 {
     rpmRC rc = RPMRC_FAIL;
 
@@ -339,7 +339,15 @@ rpmRC rpmKeyringVerifySig(rpmKeyring keyring, pgpDigParams sig, DIGEST_CTX ctx)
 	    rpmlog(rc ? RPMLOG_ERR : RPMLOG_WARNING, "%s\n", lints);
 	    free(lints);
 	}
+	if (keyptr) {
+	    *keyptr = pubkeyPrimarykey(key);
+	}
     }
 
     return rc;
+}
+
+rpmRC rpmKeyringVerifySig(rpmKeyring keyring, pgpDigParams sig, DIGEST_CTX ctx)
+{
+    return rpmKeyringVerifySig2(keyring, sig, ctx, NULL);
 }

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -53,7 +53,7 @@ char *pgpIdentItem(pgpDigParams digp)
 {
     char *id = NULL;
     if (digp) {
-        char *signid = rpmhex(pgpDigParamsSignID(digp) + 4, PGP_KEYID_LEN - 4);
+        char *signid = rpmhex(pgpDigParamsSignID(digp), PGP_KEYID_LEN);
 	rasprintf(&id, _("V%d %s/%s %s, key ID %s"),
                   pgpDigParamsVersion(digp),
                   pgpValString(PGPVAL_PUBKEYALGO,

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -292,7 +292,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ],
 [0],
 [],
-[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 ])
 RPMTEST_CLEANUP
 
@@ -308,8 +308,8 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ],
 [1],
 [],
-[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 ])
 RPMTEST_CLEANUP
 
@@ -387,7 +387,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ],
 [1],
 [],
-[error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+[error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
 error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
 error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header SHA1 digest: BAD (Expected 5cd9874c510b67b44483f9e382a1649ef7743bac != 4261b2c1eb861a4152c2239bce20bfbcaa8971ba)
 error: /tmp/hello-2.0-1.x86_64-signed.rpm cannot be installed
@@ -434,19 +434,19 @@ runroot rpm -U --ignorearch --ignoreos --nodeps --noverify \
 ],
 [1],
 [INSTALL 1
-warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 INSTALL 2
 error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 INSTALL 3
-warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 INSTALL 4
 	package hello-2.0-1.x86_64 does not verify: no signature
 INSTALL 5
-warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 ],

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -418,7 +418,7 @@ runroot rpm \
 ],
 [0],
 [RSA/SHA256, Thu Apr  6 13:02:33 2017, Key ID 4344591e1964c5fc],
-[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 ])
 RPMTEST_CLEANUP
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -922,7 +922,7 @@ RPMTEST_CHECK([
 RPMDB_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
-run rpmsign --key-id 1964C5FC --rpmv3 --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+run rpmsign --key-id 4344591E1964C5FC --rpmv3 --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
 echo PRE-IMPORT
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 echo POST-IMPORT
@@ -951,7 +951,7 @@ RPMTEST_CHECK([
 RPMDB_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
-run rpmsign --key-id 1964C5FC --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+run rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
 echo PRE-IMPORT
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 echo POST-IMPORT
@@ -981,7 +981,7 @@ ORIG="${RPMTEST}/data/RPMS/hello-2.0-1.x86_64.rpm"
 NEW="${RPMTEST}/tmp/hello-2.0-1.x86_64.rpm"
 
 cp ${ORIG} "${RPMTEST}"/tmp/
-run rpmsign --key-id 1964C5FC --addsign ${NEW} > /dev/null
+run rpmsign --key-id 4344591E1964C5FC --addsign ${NEW} > /dev/null
 cmp -s ${ORIG} ${NEW}; echo $?
 run rpmsign --delsign ${NEW} > /dev/null
 cmp -s ${ORIG} ${NEW}; echo $?
@@ -1014,7 +1014,7 @@ RPMTEST_CHECK([
 RPMDB_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64-signed.rpm "${RPMTEST}"/tmp/
-run rpmsign --key-id 1964C5FC --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64-signed.rpm 2>&1 |grep -q "already contains identical signature, skipping"
+run rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64-signed.rpm 2>&1 |grep -q "already contains identical signature, skipping"
 ],
 [0],
 [],
@@ -1030,7 +1030,7 @@ pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
 dd if=/dev/zero of="${RPMTEST}"/tmp/${pkg} \
    conv=notrunc bs=1 seek=333 count=4 2> /dev/null
-runroot rpmsign --define "_pkgverify_flags 0" --key-id 1964C5FC --digest-algo sha256 --addsign "/tmp/${pkg}"
+runroot rpmsign --define "_pkgverify_flags 0" --key-id 4344591E1964C5FC --digest-algo sha256 --addsign "/tmp/${pkg}"
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
@@ -1186,7 +1186,7 @@ RPMTEST_CHECK([
 RPMDB_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
-run rpmsign --key-id 757BF69E --digest-algo sha512 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+run rpmsign --key-id B0645AEC757BF69E --digest-algo sha512 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
 echo PRE-IMPORT
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 echo POST-IMPORT
@@ -1219,7 +1219,7 @@ RPMTEST_CHECK([
 RPMDB_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
-run rpmsign --key-id 5F65BBE8 --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+run rpmsign --key-id 7f1c21f95f65bbe8 --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
 echo PRE-IMPORT
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 echo POST-IMPORT

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -353,13 +353,13 @@ Checking for key:
 Version     : eb04e625
 Checking package after importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
+    Header V4 RSA/SHA512 Signature, Key Fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 0
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
+    Header V4 RSA/SHA512 Signature, Key Fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
     RSA signature: NOTFOUND
@@ -688,24 +688,24 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo
 1
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V3 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V3 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V3 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V3 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
     Header SHA256 digest: OK
@@ -754,7 +754,7 @@ RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-confo
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 ],
 [])
 RPMTEST_CLEANUP
@@ -856,7 +856,7 @@ runroot rpmkeys -Kv /tmp/${pkg}
     V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
@@ -896,7 +896,7 @@ dorpm -Kv
     MD5 digest: OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm: DIGESTS SIGNATURES NOT OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
@@ -939,8 +939,8 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -967,7 +967,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1118,7 +1118,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     Header V4 RSA/SHA512 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA512 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1199,7 +1199,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     Header V4 EdDSA/SHA512 Signature, key ID b0645aec757bf69e: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA512 Signature, key ID b0645aec757bf69e, key fingerprint: 152bb32fd9ca982797e835cfb0645aec757bf69e: OK
+    Header V4 EdDSA/SHA512 Signature, Key Fingerprint: 152bb32fd9ca982797e835cfb0645aec757bf69e: OK
 ],
 [])
 gpgconf --kill gpg-agent
@@ -1232,7 +1232,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     Header V4 ECDSA/SHA256 Signature, key ID 7f1c21f95f65bbe8: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 ECDSA/SHA256 Signature, key ID 7f1c21f95f65bbe8, key fingerprint: e8a62c0512b06b5d2183ba207f1c21f95f65bbe8: OK
+    Header V4 ECDSA/SHA256 Signature, Key Fingerprint: e8a62c0512b06b5d2183ba207f1c21f95f65bbe8: OK
 ],
 [])
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -416,7 +416,7 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
-    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOTTRUSTED
+    Header V4 RSA/SHA512 Signature, Key Fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
@@ -430,7 +430,7 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
-    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOTTRUSTED
+    Header V4 RSA/SHA512 Signature, Key Fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header DSA signature: NOTFOUND
     RSA signature: NOTFOUND
     DSA signature: NOTFOUND
@@ -484,7 +484,7 @@ Checking package after importing key:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
-    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOTTRUSTED
+    Header V4 RSA/SHA512 Signature, Key Fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
@@ -496,7 +496,7 @@ Checking package after importing key, no digest:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
-    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOTTRUSTED
+    Header V4 RSA/SHA512 Signature, Key Fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header DSA signature: NOTFOUND
     RSA signature: NOTFOUND
     DSA signature: NOTFOUND
@@ -785,11 +785,11 @@ runroot rpmkeys -Kv /tmp/${pkg}
     V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
+    Header V3 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
+    V3 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 ],
 [])
@@ -820,11 +820,11 @@ runroot rpmkeys -Kv /tmp/${pkg}
     V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
+    V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 ],
 [])
@@ -860,7 +860,7 @@ runroot rpmkeys -Kv /tmp/${pkg}
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
+    V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     DSA signature: NOTFOUND
     MD5 digest: NOTFOUND
 ],

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -340,7 +340,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [[Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOKEY
     Header DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
@@ -353,13 +353,13 @@ Checking for key:
 Version     : eb04e625
 Checking package after importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: OK
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 0
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: OK
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
     RSA signature: NOTFOUND
@@ -398,7 +398,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOKEY
     Header DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
@@ -416,7 +416,7 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOTTRUSTED
     Header DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
@@ -430,7 +430,7 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOTTRUSTED
     Header DSA signature: NOTFOUND
     RSA signature: NOTFOUND
     DSA signature: NOTFOUND
@@ -468,7 +468,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOKEY
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOKEY
     Header DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
@@ -484,7 +484,7 @@ Checking package after importing key:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOTTRUSTED
     Header DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
@@ -496,7 +496,7 @@ Checking package after importing key, no digest:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
-    Header V4 RSA/SHA512 Signature, key ID 15217ee0: NOTTRUSTED
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOTTRUSTED
     Header DSA signature: NOTFOUND
     RSA signature: NOTFOUND
     DSA signature: NOTFOUND
@@ -675,37 +675,37 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo
 ],
 [0],
 [/data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 1
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 1
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 1964c5fc: OK
-    V3 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
     Header SHA256 digest: OK
@@ -745,7 +745,7 @@ RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-confo
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 /tmp/hello-2.0-1.x86_64-signed.rpm:
 RPMOUTPUT_LEGACY([    Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: Signature without creation time)])dnl
 RPMOUTPUT_SEQUOIA([    Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
@@ -754,7 +754,7 @@ RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-confo
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
 ],
 [])
 RPMTEST_CLEANUP
@@ -778,18 +778,18 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 ],
 [])
@@ -813,18 +813,18 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 ],
 [])
@@ -849,18 +849,18 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: BAD
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     DSA signature: NOTFOUND
     MD5 digest: NOTFOUND
 ],
@@ -891,12 +891,12 @@ dorpm -Kv
 [0],
 [[/data/RPMS/hello-2.0-1.x86_64-corrupted.rpm: digests SIGNATURES NOT OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     MD5 digest: OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm: DIGESTS SIGNATURES NOT OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
@@ -935,12 +935,12 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -964,10 +964,10 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1115,10 +1115,10 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 1964c5fc: NOKEY
+    Header V4 RSA/SHA512 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA512 Signature, key ID 4344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1143,8 +1143,8 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64-signed.rpm|grep -v digest
 [0],
 [PRE-DELSIGN
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64-signed.rpm:
 ],
@@ -1196,10 +1196,10 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA512 Signature, key ID 757bf69e: NOKEY
+    Header V4 EdDSA/SHA512 Signature, key ID b0645aec757bf69e: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA512 Signature, key ID 757bf69e: OK
+    Header V4 EdDSA/SHA512 Signature, key ID b0645aec757bf69e: OK
 ],
 [])
 gpgconf --kill gpg-agent
@@ -1229,10 +1229,10 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 ECDSA/SHA256 Signature, key ID 5f65bbe8: NOKEY
+    Header V4 ECDSA/SHA256 Signature, key ID 7f1c21f95f65bbe8: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 ECDSA/SHA256 Signature, key ID 5f65bbe8: OK
+    Header V4 ECDSA/SHA256 Signature, key ID 7f1c21f95f65bbe8: OK
 ],
 [])
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -353,13 +353,13 @@ Checking for key:
 Version     : eb04e625
 Checking package after importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: OK
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 0
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: OK
+    Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
     RSA signature: NOTFOUND
@@ -688,24 +688,24 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo
 1
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
-    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V3 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
     Header SHA256 digest: OK
@@ -754,7 +754,7 @@ RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-confo
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 ],
 [])
 RPMTEST_CLEANUP
@@ -856,7 +856,7 @@ runroot rpmkeys -Kv /tmp/${pkg}
     V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
@@ -896,7 +896,7 @@ dorpm -Kv
     MD5 digest: OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm: DIGESTS SIGNATURES NOT OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
@@ -939,8 +939,8 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -967,7 +967,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1118,7 +1118,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     Header V4 RSA/SHA512 Signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA512 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA512 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1199,7 +1199,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     Header V4 EdDSA/SHA512 Signature, key ID b0645aec757bf69e: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA512 Signature, key ID b0645aec757bf69e: OK
+    Header V4 EdDSA/SHA512 Signature, key ID b0645aec757bf69e, key fingerprint: 152bb32fd9ca982797e835cfb0645aec757bf69e: OK
 ],
 [])
 gpgconf --kill gpg-agent
@@ -1232,7 +1232,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
     Header V4 ECDSA/SHA256 Signature, key ID 7f1c21f95f65bbe8: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 ECDSA/SHA256 Signature, key ID 7f1c21f95f65bbe8: OK
+    Header V4 ECDSA/SHA256 Signature, key ID 7f1c21f95f65bbe8, key fingerprint: e8a62c0512b06b5d2183ba207f1c21f95f65bbe8: OK
 ],
 [])
 

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -319,7 +319,7 @@ done
 [0],
 [nopls
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
@@ -327,7 +327,7 @@ done
 0
 noplds
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: NOTFOUND
@@ -341,7 +341,7 @@ nohdrs
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     MD5 digest: OK
 0
 nosig

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -319,7 +319,7 @@ done
 [0],
 [nopls
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
@@ -327,7 +327,7 @@ done
 0
 noplds
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: NOTFOUND
@@ -341,7 +341,7 @@ nohdrs
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    V4 RSA/SHA256 Signature, Key Fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     MD5 digest: OK
 0
 nosig

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -319,7 +319,7 @@ done
 [0],
 [nopls
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
@@ -327,7 +327,7 @@ done
 0
 noplds
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: NOTFOUND
@@ -341,7 +341,7 @@ nohdrs
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: OK
     MD5 digest: OK
 0
 nosig


### PR DESCRIPTION
This does not yet adjust the test cases. So 198 209 216 217 220 221 222 223 226 227 are failing due to unexpected key finger prints.

Can probably be used in combination with #3292 as this does not touch the keyid output. Although we might want to skip the key id for verified signatures.

Related: #2403