### PR TITLE
Add a rpmKeyring iterator

### DIFF
--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -48,6 +48,29 @@ rpmKeyring rpmKeyringFree(rpmKeyring keyring);
 int rpmKeyringAddKey(rpmKeyring keyring, rpmPubkey key);
 
 /** \ingroup rpmkeyring
+ * Get iterator for all the primary keys in the keyring
+ * @param keyring       keyring handle
+ * @param unused	reserved for future use, must be 0
+ * @return		iterator or NULL
+ */
+rpmKeyringIterator rpmKeyringInitIterator(rpmKeyring keyring, int unused);
+
+/** \ingroup rpmkeyring
+ * Get next key in keyring
+ * @param iterator	iterator handle
+ * @return		weak reference to next public key
+ *			or NULL if end is reached
+ */
+rpmPubkey rpmKeyringIteratorNext(rpmKeyringIterator iterator);
+
+/** \ingroup rpmkeyring
+ * Free iterator
+ * @param iterator	iterator handle
+ * @return		NULL
+ */
+rpmKeyringIterator rpmKeyringIteratorFree(rpmKeyringIterator iterator);
+
+/** \ingroup rpmkeyring
  * Perform combined keyring lookup and signature verification
  * @param keyring	keyring handle
  * @param sig		OpenPGP signature parameters

--- a/include/rpm/rpmtypes.h
+++ b/include/rpm/rpmtypes.h
@@ -79,6 +79,7 @@ typedef void * rpmCallbackData;
 
 typedef struct rpmPubkey_s * rpmPubkey;
 typedef struct rpmKeyring_s * rpmKeyring;
+typedef struct rpmKeyringIterator_s * rpmKeyringIterator;
 
 typedef uint32_t rpmsid;
 typedef struct rpmstrPool_s * rpmstrPool;


### PR DESCRIPTION
Filter subkeys by default but support returning them. This is not exposed in the API for now. But can be used for returning a iterator over subkeys.

Resolves: #3337