### PR TITLE
Another signature verification verbose message update

### DIFF
--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -287,11 +287,11 @@ const char *rpmsinfoDescr(struct rpmsinfo_s *sinfo)
 	case RPMSIG_SIGNATURE_TYPE:
 	    if (sinfo->sig) {
 		char *t = pgpIdentItem(sinfo->sig);
-		rasprintf(&sinfo->descr, _("%s%s"),
+		rasprintf(&sinfo->descr, _("%sOpenPGP %s"),
 			rangeName(sinfo->range), t);
 		free(t);
 	    } else {
-		rasprintf(&sinfo->descr, _("%s%s%s %s"),
+		rasprintf(&sinfo->descr, _("%sOpenPGP %s%s %s"),
 			rangeName(sinfo->range),
 			pgpValString(PGPVAL_PUBKEYALGO, sinfo->sigalgo),
 			sinfo->alt ? " ALT" : "",

--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -278,7 +278,7 @@ const char *rpmsinfoDescr(struct rpmsinfo_s *sinfo)
     if (sinfo->descr == NULL) {
 	switch (sinfo->type) {
 	case RPMSIG_DIGEST_TYPE:
-	    rasprintf(&sinfo->descr, _("%s%s%s %s"),
+	    rasprintf(&sinfo->descr, _("%s %s%s %s"),
 		    rangeName(sinfo->range),
 		    pgpValString(PGPVAL_HASHALGO, sinfo->hashalgo),
 		    sinfo->alt ? " ALT" : "",
@@ -287,11 +287,11 @@ const char *rpmsinfoDescr(struct rpmsinfo_s *sinfo)
 	case RPMSIG_SIGNATURE_TYPE:
 	    if (sinfo->sig) {
 		char *t = pgpIdentItem(sinfo->sig);
-		rasprintf(&sinfo->descr, _("%sOpenPGP %s"),
+		rasprintf(&sinfo->descr, _("%s OpenPGP %s"),
 			rangeName(sinfo->range), t);
 		free(t);
 	    } else {
-		rasprintf(&sinfo->descr, _("%sOpenPGP %s%s %s"),
+		rasprintf(&sinfo->descr, _("%s OpenPGP %s%s %s"),
 			rangeName(sinfo->range),
 			pgpValString(PGPVAL_PUBKEYALGO, sinfo->sigalgo),
 			sinfo->alt ? " ALT" : "",
@@ -571,11 +571,11 @@ static const char * rpmSigString(rpmRC res)
 static const char *rangeName(int range)
 {
     switch (range) {
-    case RPMSIG_HEADER:				return _("Header ");
-    case RPMSIG_PAYLOAD:			return _("Payload ");
+    case RPMSIG_HEADER:				return _("Header");
+    case RPMSIG_PAYLOAD:			return _("Payload");
     }
-    /* trad. output for (RPMSIG_HEADER|RPMSIG_PAYLOAD) range is "" */
-    return "";
+    /* (RPMSIG_HEADER|RPMSIG_PAYLOAD) */
+    return "Legacy";
 }
 
 static rpmRC verifyDigest(struct rpmsinfo_s *sinfo)

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -292,7 +292,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ],
 [0],
 [],
-[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 ])
 RPMTEST_CLEANUP
 
@@ -308,8 +308,8 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ],
 [1],
 [],
-[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 ])
 RPMTEST_CLEANUP
 
@@ -361,9 +361,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [1],
 [],
 [`if test x$PGP = xlegacy; then
-    echo 'error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: Corrupt PGP packet)'
+    echo 'error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Corrupt PGP packet)'
 else
-    echo 'error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:'
+    echo 'error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:'
     echo '  Failed to parse Signature Packet'
     echo '      because: Malformed packet: Subpacket extends beyond the end of the subpacket area)'
 fi`
@@ -387,7 +387,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ],
 [1],
 [],
-[error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+[error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
 error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
 error: /tmp/hello-2.0-1.x86_64-signed.rpm: Header SHA1 digest: BAD (Expected 5cd9874c510b67b44483f9e382a1649ef7743bac != 4261b2c1eb861a4152c2239bce20bfbcaa8971ba)
 error: /tmp/hello-2.0-1.x86_64-signed.rpm cannot be installed
@@ -434,19 +434,19 @@ runroot rpm -U --ignorearch --ignoreos --nodeps --noverify \
 ],
 [1],
 [INSTALL 1
-warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 INSTALL 2
 error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 INSTALL 3
-warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 INSTALL 4
 	package hello-2.0-1.x86_64 does not verify: no signature
 INSTALL 5
-warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 ],

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -367,8 +367,8 @@ public key not available
 public key not available
 public key not available
 ],
-[warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
-warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY]
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
+warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY]
 )
 
 RPMPY_TEST([transaction callback 1],[

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -418,7 +418,7 @@ runroot rpm \
 ],
 [0],
 [RSA/SHA256, Thu Apr  6 13:02:33 2017, Key ID 4344591e1964c5fc],
-[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 ])
 RPMTEST_CLEANUP
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -54,7 +54,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-1.0-1.i386.rpm
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    MD5 digest: NOTFOUND
+    Legacy MD5 digest: NOTFOUND
 ],
 [])
 RPMTEST_CLEANUP
@@ -301,7 +301,7 @@ runroot rpmkeys --define "_pkgverify_flags 0" -Kv /tmp/hello-uc.rpm
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 ALT digest: OK
-    MD5 digest: BAD (Expected 055607c4dee6464b9415ae726e7d81a7 != 839d24c30e5188e0b83599fbe3865919)
+    Legacy MD5 digest: BAD (Expected 055607c4dee6464b9415ae726e7d81a7 != 839d24c30e5188e0b83599fbe3865919)
 ],
 [])
 RPMTEST_CLEANUP
@@ -336,7 +336,7 @@ runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/${pkg}
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
+    Legacy MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
 ],
 [])
 RPMTEST_CLEANUP
