### PR TITLE
Replace gpg-pubkey access with rpmkeys where possible

### DIFF
--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -128,6 +128,9 @@ AT_KEYWORDS([rpmdb query])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
 
+# root's .rpmmacros used to keep this build prefix independent
+echo "%_keyring rpmdb" >> "${RPMTEST}"/root/.rpmmacros
+
 RPMTEST_CHECK([
 runroot rpm -U --nodeps --ignorearch --ignoreos --nosignature \
 	/data/RPMS/foo-1.0-1.noarch.rpm \

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -465,7 +465,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_6
 echo Importing key:
 runroot rpmkeys --quiet --import /data/keys/alice.asc; echo $?
 echo Checking for key:
-runroot rpm -qi gpg-pubkey-eb04e625-* | grep Version | head -n1
+runroot rpmkeys --list b6542f92f30650c36b6f41bcb3a771bfeb04e625
 echo Checking package after importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm; echo $?
 echo Checking package after importing key, no digest:
@@ -486,7 +486,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 Importing key:
 0
 Checking for key:
-Version     : eb04e625
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
 Checking package after importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
     Header V4 RSA/SHA512 Signature, Key Fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
@@ -523,7 +523,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_6
 echo Importing key:
 runroot rpmkeys --quiet --import /data/keys/alice-expired-subkey.asc 2>&1; echo $?
 echo Checking for key:
-runroot rpm -qi gpg-pubkey-eb04e625-* | grep Version | head -n1
+runroot rpmkeys --list b6542f92f30650c36b6f41bcb3a771bfeb04e625
 echo Checking package after importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm 2>&1; echo $?
 echo Checking package after importing key, no digest:
@@ -544,7 +544,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 Importing key:
 0
 Checking for key:
-Version     : eb04e625
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
 Checking package after importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) expired on 2022-04-12 00:00:15])dnl
@@ -593,7 +593,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_6
 echo Importing key:
 runroot rpmkeys --quiet --import /data/keys/alice-revoked-subkey.asc 2>&1; echo $?
 echo Checking for key:
-runroot rpm -qi gpg-pubkey-eb04e625-* | grep Version | head -n1
+runroot rpmkeys --list b6542f92f30650c36b6f41bcb3a771bfeb04e625
 echo Checking package after importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm 2>&1; echo $?
 echo Checking package after importing key, no digest:
@@ -614,7 +614,7 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 Importing key:
 0
 Checking for key:
-Version     : eb04e625
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
 Checking package after importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -348,7 +348,9 @@ AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMDB_INIT
 
-runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+	--define "_keyring rpmdb" \
+	--import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpm -qi gpg-pubkey-1964c5fc-58e63918|grep -v Date|grep -v Version:
 runroot rpm -q --provides gpg-pubkey-1964c5fc-58e63918],
 [0],
@@ -704,7 +706,9 @@ AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
 RPMTEST_CHECK([
-runroot rpmkeys --import /data/keys/different-creation-times.asc
+runroot rpmkeys \
+	--define "_keyring rpmdb" \
+	--import /data/keys/different-creation-times.asc
 runroot rpm -qi gpg-pubkey-62837bea-62553e62|grep -v Date|grep -v Version:
 runroot rpm -q --provides gpg-pubkey
 ],


### PR DESCRIPTION
Replace gpg-pubkey queries with rpmkeys --list where possible. We can't drop all gpg-pubkey tests while we support it, so make the remaining gpg-pubkey use the rpmdb keystore explicitly rather than assuming the default. 

With this, changing the default keystore no longer causes test-suite failures.