### PR TITLE
Drill pubkeys one level deeper into the keystore APIs

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -159,7 +159,7 @@ echo "%_keyring fs" >> "${RPMTEST}"/root/.rpmmacros
 
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
-runroot_other mv /var/lib/rpm/pubkeys/gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc-58e63918.key /var/lib/rpm/pubkeys/gpg-pubkey-1964c5fc-58e63918.key
+runroot_other mv /var/lib/rpm/pubkeys/gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc.key /var/lib/rpm/pubkeys/gpg-pubkey-1964c5fc-58e63918.key
 runroot_other ls /var/lib/rpm/pubkeys/
 runroot rpmkeys --list
 ],
@@ -180,7 +180,7 @@ RPMTEST_CHECK([
 runroot_other ls /var/lib/rpm/pubkeys/
 ],
 [0],
-[gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc-58e63918.key
+[gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc.key
 ],
 [])
 RPMTEST_CLEANUP
@@ -495,7 +495,7 @@ runroot rpmkeys \
 	--define "_keyringpath /tmp/kr" \
 	--define "_keyring fs" \
 	--import /data/keys/rpm.org-rsa-2048-test.pub
-runroot_other cat /tmp/kr/gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc-58e63918.key | grep -v 'Version: '
+runroot_other cat /tmp/kr/gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc.key | grep -v 'Version: '
 ],
 [0],
 [-----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
Pass pubkeys down to the keystore on import, and let the keystore handle the actual format. For rpmdb keystore this remains the header, so it's a no-op there, but on the fs keystore we drop the trailing "time or something" hex garbage from the filename because we no longer have it at hand but also because it's just not relevant for anything. The key load glob is relaxed enough that we still pick the old format keys too.

Related: #3342