### PR TITLE
Use keyring to implement rpmkeys --list

### DIFF
--- a/docs/man/rpmkeys.8.md
+++ b/docs/man/rpmkeys.8.md
@@ -19,7 +19,7 @@ DESCRIPTION
 
 The general forms of rpm digital signature commands are
 
-**rpmkeys** **\--list** \[*KEYHASH \...*\]
+**rpmkeys** **\--list** \[*KEYFINGERPRINT \...*\]
 
 **rpmkeys** **\--import** *PUBKEY \...*
 

--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -48,6 +48,29 @@ rpmKeyring rpmKeyringFree(rpmKeyring keyring);
 int rpmKeyringAddKey(rpmKeyring keyring, rpmPubkey key);
 
 /** \ingroup rpmkeyring
+ * Get iterator for all the primary keys in the keyring
+ * @param keyring       keyring handle
+ * @param unused	reserved for future use, must be 0
+ * @return		iterator or NULL
+ */
+rpmKeyringIterator rpmKeyringInitIterator(rpmKeyring keyring, int unused);
+
+/** \ingroup rpmkeyring
+ * Get next key in keyring
+ * @param iterator	iterator handle
+ * @return		weak reference to next public key
+ *			or NULL if end is reached
+ */
+rpmPubkey rpmKeyringIteratorNext(rpmKeyringIterator iterator);
+
+/** \ingroup rpmkeyring
+ * Free iterator
+ * @param iterator	iterator handle
+ * @return		NULL
+ */
+rpmKeyringIterator rpmKeyringIteratorFree(rpmKeyringIterator iterator);
+
+/** \ingroup rpmkeyring
  * Perform combined keyring lookup and signature verification
  * @param keyring	keyring handle
  * @param sig		OpenPGP signature parameters

--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -157,6 +157,13 @@ int rpmPubkeyFingerprint(rpmPubkey key, uint8_t **fp, size_t *fplen);
 char * rpmPubkeyFingerprintAsHex(rpmPubkey key);
 
 /** \ingroup rpmkeyring
+ * Return key ID of key as hex string
+ * @param key		Pubkey
+ * @ return		string or NULL on failure
+ */
+char * rpmPubkeyKeyIDAsHex(rpmPubkey key);
+
+/** \ingroup rpmkeyring
  * Return pgp params of key
  * @param key		Pubkey
  * @return		pgp params, NULL on error

--- a/include/rpm/rpmtypes.h
+++ b/include/rpm/rpmtypes.h
@@ -79,6 +79,7 @@ typedef void * rpmCallbackData;
 
 typedef struct rpmPubkey_s * rpmPubkey;
 typedef struct rpmKeyring_s * rpmKeyring;
+typedef struct rpmKeyringIterator_s * rpmKeyringIterator;
 
 typedef uint32_t rpmsid;
 typedef struct rpmstrPool_s * rpmstrPool;

--- a/rpmio/rpmkeyring.cc
+++ b/rpmio/rpmkeyring.cc
@@ -293,6 +293,12 @@ char * rpmPubkeyFingerprintAsHex(rpmPubkey key)
     return result;
 }
 
+char * rpmPubkeyKeyIDAsHex(rpmPubkey key)
+{
+    return rpmhex((const uint8_t*)(key->keyid.c_str()), key->keyid.length());
+}
+
+
 rpmPubkey rpmPubkeyFree(rpmPubkey key)
 {
     if (key == NULL)

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -97,11 +97,15 @@ hello-2.0-1.x86_64
 
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys --import /data/keys/alice.asc
+runroot rpmkeys --import /data/keys/rpm.org-ed25519-test.pub
 runroot rpm -qa | sort
 ],
 [0],
 [foo-1.0-1.noarch
 gpg-pubkey-1964c5fc-58e63918
+gpg-pubkey-757bf69e-661d22a8
+gpg-pubkey-eb04e625-62521e00
 hello-2.0-1.x86_64
 ],
 [])
@@ -110,32 +114,45 @@ RPMTEST_CHECK([
 runroot rpmkeys --list
 ],
 [0],
-[1964c5fc-58e63918: rpm.org RSA testkey <rsa@rpm.org> public key
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
 ],
 [])
 
 RPMTEST_CHECK([
-runroot rpmkeys --list 1964c5fc
+runroot rpmkeys --list 771b18d3d7baa28734333c424344591e1964c5fc
 ],
 [0],
-[1964c5fc-58e63918: rpm.org RSA testkey <rsa@rpm.org> public key
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
 ],
 [])
+
+RPMTEST_CHECK([
+runroot rpmkeys --list 4344591e1964c5fc
+],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+],
+[])
+
 
 RPMTEST_CHECK([
 runroot rpmkeys --list XXX
 ],
 [1],
-[package gpg-pubkey-XXX is not installed
+[Key XXX not found
 ],
 [])
 
 RPMTEST_CHECK([
 runroot rpmkeys --delete 1964c5fc
+runroot rpmkeys --delete 757bf69e
+runroot rpmkeys --delete eb04e625
 runroot rpmkeys --list
 ],
 [1],
-[package gpg-pubkey is not installed
+[No keys installed
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -95,7 +95,7 @@ runroot rpmkeys --delete 1964c5fc
 RPMTEST_CHECK([
 # XXX rpmkeys on rpmdb returns "package gpg-pubkey is not installed" with
 # and error code when no keys are present, paper over
-runroot rpmkeys --list | grep -v "not installed" | wc -l
+runroot rpmkeys --list | grep -v "No keys installed" | wc -l
 exit 0
 ],
 [0],


### PR DESCRIPTION
Use keyring to implement rpmkeys --list
    
This changes the output of keys --list to show the full fingerprint. It
also requires the use of the fingerprint or full key ID for querying
specific keys.

Note that this only allows fingerprints or long keyids as identifier. So it kinda assumes #2403 fixed.