### PR TITLE
Fix build regression with -Wformat-security

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,7 +399,7 @@ configure_file(config.h.in config.h)
 
 add_compile_definitions(HAVE_CONFIG_H)
 
-add_compile_options(-Wall -Wpointer-arith -Wempty-body)
+add_compile_options(-Wall -Wpointer-arith -Wempty-body -Wformat-security)
 if (ENABLE_WERROR)
 	add_compile_options(-Werror)
 endif()

--- a/rpmio/rpmlog.cc
+++ b/rpmio/rpmlog.cc
@@ -443,7 +443,7 @@ int rpmlogOnce (uint64_t domain, const char * key, int code, const char *fmt, ..
 	char *msg = NULL;
 	va_start(ap, fmt);
 	if (rvasprintf(&msg, fmt, ap) >= 0) {
-	    rpmlog(code, msg);
+	    rpmlog(code, "%s", msg);
 	    free(msg);
 	}
 	va_end(ap);


### PR DESCRIPTION
Commit 547ba089313be46861fe1f5b21fbe887205697c2 broke the build with -Wformat-security. Add the trivial fix and ensure it stays that way by adding -Wformat-security to our normal build flags.