### PR TITLE
Add rpmtsLogOnce()

### DIFF
--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -664,6 +664,16 @@ int rpmtsGetNotifyStyle(rpmts ts);
 int rpmtsSetChangeCallback(rpmts ts, rpmtsChangeFunction notify, void *data);
 
 /** \ingroup rpmts
+ * Log messages with the same key just once
+ * @param ts		transaction set
+ * @param key		key to match log messages together
+ * @param code		rpmlogLvl
+ * @param fmt		format string and parameter to render
+ * @return		0 for the first call with this key value 1 otherwise
+ */
+int rpmtsLogOnce(rpmts ts, const char * key, int code, const char * fmt, ...) RPM_GNUC_PRINTF(4, 5);
+
+/** \ingroup rpmts
  * Create an empty transaction set.
  * @return		new transaction set
  */

--- a/lib/rpmts_internal.hh
+++ b/lib/rpmts_internal.hh
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 #include <atomic>
+#include <set>
 
 #include <rpm/rpmts.h>
 #include <rpm/rpmstrpool.h>
@@ -100,6 +101,7 @@ struct rpmts_s {
     int min_writes;             /*!< macro minimize_writes used */
 
     time_t overrideTime;	/*!< Time value used when overriding system clock. */
+    std::set<std::string> logged_once; /* Messages already logged */
 };
 
 /** \ingroup rpmts

--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -196,7 +196,6 @@ static void rpmsinfoInit(const struct vfyinfo_s *vinfo,
 	char *lints = NULL;
         int ec = pgpPrtParams2((const uint8_t *)data, dlen, PGPTAG_SIGNATURE,
 				&sinfo->sig, &lints);
-	const uint8_t *signid;
 	if (ec) {
 	    if (lints) {
 		rasprintf(&sinfo->msg,
@@ -214,8 +213,6 @@ static void rpmsinfoInit(const struct vfyinfo_s *vinfo,
 	    free(lints);
 	}
 	sinfo->hashalgo = pgpDigParamsAlgo(sinfo->sig, PGPVAL_HASHALGO);
-	signid = pgpDigParamsSignID(sinfo->sig);	/* 8 bytes key id */
-	sinfo->keyid = signid[4] << 24 | signid[5] << 16 | signid[6] << 8 | signid[7];
     } else if (sinfo->type == RPMSIG_DIGEST_TYPE) {
 	if (td->type == RPM_BIN_TYPE) {
 	    sinfo->dig = rpmhex((const uint8_t *)data, dlen);


### PR DESCRIPTION
Allows showing a log message only once.

Use in handleHdrVS. This does not add a new test case but various existing test cases fail when the NOKEY message is omited or shown more than once.

Resolves: #3336
Resolves: #3333