### PR TITLE
Implement openpgp.cert.d based keystore

### DIFF
--- a/lib/keystore.hh
+++ b/lib/keystore.hh
@@ -37,6 +37,13 @@ private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, unsigned int newinstance = 0);
 };
 
+class keystore_openpgp_cert_d : public keystore {
+public:
+    virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
+    virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
+    virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
+};
+
 }; /* namespace */
 
 #endif /* _KEYSTORE_H */

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -275,6 +275,8 @@ static keystore *getKeystore(rpmts ts)
 	    ts->keystore = new keystore_fs();
 	} else if (rstreq(krtype, "rpmdb")) {
 	    ts->keystore = new keystore_rpmdb();
+	} else if (rstreq(krtype, "openpgp")) {
+	    ts->keystore = new keystore_openpgp_cert_d();
 	} else {
 	    /* Fall back to using rpmdb if unknown, for now at least */
 	    rpmlog(RPMLOG_WARNING,

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -264,6 +264,83 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i38
 RPMTEST_CLEANUP
 
 
+AT_SETUP([rpmkeys key update (openpgp)])
+AT_KEYWORDS([rpmkeys signature])
+RPMDB_INIT
+# root's .rpmmacros used to keep this build prefix independent
+echo "%_keyring openpgp" >> "${RPMTEST}"/root/.rpmmacros
+RPMTEST_CHECK([
+runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
+],
+[1],
+[/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
+    Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+],
+[])
+
+RPMTEST_CHECK([
+runroot_other touch /usr/lib/sysimage/rpm/pubkeys/writelock
+runroot_other flock -x /usr/lib/sysimage/rpm/pubkeys/writelock -c "rpmkeys --import /data/keys/rpm.org-rsa-2048-add-subkey.asc"
+runroot_other rm /usr/lib/sysimage/rpm/pubkeys/writelock
+],
+[0],
+[],
+[error: Can't acquire writelock for keyring at /usr/lib/sysimage/rpm/pubkeys
+error: /data/keys/rpm.org-rsa-2048-add-subkey.asc: key 1 import failed.
+])
+
+
+RPMTEST_CHECK([
+runroot rpmkeys --list | wc -l
+runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-add-subkey.asc
+runroot rpmkeys --list | wc -l
+],
+[0],
+[1
+1
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
+],
+[0],
+[/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys --delete abcd gimmekey 1111aaaa2222bbbb
+],
+[1],
+[],
+[error: invalid key id: abcd
+error: invalid key id: gimmekey
+error: key not found: 1111aaaa2222bbbb
+])
+
+RPMTEST_CHECK([
+runroot rpmkeys --delete 1964c5fc
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys --list | wc -l
+],
+[0],
+[0
+],
+[])
+RPMTEST_CLEANUP
+
 AT_SETUP([rpmkeys -Kv <reconstructed> 1])
 AT_KEYWORDS([rpmkeys digest])
 RPMDB_INIT


### PR DESCRIPTION
Refactor code from the fs backend into shared helper functions

This does implement the layout on the file system and the write lock of the openpgp.cert.d proposal according to
https://www.ietf.org/archive/id/draft-nwjw-openpgp-cert-d-00.html but not the Trust root, Petname mapping or Trusted introducers.

This still is a mess of C and C++ style strings that we want to clean up later by adding C++ string based path handling and may be using the filesystem C++ library.

Resolves:  #3341