### PR TITLE
Turn nrefs into atomic_int

### DIFF
--- a/lib/backend/dbi.hh
+++ b/lib/backend/dbi.hh
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include <stdio.h>
+#include <atomic>
 #include "dbiset.hh"
 #include <rpm/rpmtag.h>
 
@@ -68,7 +69,7 @@ struct rpmdb_s {
     struct rpmop_s db_putops;
     struct rpmop_s db_delops;
 
-    int nrefs;			/*!< Reference count. */
+    std::atomic_int nrefs;	/*!< Reference count. */
 };
 
 /* Type of the dbi, also serves as the join key size */

--- a/lib/header.cc
+++ b/lib/header.cc
@@ -12,6 +12,7 @@
 #include <netdb.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <atomic>
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmstring.h>
 #include "header_internal.hh"
@@ -109,7 +110,7 @@ struct headerToken_s {
     unsigned int instance;	/*!< Rpmdb instance */
     headerFlags flags;
     int sorted;			/*!< Current sort method */
-    int nrefs;			/*!< Reference count. */
+    std::atomic_int nrefs;			/*!< Reference count. */
 };
 
 /** \ingroup header
@@ -239,18 +240,9 @@ Header headerLink(Header h)
     return h;
 }
 
-static Header headerUnlink(Header h)
-{
-    if (h != NULL)
-	h->nrefs--;
-    return NULL;
-}
-
 Header headerFree(Header h)
 {
-    (void) headerUnlink(h);
-
-    if (h == NULL || h->nrefs > 0)
+    if (h == NULL || --h->nrefs > 0)
 	return NULL;
 
     if (h->index) {

--- a/lib/psm.cc
+++ b/lib/psm.cc
@@ -6,6 +6,7 @@
 #include "system.h"
 
 #include <errno.h>
+#include <atomic>
 
 #include <rpm/rpmlib.h>		/* rpmvercmp and others */
 #include <rpm/rpmmacro.h>
@@ -43,7 +44,7 @@ struct rpmpsm_s {
     rpm_loff_t amount;		/*!< Callback amount. */
     rpm_loff_t total;		/*!< Callback total. */
 
-    int nrefs;			/*!< Reference count. */
+    std::atomic_int nrefs;	/*!< Reference count. */
 };
 
 static rpmpsm rpmpsmNew(rpmts ts, rpmte te, pkgGoal goal);

--- a/lib/rpmdb.cc
+++ b/lib/rpmdb.cc
@@ -43,8 +43,6 @@
 using std::unordered_map;
 using std::vector;
 
-static rpmdb rpmdbUnlink(rpmdb db);
-
 static int buildIndexes(rpmdb db)
 {
     int rc = 0;
@@ -346,12 +344,7 @@ int rpmdbClose(rpmdb db)
 {
     int rc = 0;
 
-    if (db == NULL)
-	goto exit;
-
-    (void) rpmdbUnlink(db);
-
-    if (db->nrefs > 0)
+    if (db == NULL || --db->nrefs > 0)
 	goto exit;
 
     /* Always re-enable fsync on close of rw-database */
@@ -460,13 +453,6 @@ static int openDatabase(const char * prefix,
     }
 
     return rc;
-}
-
-static rpmdb rpmdbUnlink(rpmdb db)
-{
-    if (db)
-	db->nrefs--;
-    return NULL;
 }
 
 rpmdb rpmdbLink(rpmdb db)

--- a/lib/rpmts_internal.hh
+++ b/lib/rpmts_internal.hh
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <atomic>
 
 #include <rpm/rpmts.h>
 #include <rpm/rpmstrpool.h>
@@ -92,7 +93,7 @@ struct rpmts_s {
 
     rpmPlugins plugins;		/*!< Transaction plugins */
 
-    int nrefs;			/*!< Reference count. */
+    std::atomic_int nrefs;	/*!< Reference count. */
 
     rpmtriggers trigs2run;   /*!< Transaction file triggers */
 


### PR DESCRIPTION
Throughout the code base reference counting is done in a thread-unsave way. A few places use the content lock (aka mutex) to also protect the reference counter. This is wrong and complicates freeing interconnected data structures. This lock should only protect the content of the instance.

Turn all nrefs members into atomic_int so they are thread-save themselves.

Make sure to only use ++ and -- operators and avoid non atomic combinations of reading and writing. Drop all the static *Unlink functions that are involved in this.

Make sure the data lock is not aquired while updating the nrefs members.

Technically the *Free() functions should *Link() the instance after the ref count has reached 0 and the decision to free it has been made. Otherwise the cleanup code linking and freeing to will lead to a recusions. Right now only rpmts needs that. SO it is omitted everywhere else.

FD_t is special in that fdFree return the instance after free iff it still has not reached a ref count of 0. Unfortunately code in rpmShowProgress() relies on that.

This does not make the data structures thread save on its own. But it gives a foundation on which data locking can be implemented.