@@ -358,7 +358,7 @@ runroot rpmkeys -Kv /tmp/${pkg}
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    MD5 digest: NOTFOUND
+    Legacy MD5 digest: NOTFOUND
 ],
 [])
 RPMTEST_CLEANUP
@@ -381,7 +381,7 @@ runroot rpmkeys -Kv /tmp/${pkg}
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    MD5 digest: NOTFOUND
+    Legacy MD5 digest: NOTFOUND
 ],
 [])
 RPMTEST_CLEANUP
@@ -559,8 +559,8 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
     Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -577,8 +577,8 @@ Checking package after importing key, no digest:
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -617,8 +617,8 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
     Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -635,8 +635,8 @@ RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
     Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -647,8 +647,8 @@ RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header OpenPGP DSA signature: NOTFOUND
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -687,8 +687,8 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
     Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -703,8 +703,8 @@ RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
     Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -713,8 +713,8 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header OpenPGP DSA signature: NOTFOUND
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -895,34 +895,34 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo
     Header OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Legacy OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 1
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 1
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
     Header OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Legacy OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
     Header OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Legacy OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
     Header SHA256 digest: OK
@@ -962,7 +962,7 @@ RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-confo
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 /tmp/hello-2.0-1.x86_64-signed.rpm:
 RPMOUTPUT_LEGACY([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
 RPMOUTPUT_SEQUOIA([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
@@ -971,7 +971,7 @@ RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-confo
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 ],
 [])
 RPMTEST_CLEANUP
@@ -999,15 +999,15 @@ runroot rpmkeys -Kv /tmp/${pkg}
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
-    MD5 digest: NOTFOUND
+    Legacy OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-v3-signed.rpm:
     Header OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
-    MD5 digest: NOTFOUND
+    Legacy OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Legacy MD5 digest: NOTFOUND
 ],
 [])
 RPMTEST_CLEANUP
@@ -1034,15 +1034,15 @@ runroot rpmkeys -Kv /tmp/${pkg}
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
-    MD5 digest: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
-    MD5 digest: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Legacy MD5 digest: NOTFOUND
 ],
 [])
 RPMTEST_CLEANUP
