### PR TITLE
Fix a horrible performance regression caused by missing &

### DIFF
--- a/lib/fprint.cc
+++ b/lib/fprint.cc
@@ -311,7 +311,7 @@ fingerPrint * fpLookupList(fingerPrintCache cache, rpmstrPool pool,
 }
 
 /* Check file for to be installed symlinks in their path and correct their fp */
-static void fpLookupSubdir(rpmFpHash symlinks, fingerPrintCache fpc, fingerPrint *fp)
+static void fpLookupSubdir(rpmFpHash & symlinks, fingerPrintCache fpc, fingerPrint *fp)
 {
     struct fingerPrint current_fp;
     const char *currentsubdir;


### PR DESCRIPTION
One of the busiest functions in rpm was getting passed a new copy of a big unordered_map on each call during fingerprinting because "somebody" forgot a & in commit 08a6a5e848f007c2e8d83fc1df8712d1a43229f4. This isn't even noticeable in the test-suite or daily "update a few dozen packages" operation but when attempting to install/update a few thousand packages dragged this little buglet to the light...

Why oh why C++ do you behave in such an idiotic manner in the face of stupid mistakes. Raw pointers at least give you a compiler error.