### PR TITLE
Enable C++ exceptions on the codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,7 +404,7 @@ if (ENABLE_WERROR)
 	add_compile_options(-Werror)
 endif()
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -Wno-c++20-compat -Wno-sign-compare")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++20-compat -Wno-sign-compare")
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-prototypes -Wstrict-prototypes")
 
 if (ENABLE_ASAN)


### PR DESCRIPTION
Jan Engelheart [pointed out](https://github.com/rpm-software-management/rpm/discussions/2983#discussioncomment-10724355) that with -fno-exceptions `new` failing will return a nullptr. Which seems fine until you realize that all of rpm is built on the notion that allocations never fail, they terminate the program instead. Only with the C++ refactorings, a significant portion of the code is now relying on `new` and not checking its return. Ooops.

Uncaught exceptions will terminate an unsuspecting program anyhow, let that happen. We'll be adding catches over time...

Besides allocations, not being able to deal with exceptions in the C++ side of things would put us at severe handicap all over the place - they are an essential part of the language and STL.
