### PR TITLE
Require macro filenames to end in alphanum char

### DIFF
--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -2072,9 +2072,11 @@ rpmInitMacros(rpmMacroContext mc, const char * macrofiles)
 
 	/* Read macros from each file. */
 	for (path = files; *path; path++) {
+	    size_t len = strlen(*path);
 	    if (rpmFileHasSuffix(*path, ".rpmnew") || 
 		rpmFileHasSuffix(*path, ".rpmsave") ||
-		rpmFileHasSuffix(*path, ".rpmorig")) {
+		rpmFileHasSuffix(*path, ".rpmorig") ||
+		(len > 0 && !risalnum((*path)[len - 1]))) {
 		continue;
 	    }
 	    (void) loadMacroFile(mc, *path);

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -39,6 +39,23 @@ runroot --setenv  XDG_CONFIG_HOME "~/.zzz" rpm --showrc | awk '/^Macro path/{pri
 RPMTEST_CLEANUP
 
 # ------------------------------
+AT_SETUP([macro path: skip editor backups])
+AT_KEYWORDS([macros])
+RPMTEST_SETUP
+RPMTEST_CHECK([
+echo '%this that' > $RPMTEST/$RPM_CONFIGDIR_PATH/macros.d/macros.this
+runroot rpm --eval '%{this}'
+mv $RPMTEST/$RPM_CONFIGDIR_PATH/macros.d/macros.this{,~}
+runroot rpm --eval '%{this}'
+],
+[0],
+[that
+%{this}
+],
+[])
+RPMTEST_CLEANUP
+
+# ------------------------------
 AT_SETUP([simple rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([


### PR DESCRIPTION
Make sure (text editor) backup files, such as those with the tilde (~) at the end, aren't processed by our macrofiles globs.  These can appear while editing a macro file in place and may result in confusing behavior where an old version of a macro overrides the one being written, like seen in the ticket #3373.

Rather than enumerating any specific suffixes, just mandate that macro files end with alphanumerics.  That's more of a name sanity check than anything but fits the bill here.