### PR TITLE
Handle subkeys in rpmKeyringModify

### DIFF
--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -291,11 +291,9 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
     rpmRC rc = RPMRC_FAIL;		/* assume failure */
     char *lints = NULL;
     rpmPubkey pubkey = NULL;
-    rpmPubkey *subkeys = NULL;
     rpmPubkey oldkey = NULL;
-    int subkeysCount = 0;
     rpmKeyring keyring = NULL;
-    int krc, i;
+    int krc;
 
     if (txn == NULL)
 	return rc;
@@ -337,14 +335,10 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
 	rpmPubkeyFree(pubkey);
 	pubkey = mergedkey;
     }
-    if ((subkeys = rpmGetSubkeys(pubkey, &subkeysCount)) == NULL)
-	goto exit;
 
     krc = rpmKeyringModify(keyring, pubkey, oldkey ? RPMKEYRING_REPLACE : RPMKEYRING_ADD);
     if (krc < 0)
 	goto exit;
-    for (i = 0; i < subkeysCount; i++)
-	rpmKeyringModify(keyring, subkeys[i], oldkey ? RPMKEYRING_REPLACE : RPMKEYRING_ADD);
 
     /* If we dont already have the key, make a persistent record of it */
     if (krc == 0) {
@@ -356,9 +350,6 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
 exit:
     /* Clean up. */
     rpmPubkeyFree(pubkey);
-    for (i = 0; i < subkeysCount; i++)
-	rpmPubkeyFree(subkeys[i]);
-    free(subkeys);
     rpmPubkeyFree(oldkey);
 
     rpmKeyringFree(keyring);

--- a/rpmio/rpmkeyring.cc
+++ b/rpmio/rpmkeyring.cc
@@ -133,15 +133,11 @@ int rpmKeyringModify(rpmKeyring keyring, rpmPubkey key, rpmKeyringModifyMode mod
 	if (item->second->fp == key->fp)
 	    break;
     }
-    if (item != range.second && mode == RPMKEYRING_DELETE) {
+    if (item != range.second && (mode == RPMKEYRING_DELETE || mode == RPMKEYRING_REPLACE)) {
 	rpmPubkeyFree(item->second);
 	keyring->keys.erase(item);
 	rc = 0;
-    } else if (item != range.second && mode == RPMKEYRING_REPLACE) {
-	rpmPubkeyFree(item->second);
-	item->second = rpmPubkeyLink(key);
-	rc = 0;
-    } else if (item == range.second && (mode == RPMKEYRING_ADD || mode == RPMKEYRING_REPLACE) ) {
+    } else if ((item == range.second && mode == RPMKEYRING_ADD) || mode == RPMKEYRING_REPLACE) {
 	keyring->keys.insert({key->keyid, rpmPubkeyLink(key)});
 	rc = 0;
     }


### PR DESCRIPTION
Remove all other subkey handling code

Inline the remaining few lines of keyringAdd in keystore.cc

This slightly changes the DEBUG messages as the keyring does not have
access to the origin of the keys. So rpmtsLoadKeyringFrom* still gives
the location the keys came from while the keyring only lists the
fingerprint of the primary keys and the number for the sub keys.

This changes the return value of rpmKeystoreLoad to the number of
primary keys and no longer accounts for the subkeys.

Subkeys are covered by multiple test already - including merging a newer
key. So this does not add additional tests.

Resolves: #3350