### PR TITLE
Don’t read *~ macro files, which are text editor backups

### DIFF
--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -2074,7 +2074,8 @@ rpmInitMacros(rpmMacroContext mc, const char * macrofiles)
 	for (path = files; *path; path++) {
 	    if (rpmFileHasSuffix(*path, ".rpmnew") || 
 		rpmFileHasSuffix(*path, ".rpmsave") ||
-		rpmFileHasSuffix(*path, ".rpmorig")) {
+		rpmFileHasSuffix(*path, ".rpmorig") ||
+		rpmFileHasSuffix(*path, "~")) {
 		continue;
 	    }
 	    (void) loadMacroFile(mc, *path);


### PR DESCRIPTION
This follows on from https://github.com/rpm-software-management/rpm/pull/3373#issuecomment-2413627289 where I became confused by the current behaviour.