### PR TITLE
Bump the lowest level file digest default to SHA256 too

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1015,7 +1015,7 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
     char buf[BUFSIZ];
     int i, npaths = 0;
     int fail_on_dupes = rpmExpandNumeric("%{?_duplicate_files_terminate_build}") > 0;
-    uint32_t defaultalgo = RPM_HASH_MD5, digestalgo;
+    uint32_t defaultalgo = RPM_HASH_SHA256, digestalgo;
     rpm_loff_t totalFileSize = 0;
     Header h = pkg->header; /* just a shortcut */
     int override_date = 0;
@@ -1058,8 +1058,8 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
     free(mtime_policy_str);
 
     /*
-     * See if non-md5 file digest algorithm is requested. If not
-     * specified, quietly assume md5. Otherwise check if supported type.
+     * See if non-default file digest algorithm is requested. If not
+     * specified, quietly assume default. Otherwise check if supported type.
      */
     digestalgo = rpmExpandNumeric(isSrc ? "%{_source_filedigest_algorithm}" :
 					  "%{_binary_filedigest_algorithm}");
@@ -1069,8 +1069,8 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
 
     if (rpmDigestLength(digestalgo) == 0) {
 	rpmlog(RPMLOG_WARNING,
-		_("Unknown file digest algorithm %u, falling back to MD5\n"), 
-		digestalgo);
+		_("Unknown file digest algorithm %u, falling back to %u\n"),
+		digestalgo, defaultalgo);
 	digestalgo = defaultalgo;
     }
 
@@ -1288,7 +1288,7 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
 	headerPutUint64(h, RPMTAG_LONGSIZE, &totalsize, 1);
     }
 
-    if (digestalgo != defaultalgo) {
+    if (digestalgo != RPM_HASH_MD5) {
 	headerPutUint32(h, RPMTAG_FILEDIGESTALGO, &digestalgo, 1);
 	rpmlibNeedsFeature(pkg, "FileDigests", "4.6.0-1");
     }

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -75,6 +75,7 @@ runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-1.0-1.src.rpm
 [Iam
 ],
 [])
+
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild -b buildsystem])
@@ -3566,6 +3567,62 @@ runroot rpmbuild -bc /data/SPECS/mydir.spec 2>&1 | awk /^mydir/
 [0],
 [mydir1=/build/BUILD/mydir-1.0-build/mydir-1.0
 mydir2=/build/BUILD/mydir-1.0-build/mydir-1.0
+],
+[])
+RPMTEST_CLEANUP
+
+AT_SETUP([file digests])
+AT_KEYWORDS([build digest])
+RPMDB_INIT
+RPMTEST_CHECK([[
+runroot rpmbuild -bs --quiet /data/SPECS/hello.spec
+runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.src.rpm
+]],
+[0],
+[bd70bbf9335f28297008dafdc7679583e3b63469c435aee7c3ba1c86890fb91e hello-1.0-modernize.patch
+7da10c0f91e120beff34b1d1077f1a77b2422dab7cb158379d44de4e83f90f30 hello-1.0.tar.gz
+c5b976d6e0d8068cf4c5a2910c511a76b94b0e263396d72176de1d9f855794d3 hello.spec
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpmbuild -bs --quiet \
+		--define "_source_filedigest_algorithm 0" \
+		/data/SPECS/hello.spec
+runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.src.rpm
+]],
+[0],
+[bd70bbf9335f28297008dafdc7679583e3b63469c435aee7c3ba1c86890fb91e hello-1.0-modernize.patch
+7da10c0f91e120beff34b1d1077f1a77b2422dab7cb158379d44de4e83f90f30 hello-1.0.tar.gz
+c5b976d6e0d8068cf4c5a2910c511a76b94b0e263396d72176de1d9f855794d3 hello.spec
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpmbuild -bs --quiet \
+		--define "_source_filedigest_algorithm 12345" \
+		/data/SPECS/hello.spec
+runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.src.rpm
+]],
+[0],
+[bd70bbf9335f28297008dafdc7679583e3b63469c435aee7c3ba1c86890fb91e hello-1.0-modernize.patch
+7da10c0f91e120beff34b1d1077f1a77b2422dab7cb158379d44de4e83f90f30 hello-1.0.tar.gz
+c5b976d6e0d8068cf4c5a2910c511a76b94b0e263396d72176de1d9f855794d3 hello.spec
+],
+[warning: Unknown file digest algorithm 12345, falling back to 8
+])
+
+# Just in case somebody still needs 4.4 compatibility...
+RPMTEST_CHECK([[
+runroot rpmbuild -bs --quiet \
+		--define "_source_filedigest_algorithm 1" \
+		/data/SPECS/hello.spec
+runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.src.rpm
+]],
+[0],
+[79678ec5e51e7565b4703286f26ac6a6 hello-1.0-modernize.patch
+b718a835936fd2f6c8855f210c4789a1 hello-1.0.tar.gz
+155931ba96d11559b7f116412214db3a hello.spec
 ],
 [])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Should've been in commit 0cd74ade37d16d282d13e781deb68a219b2c04b9 already, didn't even realize we have such a hardcoded default in code too until accidentally stumbled on it a few days ago.

This only affects anything if rpm's own normal macro configuration isn't available at all, so just an obscure corner case.

A funny little gotcha is that inserting RPMTAG_FILEDIGESTALGO tag depended on defaultalgo being MD5, so the obvious one-liner change caused a whopping 104 test failures. The tag needs to be added on any non-MD5 algorithm, change it to test for that explicitly.

So I guess it needs some tests afterall...