### PR TITLE
Fix FA_TOUCH'ed files getting removed on failed update

### DIFF
--- a/lib/fsm.cc
+++ b/lib/fsm.cc
@@ -1094,7 +1094,7 @@ setmeta:
 	    if (ensureDir(NULL, rpmfiDN(fi), 0, 0, 1, &di.dirfd))
 		continue;
 
-	    if (fp->stage > FILE_NONE && !fp->skip) {
+	    if (fp->stage > FILE_NONE && !fp->skip && fp->action != FA_TOUCH) {
 		(void) fsmRemove(di.dirfd, fp->fpath, fp->sb.st_mode);
 	    }
 	}

--- a/tests/data/SPECS/pamupdate.spec
+++ b/tests/data/SPECS/pamupdate.spec
@@ -1,0 +1,21 @@
+Name: pamupdate
+Version: 1.0
+Release: %{rel}
+Group: Testing
+License: Public domain
+Summary: Test config behavior on update failure
+BuildArch: noarch
+
+%description
+%{summary}
+
+%install
+mkdir -p ${RPM_BUILD_ROOT}/etc
+echo AAAA > ${RPM_BUILD_ROOT}/etc/my.conf
+echo BBBB > ${RPM_BUILD_ROOT}/etc/your.conf
+mkdir -p ${RPM_BUILD_ROOT}/var/run/faillock
+
+%files
+%config /etc/my.conf
+%config /etc/your.conf
+%dir /var/run/faillock

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1696,6 +1696,46 @@ error: replacetest-1.0-1.noarch: install failed
 ])
 RPMTEST_CLEANUP
 
+AT_SETUP([update on invalid symlinked directory])
+AT_KEYWORDS([install update symlink])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+for r in 1 2; do
+    runroot rpmbuild --quiet --bb \
+		--define "rel ${r}" \
+		/data/SPECS/pamupdate.spec
+done
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/pamupdate-1.0-1.noarch.rpm
+runroot rpm -V pamupdate
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot_other chown -h nobody:nobody /var/run
+runroot rpm -U /build/RPMS/noarch/pamupdate-1.0-2.noarch.rpm
+],
+[1],
+[],
+[ignore])
+
+RPMTEST_CHECK([
+# --nomtime shouldn't be needed but fixing that's another story
+runroot rpm -V --nomtime pamupdate
+],
+[0],
+[],
+[])
+RPMTEST_CLEANUP
+
 AT_SETUP([rpm -U diskspace])
 AT_KEYWORDS([install diskspace])
 RPMTEST_CHECK([


### PR DESCRIPTION
On install/update, most files are laid down with a temporary suffix and if the update fails, removing those at the end of the loop is the right thing to do. However FA_TOUCH'ed files were already there, we only update their metadata, and we better not remove them!

AFAICS this all versions since rpm >= 4.14 in one way or the other. If %_minimize_writes is enabled then it affects way more than just unmodified config files.

The test is a simplified version of pam update failing in the original report.

Fixes: RHEL-54386
Fixes: #3284