### PR TITLE
Use rpmkeys --list in test cases

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -203,13 +203,14 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [])
 
 RPMTEST_CHECK([
-# XXX rpmkeys --list doesn't yet work with fs keystore
-runroot_other find /usr/lib/sysimage/rpm/pubkeys -name "*.key" | wc -l
+runroot rpmkeys --list | wc -l
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-add-subkey.asc
+runroot rpmkeys --list | wc -l
 runroot_other find /usr/lib/sysimage/rpm/pubkeys -name "*.key" | wc -l
 ],
 [0],
 [1
+1
 1
 ],
 [])
@@ -243,8 +244,7 @@ runroot rpmkeys --delete 1964c5fc
 [])
 
 RPMTEST_CHECK([
-# XXX rpmkeys --list doesn't yet work with fs keystore
-runroot_other find /usr/lib/sysimage/rpm/pubkeys -name "*.key" | wc -l
+runroot rpmkeys --list | wc -l
 ],
 [0],
 [0


### PR DESCRIPTION
This indeed does work with the fs backend nowadays. Since 42985d54824fc518b203aebfaf12e1daa3bb994a actually.