### PR TITLE
Silence extra output on rpmspeq query on Buildsystem specs

### DIFF
--- a/build/parseSpec.cc
+++ b/build/parseSpec.cc
@@ -1426,7 +1426,7 @@ static rpmRC parseSpecParts(rpmSpec spec, const char *pattern,
     /* rpmGlob returns files sorted */
     if (rpmGlob(pattern, &argc, &argv) == 0) {
 	for (int i = 0; i < argc; i++) {
-	    rpmlog(RPMLOG_NOTICE, "Reading %s\n", argv[i]);
+	    rpmlog(RPMLOG_INFO, "Reading %s\n", argv[i]);
 	    pushOFI(spec, argv[i]);
 	    snprintf(spec->fileStack->readBuf, spec->fileStack->readBufLen,
 		     "# Spec part read from %s\n\n", argv[i]);

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -79,7 +79,7 @@ runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-1.0-1.src.rpm
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild -b buildsystem])
-AT_KEYWORDS([build])
+AT_KEYWORDS([build buildsystem])
 RPMDB_INIT
 
 cp "${RPMTEST}/data/macros.buildsystem" "${RPMTEST}/${RPM_CONFIGDIR_PATH}/macros.d/"
@@ -186,6 +186,13 @@ runroot rpmbuild -bb \
 [error: line 11: Required parametric macro %buildsystem_autotools_build not defined for buildsystem autotools
 ])
 
+RPMTEST_CHECK([
+runroot rpmspec -q --qf "%{nvr}\n" /data/SPECS/amhello.spec
+],
+[0],
+[amhello-1.0-1
+],
+[])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild -b steps])


### PR DESCRIPTION
Dynamic spec parsing emits "Reading <path>" messages to make it clear something out of the ordinary is going on, but this is undesireable on rpmspeq queries. Luckily there's a trivial solution: rpmbuild where you want these messages runs in verbose mode by default whereas rpmspec does not. So just moving the message to INFO level does exactly the right thing in both the above cases and as an added bonus, rpmbuild --quiet too. Add a test to go.

Fies: #3413