### PR TITLE
Use full keyid for the unknown keyid warning message tracking

### DIFF
--- a/lib/package.cc
+++ b/lib/package.cc
@@ -4,6 +4,7 @@
 
 #include "system.h"
 
+#include <string>
 #include <mutex>
 #include <set>
 
@@ -115,13 +116,13 @@ exit:
  * @param keyid		signature keyid
  * @return		0 if new keyid, otherwise 1
  */
-static int stashKeyid(unsigned int keyid)
+static int stashKeyid(const char *keyid)
 {
     static std::mutex keyid_mutex;
-    static std::set<unsigned int> keyids;
+    static std::set<std::string> keyids;
     int seen = 0;
 
-    if (keyid == 0)
+    if (keyid == NULL)
 	return 0;
 
     std::lock_guard<std::mutex> lock(keyid_mutex);

--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -196,7 +196,6 @@ static void rpmsinfoInit(const struct vfyinfo_s *vinfo,
 	char *lints = NULL;
         int ec = pgpPrtParams2((const uint8_t *)data, dlen, PGPTAG_SIGNATURE,
 				&sinfo->sig, &lints);
-	const uint8_t *signid;
 	if (ec) {
 	    if (lints) {
 		rasprintf(&sinfo->msg,
@@ -214,8 +213,7 @@ static void rpmsinfoInit(const struct vfyinfo_s *vinfo,
 	    free(lints);
 	}
 	sinfo->hashalgo = pgpDigParamsAlgo(sinfo->sig, PGPVAL_HASHALGO);
-	signid = pgpDigParamsSignID(sinfo->sig);	/* 8 bytes key id */
-	sinfo->keyid = signid[4] << 24 | signid[5] << 16 | signid[6] << 8 | signid[7];
+	sinfo->keyid = rpmhex(pgpDigParamsSignID(sinfo->sig), PGP_KEYID_LEN);
     } else if (sinfo->type == RPMSIG_DIGEST_TYPE) {
 	if (td->type == RPM_BIN_TYPE) {
 	    sinfo->dig = rpmhex((const uint8_t *)data, dlen);
@@ -251,6 +249,7 @@ static void rpmsinfoFini(struct rpmsinfo_s *sinfo)
 	rpmPubkeyFree(sinfo->key);
 	free(sinfo->msg);
 	free(sinfo->descr);
+	free(sinfo->keyid);
 	memset(sinfo, 0, sizeof(*sinfo));
     }
 }

--- a/lib/rpmvs.hh
+++ b/lib/rpmvs.hh
@@ -24,7 +24,7 @@ struct rpmsinfo_s {
     int wrapped;
     int strength;
     rpmPubkey key;
-    unsigned int keyid;
+    char *keyid;
     union {
 	pgpDigParams sig;
 	char *dig;

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -7,6 +7,30 @@ m4_define([RPMOUTPUT_SEQUOIA], [m4_if(RPM_PGP, [sequoia], [$1
 m4_define([RPMOUTPUT_LEGACY], [m4_if(RPM_PGP, [legacy], [$1
 ])])
 
+AT_SETUP([seen signer id tracking])
+AT_KEYWORDS([query signature])
+RPMTEST_CHECK([
+# stderr redirected to stdout to test the exact order of output
+runroot rpm -qp \
+	/data/RPMS/hello-2.0-1.x86_64-signed.rpm \
+	/data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm \
+	/data/RPMS/hello-2.0-1.x86_64.rpm \
+	/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm \
+	/data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm 2>&1
+],
+[0],
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 Signature, key ID 4344591e1964c5fc: NOKEY
+hello-2.0-1.x86_64
+warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOKEY
+hello-2.0-1.x86_64
+hello-2.0-1.x86_64
+warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm: Header V4 EdDSA/SHA512 Signature, key ID 6323c42711450b6c: NOKEY
+hello-2.0-1.x86_64
+hello-2.0-1.x86_64
+],
+[])
+RPMTEST_CLEANUP
+
 # ------------------------------
 # Test pre-built package verification
 AT_SETUP([rpmkeys -Kv <unsigned> 1])


### PR DESCRIPTION
Just use the actual hex string, it's what the user needs to see and makes no difference to the computer. Add a test as well.

Fixes: #3333