### PR TITLE
Ensure the keyring directory exists when importing to fs keyring

### DIFF
--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -590,8 +590,13 @@ static rpmRC rpmtsImportFSKey(rpmtxn txn, Header h, rpmFlags flags, int replace)
 	unlink(tmppath);
     }
 
-    FD_t fd = Fopen(tmppath ? tmppath : path, "wx");
-    if (fd) {
+    if (rpmMkdirs(rpmtsRootDir(txn->ts), "%{_keyringpath}")) {
+	rpmlog(RPMLOG_ERR, _("failed to create keyring directory %s: %s\n"),
+		path, strerror(errno));
+	goto exit;
+    }
+
+    if (FD_t fd = Fopen(tmppath ? tmppath : path, "wx")) {
 	size_t keylen = strlen(keyval);
 	if (Fwrite(keyval, 1, keylen, fd) == keylen)
 	    rc = RPMRC_OK;
@@ -625,6 +630,7 @@ static rpmRC rpmtsImportFSKey(rpmtxn txn, Header h, rpmFlags flags, int replace)
 	free(keyglob);
     }
 
+exit:
     free(path);
     free(keyval);
     free(keyfmt);

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -275,7 +275,6 @@ AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMDB_INIT
 
-runroot_other mkdir -p /tmp/kr
 runroot rpmkeys \
 	--define "_keyringpath /tmp/kr" \
 	--define "_keyring fs" \


### PR DESCRIPTION
This was previously papered over in the test-suite.