### PR TITLE
Add rpmlogOnce() and rpmlogReset()

### DIFF
--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -30,6 +30,7 @@
 #include "rpmplugins.hh"
 #include "rpmts_internal.hh"
 #include "rpmte_internal.hh"
+#include "rpmlog_internal.hh"
 #include "misc.hh"
 #include "rpmtriggers.hh"
 
@@ -575,6 +576,7 @@ rpmts rpmtsFree(rpmts ts)
     ts->plugins = rpmpluginsFree(ts->plugins);
 
     rpmtriggersFree(ts->trigs2run);
+    rpmlogReset((uint64_t) ts);
 
     if (_rpmts_stats)
 	rpmtsPrintStats(ts);

--- a/rpmio/rpmlog_internal.hh
+++ b/rpmio/rpmlog_internal.hh
@@ -1,0 +1,23 @@
+#ifndef H_RPMLOG_INTERNAL
+#define H_RPMLOG_INTERNAL 1
+
+
+/** \ingroup rpmlog
+ * Generate a log message using FMT string and option arguments.
+ * Only actually log on the first time passing the key value
+ * @param domain	group of messages to be reset together
+ * @param key		key to match log messages together
+ * @param code		rpmlogLvl
+ * @param fmt		format string and parameter to render
+ * @return		1 if actually logging 0 otherwise
+ */
+int rpmlogOnce (uint64_t domain, const char * key, int code, const char *fmt, ...) RPM_GNUC_PRINTF(4, 5);
+
+/** \ingroup rpmlog
+ * Clear memory of logmessages for a given domain
+ * @param domain	group of messages to be reset together
+ * @param mode		curretnly only 0 supported whihc drops everything
+ */
+void rpmlogReset(uint64_t domain, int mode=0);
+
+#endif

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -353,6 +353,24 @@ for e in ts:
 lock]
 )
 
+RPMPY_TEST([log suppression per transaction],[
+for i in range(4):
+    try:
+        ts.addInstall('${RPMDATA}/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm', 'u')
+    except rpm.error as e:
+        print(e)
+    if i==1:
+        ts = rpm.ts()
+],
+[public key not available
+public key not available
+public key not available
+public key not available
+],
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOKEY
+warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header V4 RSA/SHA512 Signature, key ID 1f71177215217ee0: NOKEY]
+)
+
 RPMPY_TEST([transaction callback 1],[
 def ocb(what, amount, total, key, data):
     print(what, amount, total, type(key), data)


### PR DESCRIPTION
These are internal only for now to allow us gain soem more confidence on the design.

rpmlogOnce allows showing a log message only once. rpmlogReset allows purging the list of known message keys for a given domain. This allows for different live times e.g. per transaction or per package.

Use in handleHdrVS. This does not add a new test case but various existing test cases fail when the NOKEY message is omited or shown more than once. The code uses the pointer to the rpmts object as a domain and resets it when the rpmts is freed.

Resolves: #3336
Resolves: #3395