### PR TITLE
Having no keys imported is not an error

### DIFF
--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -196,9 +196,8 @@ runroot rpmkeys --delete 757bf69e
 runroot rpmkeys --delete eb04e625
 runroot rpmkeys --list
 ],
-[1],
-[No keys installed
-],
+[0],
+[],
 [])
 RPMTEST_CLEANUP
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -93,14 +93,10 @@ runroot rpmkeys --delete 1964c5fc
 [])
 
 RPMTEST_CHECK([
-# XXX rpmkeys on rpmdb returns "package gpg-pubkey is not installed" with
-# and error code when no keys are present, paper over
-runroot rpmkeys --list | grep -v "No keys installed" | wc -l
-exit 0
+runroot rpmkeys --list
 ],
 [0],
-[0
-],
+[],
 [])
 RPMTEST_CLEANUP
 

--- a/tools/rpmkeys.cc
+++ b/tools/rpmkeys.cc
@@ -72,18 +72,12 @@ static int matchingKeys(rpmKeyring keyring, ARGV_const_t args, void * userdata, 
 	    }
 	}
     } else {
-	int found = false;
 	auto iter = rpmKeyringInitIterator(keyring, 0);
 	rpmPubkey key = NULL;
 	while ((key = rpmKeyringIteratorNext(iter))) {
-	    found = true;
 	    callback(key, userdata);
 	}
 	rpmKeyringIteratorFree(iter);
-	if (!found) {
-	    rpmlog(RPMLOG_NOTICE, "No keys installed\n");
-	    ec = EXIT_FAILURE;
-	}
     }
     return ec;
 }


### PR DESCRIPTION
...any more than "ls" in an empty directory is. We should fix this in 4.20 too before people start making assumptions about this behavior.