@@ -1070,16 +1070,16 @@ runroot rpmkeys -Kv /tmp/${pkg}
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
-    MD5 digest: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
-    OpenPGP DSA signature: NOTFOUND
-    MD5 digest: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy MD5 digest: NOTFOUND
 ],
 [])
 RPMTEST_CLEANUP
@@ -1110,16 +1110,16 @@ dorpm -Kv
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
-    MD5 digest: OK
+    Legacy MD5 digest: OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm: DIGESTS SIGNATURES NOT OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
-    MD5 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy MD5 digest: OK
 ]],
 [])
 RPMTEST_CLEANUP
@@ -1151,11 +1151,11 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
-    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1249,7 +1249,7 @@ runroot rpmsign --define "_pkgverify_flags 0" --key-id 4344591E1964C5FC --digest
 ],
 [1],
 [],
-[error: not signing corrupt package /tmp/hello-2.0-1.x86_64.rpm: MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
+[error: not signing corrupt package /tmp/hello-2.0-1.x86_64.rpm: Legacy MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
 ])
 
 RPMTEST_CHECK([
@@ -1260,7 +1260,7 @@ runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/hello-2.0-1.x86_64.rpm
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
+    Legacy MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
 ],
 [])
 
@@ -1287,7 +1287,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    MD5 digest: NOTFOUND
+    Legacy MD5 digest: NOTFOUND
 ],
 [])
 gpgconf --kill gpg-agent
@@ -1375,7 +1375,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64-signed.rpm|grep -v digest
 [PRE-DELSIGN
 /tmp/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
-    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64-signed.rpm:
 ],

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -19,12 +19,12 @@ runroot rpm -qp \
 	/data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm 2>&1
 ],
 [0],
-[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 hello-2.0-1.x86_64
-warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
+warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm: Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
 hello-2.0-1.x86_64
 hello-2.0-1.x86_64
-warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm: Header V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
+warning: /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm: Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
 hello-2.0-1.x86_64
 hello-2.0-1.x86_64
 ],
@@ -71,7 +71,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 ],
 [1],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
-    Header V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
+    Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 ],
@@ -93,7 +93,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 ],
 [0],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
-    Header V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 ],
@@ -196,7 +196,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 ],
 [1],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
-    Header V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
+    Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 ],
@@ -219,7 +219,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 ],
 [0],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
