### PR TITLE
Default to test-suite disabled in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(ENABLE_WERROR "Stop build on warnings" OFF)
 option(ENABLE_SQLITE "Enable sqlite rpmdb support" ON)
 option(ENABLE_NDB "Enable ndb rpmdb support" ON)
 option(ENABLE_BDB_RO "Enable read-only Berkeley DB rpmdb support (EXPERIMENTAL)" OFF)
-option(ENABLE_TESTSUITE "Enable test-suite" ON)
+option(ENABLE_TESTSUITE "Enable test-suite" OFF)
 option(ENABLE_ASAN "Enable address-sanitizer" OFF)
 option(ENABLE_UBSAN "Enable undefined behavior-sanitizer" OFF)
 

--- a/INSTALL
+++ b/INSTALL
@@ -199,8 +199,8 @@ This also creates and installs the new platform file e.g.
 
 Rpm comes with an automated self-test suite. The test-suite requires podman
 (https://github.com/containers/podman/) or docker (https://github.com/docker/).
-It is enabled by default but can be disabled with -DENABLE_TESTSUITE=OFF to
-avoid the dependencies.  The test-suite can be executed with:
+It is disabled by default to avoid the dependencies but can be enabled with
+-DENABLE_TESTSUITE=ON.  The test-suite can be executed with:
 
     make check
 

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -87,6 +87,7 @@ RUN cmake \
 	-DWITH_FSVERITY=ON \
 	-DWITH_IMAEVM=ON \
 	-DWITH_DOXYGEN=ON \
+	-DENABLE_TESTSUITE=ON \
 	-DMKTREE_BACKEND=rootfs \
 	../rpm
 RUN make -j$(nproc) tree


### PR DESCRIPTION
Despite being bound to "make check" and reasonably fast, our tests sit at least one level above what you'd normally call "self tests" or "unit tests" and require external container tooling to run.

Therefore, disable them by default, they're only really useful for RPM development, certainly not for building RPM itself, e.g. from a release tarball.  Update the INSTALL file accordigly.

Fixes: #3388