### PR TITLE
Fix rpmsign --key-id regression

### DIFF
--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -217,7 +217,7 @@ rpmbuild alias --nodebuginfo	--define 'debug_package %{nil}' \
 rpmbuild alias --build-in-place --define '_build_in_place 1' \
 	--POPTdesc=$"run build in current directory on checked out sources"
 
-rpmsign alias --key-id  --define '_gpg_name !#:+' \
+rpmsign alias --key-id  --define '_openpgp_sign_id !#:+' \
 	--POPTdesc=$"key id/name to sign with" \
 	--POPTargs=$"<id>"
 rpmsign alias --digest-algo --define '_gpg_digest_algo !#:+' \

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1301,7 +1301,7 @@ RPMTEST_CLEANUP
 # stderr is ignored due to noisy failures from gpgconf which we don't
 # care about in this test...
 AT_SETUP([rpmsign --addsign sequoia])
-AT_KEYWORDS([rpmsign signature])
+AT_KEYWORDS([rpmsign sequoia signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
 
@@ -1311,7 +1311,7 @@ cat << EOF > ${HOME}/.rpmmacros
 %_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
 EOF
 
-runroot_other sq key import /data/keys/rpm.org-rsa-2048-test.secret
+runroot_other sq key import /data/keys/*.secret
 ],
 [0],
 [ignore],
@@ -1338,6 +1338,18 @@ POST-IMPORT
     Header V4 RSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
+],
+[ignore])
+
+RPMTEST_CHECK([
+runroot rpmsign --addsign --key-id 152bb32fd9ca982797e835cfb0645aec757bf69e /tmp/hello-2.0-1.x86_64.rpm > /dev/null
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[1],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOKEY
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
 ],
 [ignore])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Commit d99186f2ef6fc0dfaaefe599a98492a84fd18940 failed to update the popt alias to the new macro. So --key-id worked only if you hadn't set %_openpgp_sign_id in your rpm macro config - the prime case for wanting to use --key-id to override that choice. Doh.  Just goes to show what you don't test, really is broken by definition...
