### PR TITLE
Drop --pkgid and --hdrid query source cli-switches

### DIFF
--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -52,7 +52,7 @@ select-options
 
 \[*PACKAGE\_NAME*\] \[**-a,\--all \[***SELECTOR*\]\] \[**-f,\--file
 ***FILE*\] \[**\--path ***PATH*\] \[**-g,\--group ***GROUP*\] \[**-p,\--package
-***PACKAGE\_FILE*\] \[**\--hdrid ***SHA1*\] \[**\--pkgid ***MD5*\]
+***PACKAGE\_FILE*\]
 \[**\--tid ***TID*\] \[**\--querybynumber ***HDRNUM*\]
 \[**\--triggeredby ***PACKAGE\_NAME*\] \[**\--whatprovides
 ***CAPABILITY*\] \[**\--whatrequires ***CAPABILITY*\]
@@ -638,11 +638,6 @@ name starts with \"b\".
 
 :   Query packages with the group of *GROUP*.
 
-**\--hdrid ***SHA1*
-
-:   Query package that contains a given header identifier, i.e. the
-    *SHA1* digest of the immutable header region.
-
 **-p, \--package ***PACKAGE\_FILE*
 
 :   Query an (uninstalled) package *PACKAGE\_FILE*. The *PACKAGE\_FILE*
@@ -663,11 +658,6 @@ name starts with \"b\".
 :   Query package(s) owning *PATH*, whether the file is installed or not.
     Multiple packages may own a *PATH*, but the file is only owned by the
     package installed last.
-
-**\--pkgid ***MD5*
-
-:   Query package that contains a given package identifier, i.e. the
-    *MD5* digest of the combined header and payload contents.
 
 **\--querybynumber ***HDRNUM*
 

--- a/include/rpm/rpmcli.h
+++ b/include/rpm/rpmcli.h
@@ -90,8 +90,6 @@ enum rpmQVSources_e {
     RPMQV_DBOFFSET,	/*!< ... from database header instance. */
     RPMQV_SPECRPMS,	/*!< ... from spec file binaries (query only). */
     RPMQV_SPECFILE = RPMQV_SPECRPMS, /*!< ... backwards compatibility */
-    RPMQV_PKGID,	/*!< ... from package id (header+payload MD5). */
-    RPMQV_HDRID,	/*!< ... from header id (immutable header SHA1). */
     RPMQV_TID,		/*!< ... from install transaction id (time stamp). */
     RPMQV_SPECSRPM,	/*!< ... from spec file source (query only). */
     RPMQV_WHATRECOMMENDS,	/*!< ... from recommends db search. */

--- a/lib/poptQV.c
+++ b/lib/poptQV.c
@@ -20,8 +20,6 @@ struct rpmQVKArguments_s rpmQVKArgs;
 #define POPT_QUERYBYNUMBER	-1003
 #define POPT_TRIGGEREDBY	-1004
 #define POPT_DUMP		-1005
-#define POPT_QUERYBYPKGID	-1007
-#define POPT_QUERYBYHDRID	-1008
 #define POPT_QUERYBYTID		-1010
 #define POPT_WHATRECOMMENDS	-1011
 #define POPT_WHATSUGGESTS	-1012
@@ -62,8 +60,6 @@ static void rpmQVSourceArgCallback( poptContext con,
     case POPT_WHATENHANCES: qva->qva_source |= RPMQV_WHATENHANCES; break;
     case POPT_TRIGGEREDBY: qva->qva_source |= RPMQV_TRIGGEREDBY; break;
     case POPT_QUERYBYPATH: qva->qva_source |= RPMQV_PATH_ALL; break;
-    case POPT_QUERYBYPKGID: qva->qva_source |= RPMQV_PKGID; break;
-    case POPT_QUERYBYHDRID: qva->qva_source |= RPMQV_HDRID; break;
     case POPT_QUERYBYTID: qva->qva_source |= RPMQV_TID; break;
     case POPT_QUERYBYNUMBER: qva->qva_source |= RPMQV_DBOFFSET; break;
     }
@@ -91,11 +87,6 @@ struct poptOption rpmQVSourcePoptTable[] = {
 	N_("query/verify package(s) in group"), "GROUP" },
  { "package", 'p', 0, 0, 'p',
 	N_("query/verify a package file"), NULL },
-
- { "pkgid", '\0', 0, 0, POPT_QUERYBYPKGID,
-	N_("query/verify package(s) with package identifier"), "MD5" },
- { "hdrid", '\0', 0, 0, POPT_QUERYBYHDRID,
-	N_("query/verify package(s) with header identifier"), "SHA1" },
 
  { "query", 'q', 0, NULL, 'q',
 	N_("rpm query mode"), NULL },

--- a/lib/query.c
+++ b/lib/query.c
@@ -309,7 +309,6 @@ static rpmdbMatchIterator matchesIterator(rpmts ts, rpmDbiTag dbi,
 static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * arg)
 {
     const char * s;
-    int i;
     rpmdbMatchIterator mi = NULL;
 
     if (qva->qva_showPackage == NULL)
@@ -328,43 +327,6 @@ static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * ar
 	mi = rpmtsInitIterator(ts, RPMDBI_TRIGGERNAME, arg, 0);
 	if (mi == NULL) {
 	    rpmlog(RPMLOG_NOTICE, _("no package triggers %s\n"), arg);
-	}
-	break;
-
-    case RPMQV_PKGID:
-    {	unsigned char MD5[16];
-	unsigned char * t;
-
-	for (i = 0, s = arg; *s && isxdigit(*s); s++, i++)
-	    {};
-	if (i != 32) {
-	    rpmlog(RPMLOG_ERR, _("malformed %s: %s\n"), "pkgid", arg);
-	    goto exit;
-	}
-
-	MD5[0] = '\0';
-        for (i = 0, t = MD5, s = arg; i < 16; i++, t++, s += 2)
-            *t = (rnibble(s[0]) << 4) | rnibble(s[1]);
-	
-	mi = rpmtsInitIterator(ts, RPMDBI_SIGMD5, MD5, sizeof(MD5));
-	if (mi == NULL) {
-	    rpmlog(RPMLOG_NOTICE, _("no package matches %s: %s\n"),
-			"pkgid", arg);
-	}
-    }	break;
-
-    case RPMQV_HDRID:
-	for (i = 0, s = arg; *s && isxdigit(*s); s++, i++)
-	    {};
-	if (i != 40) {
-	    rpmlog(RPMLOG_ERR, _("malformed %s: %s\n"), "hdrid", arg);
-	    goto exit;
-	}
-
-	mi = rpmtsInitIterator(ts, RPMDBI_SHA1HEADER, arg, 0);
-	if (mi == NULL) {
-	    rpmlog(RPMLOG_NOTICE, _("no package matches %s: %s\n"),
-			"hdrid", arg);
 	}
 	break;
 


### PR DESCRIPTION
These obscure switches are backed up by obsolete crypto that wont be, cannot be, present in v6 packages. It would be possible to keep them alive by making them point to non-obsolete data, but for that there would need to be a use-case and users. These have neither as far as I've learned in the last ~20 years.

Fixes: #2633