-    Header V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 ],
@@ -555,12 +555,12 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [[Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
-    Header DSA signature: NOTFOUND
+    Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -568,17 +568,17 @@ Checking for key:
 b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
 Checking package after importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 0
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -613,12 +613,12 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
-    Header DSA signature: NOTFOUND
+    Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -631,12 +631,12 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
-    Header V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
-    Header DSA signature: NOTFOUND
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -645,10 +645,10 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
-    Header V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
-    Header DSA signature: NOTFOUND
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
+    Header OpenPGP DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -683,12 +683,12 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
-    Header V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
-    Header DSA signature: NOTFOUND
+    Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -699,22 +699,22 @@ Checking package after importing key:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
-    Header V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
-    Header DSA signature: NOTFOUND
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
-    Header V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
-    Header DSA signature: NOTFOUND
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
+    Header OpenPGP DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -892,37 +892,37 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo
 ],
 [0],
 [/data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 1
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 1
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
     Header SHA256 digest: OK
@@ -955,23 +955,23 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
-RPMOUTPUT_LEGACY([    Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
-RPMOUTPUT_SEQUOIA([    Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
+RPMOUTPUT_LEGACY([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
+RPMOUTPUT_SEQUOIA([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
 RPMOUTPUT_SEQUOIA([  Failed to parse Signature Packet])dnl
 RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-conformant OpenPGP implementation, see <https://github.com/rpm-software-management/rpm/issues/2351>.])dnl
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-RPMOUTPUT_LEGACY([    Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
-RPMOUTPUT_SEQUOIA([    Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
+RPMOUTPUT_LEGACY([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
+RPMOUTPUT_SEQUOIA([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
 RPMOUTPUT_SEQUOIA([  Failed to parse Signature Packet])dnl
 RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-conformant OpenPGP implementation, see <https://github.com/rpm-software-management/rpm/issues/2351>.])dnl
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 ],
 [])
 RPMTEST_CLEANUP
@@ -995,18 +995,18 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Header OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-v3-signed.rpm:
-    Header V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Header OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 ],
 [])
@@ -1030,18 +1030,18 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 ],
 [])
@@ -1066,19 +1066,19 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
-    V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
-    DSA signature: NOTFOUND
+    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    OpenPGP DSA signature: NOTFOUND
     MD5 digest: NOTFOUND
 ],
 [])
@@ -1108,17 +1108,17 @@ dorpm -Kv
 [0],
 [[/data/RPMS/hello-2.0-1.x86_64-corrupted.rpm: digests SIGNATURES NOT OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
-    Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header SHA256 digest: OK
     MD5 digest: OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm: DIGESTS SIGNATURES NOT OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
     MD5 digest: OK
 ]],
 [])
@@ -1150,12 +1150,12 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
-    V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1179,10 +1179,10 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
@@ -1332,10 +1332,10 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 /tmp/hello-2.0-1.x86_64.rpm
 PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA512 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP V4 RSA/SHA512 signature, key ID 4344591e1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 RSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm
 POST-DELSIGN
@@ -1349,7 +1349,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOKEY
+    Header OpenPGP V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 ],
@@ -1374,8 +1374,8 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64-signed.rpm|grep -v digest
 [0],
 [PRE-DELSIGN
 /tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
-    V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64-signed.rpm:
 ],
@@ -1398,7 +1398,7 @@ runroot rpm -qp /data/RPMS/hello-2.0-1.x86_64-signed.rpm
 ],
 [1],
 [],
-[error: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header RSA signature: BAD (package tag 268: invalid OpenPGP signature: RPM was compiled without OpenPGP support)
+[error: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: RPM was compiled without OpenPGP support)
 error: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: not an rpm package (or package manifest)
 ])
 RPMTEST_CLEANUP
@@ -1425,10 +1425,10 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOKEY
+    Header OpenPGP V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA512 signature, key fingerprint: 152bb32fd9ca982797e835cfb0645aec757bf69e: OK
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 152bb32fd9ca982797e835cfb0645aec757bf69e: OK
 ],
 [])
 gpgconf --kill gpg-agent
@@ -1456,10 +1456,10 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 ECDSA/SHA256 signature, key ID 7f1c21f95f65bbe8: NOKEY
+    Header OpenPGP V4 ECDSA/SHA256 signature, key ID 7f1c21f95f65bbe8: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 ECDSA/SHA256 signature, key fingerprint: e8a62c0512b06b5d2183ba207f1c21f95f65bbe8: OK
+    Header OpenPGP V4 ECDSA/SHA256 signature, key fingerprint: e8a62c0512b06b5d2183ba207f1c21f95f65bbe8: OK
 ],
 [])
 
@@ -1489,12 +1489,12 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA256 signature, key ID 42655a75156b3de0: NOKEY
+    Header OpenPGP V4 EdDSA/SHA256 signature, key ID 42655a75156b3de0: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA256 signature, key fingerprint: 94706f8da571389e8642bdfd42655a75156b3de0: BAD
+    Header OpenPGP V4 EdDSA/SHA256 signature, key fingerprint: 94706f8da571389e8642bdfd42655a75156b3de0: BAD
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA256 signature, key fingerprint: 79cc07f167fee8841829acaa42655a75156b3de0: OK
+    Header OpenPGP V4 EdDSA/SHA256 signature, key fingerprint: 79cc07f167fee8841829acaa42655a75156b3de0: OK
 ],
 [error: Verifying a signature using certificate 94706F8DA571389E8642BDFD42655A75156B3DE0 ():
   Certificate 42655A75156B3DE0 does not contain key 79CC07F167FEE8841829ACAA42655A75156B3DE0 or it is not valid
@@ -1526,12 +1526,12 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [0],
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA256 signature, key ID 42655a75156b3de0: NOKEY
+    Header OpenPGP V4 EdDSA/SHA256 signature, key ID 42655a75156b3de0: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA256 signature, key fingerprint: 79cc07f167fee8841829acaa42655a75156b3de0: BAD
+    Header OpenPGP V4 EdDSA/SHA256 signature, key fingerprint: 79cc07f167fee8841829acaa42655a75156b3de0: BAD
 /tmp/hello-2.0-1.x86_64.rpm:
-    Header V4 EdDSA/SHA256 signature, key fingerprint: 94706f8da571389e8642bdfd42655a75156b3de0: OK
+    Header OpenPGP V4 EdDSA/SHA256 signature, key fingerprint: 94706f8da571389e8642bdfd42655a75156b3de0: OK
 ],
 [error: Verifying a signature using certificate 79CC07F167FEE8841829ACAA42655A75156B3DE0 ():
   Certificate 42655A75156B3DE0 does not contain key 94706F8DA571389E8642BDFD42655A75156B3DE0 or it is not valid

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -319,7 +319,7 @@ done
 [0],
 [nopls
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
@@ -327,13 +327,13 @@ done
 0
 noplds
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
     MD5 digest: OK
 1
 nohdrs
@@ -341,18 +341,18 @@ nohdrs
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     MD5 digest: OK
 0
 nosig
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header RSA signature: NOTFOUND
-    Header DSA signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    RSA signature: NOTFOUND
-    DSA signature: NOTFOUND
+    OpenPGP RSA signature: NOTFOUND
+    OpenPGP DSA signature: NOTFOUND
     MD5 digest: OK
 1
 ],

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -106,7 +106,7 @@ nopld
 /data/RPMS/hello-2.0-1.x86_64.rpm:
     Header SHA256 digest: OK
     Header SHA1 digest: OK
-    MD5 digest: OK
+    Legacy MD5 digest: OK
 0
 nopl
 /data/RPMS/hello-2.0-1.x86_64.rpm:
@@ -114,31 +114,31 @@ nopl
     Header SHA1 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    MD5 digest: NOTFOUND
+    Legacy MD5 digest: NOTFOUND
 1
 nosha1
 /data/RPMS/hello-2.0-1.x86_64.rpm:
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    MD5 digest: OK
+    Legacy MD5 digest: OK
 0
 nosha2
 /data/RPMS/hello-2.0-1.x86_64.rpm:
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    MD5 digest: OK
+    Legacy MD5 digest: OK
 0
 nosha
 /data/RPMS/hello-2.0-1.x86_64.rpm:
     Payload SHA256 digest: OK
-    MD5 digest: OK
+    Legacy MD5 digest: OK
 0
 nohdr
 /data/RPMS/hello-2.0-1.x86_64.rpm:
     Header SHA256 digest: NOTFOUND
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    MD5 digest: NOTFOUND
+    Legacy MD5 digest: NOTFOUND
 1
 ],
 [])
@@ -323,7 +323,7 @@ done
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    MD5 digest: OK
+    Legacy MD5 digest: OK
 0
 noplds
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
@@ -332,17 +332,17 @@ noplds
     Header SHA1 digest: OK
     Payload SHA256 digest: NOTFOUND
     Payload SHA256 ALT digest: NOTFOUND
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
-    MD5 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy MD5 digest: OK
 1
 nohdrs
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
-    MD5 digest: OK
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Legacy MD5 digest: OK
 0
 nosig
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
@@ -351,9 +351,9 @@ nosig
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    OpenPGP RSA signature: NOTFOUND
-    OpenPGP DSA signature: NOTFOUND
-    MD5 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy MD5 digest: OK
 1
 ],
 [])


### PR DESCRIPTION
This adds the following to verbose mode signature verification:
- OpenPGP string to all signatures (these are not raw DSA/RSA/etc but OpenPGP)
- Header+payload signatures and digests are now prefixed Legacy to make it clear what they are

Both needed to pave way for the multiple signature stuff.