### PR TITLE
Make rpmPubkeyFingerprintAsHex() and rpmPubkeyKeyIDAsHex() nicer to use from C

### DIFF
--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -159,9 +159,9 @@ int rpmPubkeyFingerprint(rpmPubkey key, uint8_t **fp, size_t *fplen);
 /** \ingroup rpmkeyring
  * Return fingerprint of primary key as hex string
  * @param key		Pubkey
- * @ return		string or NULL on failure
+ * @return		string or NULL on failure
  */
-char * rpmPubkeyFingerprintAsHex(rpmPubkey key);
+const char * rpmPubkeyFingerprintAsHex(rpmPubkey key);
 
 /** \ingroup rpmkeyring
  * Return key ID of key as hex string

--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -166,9 +166,9 @@ char * rpmPubkeyFingerprintAsHex(rpmPubkey key);
 /** \ingroup rpmkeyring
  * Return key ID of key as hex string
  * @param key		Pubkey
- * @ return		string or NULL on failure
+ * @return		string or NULL on failure
  */
-char * rpmPubkeyKeyIDAsHex(rpmPubkey key);
+const char * rpmPubkeyKeyIDAsHex(rpmPubkey key);
 
 /** \ingroup rpmkeyring
  * Return pgp params of key

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -777,7 +777,6 @@ exit:
 rpmRC rpmtxnDeletePubkey(rpmtxn txn, rpmPubkey key)
 {
     rpmRC rc = RPMRC_FAIL;
-    char * keyid = rpmPubkeyKeyIDAsHex(key);
 
     if (txn) {
 	/* force keyring load */
@@ -789,6 +788,7 @@ rpmRC rpmtxnDeletePubkey(rpmtxn txn, rpmPubkey key)
 	/* Both import and delete just return OK on test-transaction */
 	rc = RPMRC_OK;
 	if (!(rpmtsFlags(txn->ts) & RPMTRANS_FLAG_TEST)) {
+	    const char *keyid = rpmPubkeyKeyIDAsHex(key);
 	    if (txn->ts->keyringtype == KEYRING_FS)
 		rc = rpmtsDeleteFSKey(txn, keyid+8);
 	    else
@@ -796,7 +796,6 @@ rpmRC rpmtxnDeletePubkey(rpmtxn txn, rpmPubkey key)
 	}
 	rpmKeyringFree(keyring);
     }
-    free(keyid);
     return rc;
 }
 

--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -307,7 +307,7 @@ const char *rpmsinfoDescr(struct rpmsinfo_s *sinfo)
 char *rpmsinfoMsg(struct rpmsinfo_s *sinfo)
 {
     char *msg = NULL;
-    char *fphex = NULL;
+    const char *fphex = NULL;
     char *fpmsg = NULL;
     char * descr = xstrdup(rpmsinfoDescr(sinfo));
     if (sinfo->key) {
@@ -330,7 +330,6 @@ char *rpmsinfoMsg(struct rpmsinfo_s *sinfo)
 		  descr, fpmsg, rpmSigString(sinfo->rc));
     }
     free(descr);
-    free(fphex);
     free(fpmsg);
     return msg;
 }

--- a/rpmio/rpmkeyring.cc
+++ b/rpmio/rpmkeyring.cc
@@ -20,7 +20,7 @@ int _print_pkts = 0;
 
 struct rpmPubkey_s {
     std::vector<uint8_t> pkt;
-    std::string keyid;
+    std::string keyid;		/* hex keyid */
     rpmPubkey primarykey;
     pgpDigParams pgpkey;
     std::atomic_int nrefs;
@@ -45,7 +45,10 @@ struct rpmKeyringIterator_s {
 
 static std::string key2str(const uint8_t *keyid)
 {
-    return std::string(reinterpret_cast<const char *>(keyid), PGP_KEYID_LEN);
+    char *hexid = rpmhex(keyid, PGP_KEYID_LEN);
+    std::string s { hexid };
+    free(hexid);
+    return s;
 }
 
 rpmKeyring rpmKeyringNew(void)
@@ -285,9 +288,9 @@ char * rpmPubkeyFingerprintAsHex(rpmPubkey key)
     return result;
 }
 
-char * rpmPubkeyKeyIDAsHex(rpmPubkey key)
+const char * rpmPubkeyKeyIDAsHex(rpmPubkey key)
 {
-    return rpmhex((const uint8_t*)(key->keyid.c_str()), key->keyid.length());
+    return key ? key->keyid.c_str() : NULL;
 }
 
 

--- a/tools/rpmkeys.cc
+++ b/tools/rpmkeys.cc
@@ -80,13 +80,12 @@ static int matchingKeys(rpmts ts, ARGV_const_t args, int callback(rpmPubkey, voi
 	    rpmPubkey key = NULL;
 	    while ((key = rpmKeyringIteratorNext(iter))) {
 		char * fp = rpmPubkeyFingerprintAsHex(key);
-		char * keyid = rpmPubkeyKeyIDAsHex(key);
+		const char * keyid = rpmPubkeyKeyIDAsHex(key);
 		if (!strcmp(*arg, fp) || !strcmp(*arg, keyid) ||
 		    !strcmp(*arg, keyid+8)) {
 		    found = true;
 		}
 		free(fp);
-		free(keyid);
 		if (found)
 		    break;
 	    }

--- a/tools/rpmkeys.cc
+++ b/tools/rpmkeys.cc
@@ -79,13 +79,12 @@ static int matchingKeys(rpmts ts, ARGV_const_t args, int callback(rpmPubkey, voi
 	    auto iter = rpmKeyringInitIterator(keyring, 0);
 	    rpmPubkey key = NULL;
 	    while ((key = rpmKeyringIteratorNext(iter))) {
-		char * fp = rpmPubkeyFingerprintAsHex(key);
+		const char * fp = rpmPubkeyFingerprintAsHex(key);
 		const char * keyid = rpmPubkeyKeyIDAsHex(key);
 		if (!strcmp(*arg, fp) || !strcmp(*arg, keyid) ||
 		    !strcmp(*arg, keyid+8)) {
 		    found = true;
 		}
-		free(fp);
 		if (found)
 		    break;
 	    }
@@ -111,10 +110,9 @@ static int matchingKeys(rpmts ts, ARGV_const_t args, int callback(rpmPubkey, voi
 
 static int printKey(rpmPubkey key, void * data)
 {
-    char * fp = rpmPubkeyFingerprintAsHex(key);
     pgpDigParams params = rpmPubkeyPgpDigParams(key);
-    rpmlog(RPMLOG_NOTICE, "%s %s public key\n", fp, pgpDigParamsUserID(params));
-    free(fp);
+    rpmlog(RPMLOG_NOTICE, "%s %s public key\n",
+		rpmPubkeyFingerprintAsHex(key), pgpDigParamsUserID(params));
     return 0;
 }
 


### PR DESCRIPTION
Store both the keyid and fingerprint in hex format inside the key, so we can return const pointers to them.
Makes them nicer to use from C.