### PR TITLE
Link to macro syntax page from spec syntax page

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -104,6 +104,7 @@ various common operations.
 | `%define ...`       | define a macro |
 | `%undefine ...`     | undefine a macro |
 | `%global ...`       | define a macro whose body is available in global context |
+| `%dnl`              | discard to next line (without expanding) | 4.15.0
 | `%{load:...}`       | load a macro file | 4.12.0
 | `%{expand:...}`     | like eval, expand ... to \<body> and (re-)expand \<body> |
 | `%{expr:...}`       | evaluate an [expression](#expression-expansion) | 4.15.0

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -6,6 +6,13 @@ title: rpm.org - Spec file format
 
 ## Generic syntax
 
+### Macros
+
+Each line in the spec is macro-expanded before further processing. The macro
+syntax and the built-in macros are described on a [dedicated page](macros).
+Typically there are vast amounts of other macros available for helping with
+common packaging tasks.
+
 ### Comments
 
 Comments in spec file have # at the start of the line.


### PR DESCRIPTION
We speak about (built-in) macros and their expansion in various parts of the spec page but never care to actually mention to the reader that there's a dedicated page on macro syntax.  Add a bunch of links where appropriate, and since one of those places mentions %dnl, also add %dnl to the macro page (this used to be there, just got missed in the reformatting commit 015c829c7670c606b952bb34ef69debb60f5985a).

Fixes: #3331