### PR TITLE
Add internal C++ native path manipulation functions

### DIFF
--- a/build/files.cc
+++ b/build/files.cc
@@ -32,6 +32,7 @@
 #include <rpm/rpmbase64.h>
 
 #include "rpmio_internal.hh"	/* XXX rpmioSlurp */
+#include "rpmmacro_internal.hh"
 #include "rpmfts.h"
 #include "rpmfi_internal.hh"	/* XXX fi->apath */
 #include "rpmbuild_internal.hh"
@@ -2151,7 +2152,7 @@ static int generateBuildIDs(FileList fl, ARGV_t *files)
 static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
 			       int doGlob)
 {
-    char *diskPath = NULL;
+    std::string diskPath;
     rpmRC rc = RPMRC_OK;
     size_t fnlen = strlen(fileName);
     int trailing_slash = (fnlen > 0 && fileName[fnlen-1] == '/');
@@ -2172,27 +2173,27 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
     
     /* Copy file name or glob pattern removing multiple "/" chars. */
     /*
-     * Note: rpmCleanPath should guarantee a "canonical" path. That means
+     * Note: join_path() returns a normalized path. That means
      * that the following pathologies should be weeded out:
      *		//bin//sh
      *		//usr//bin/
      *		/.././../usr/../bin//./sh
      */
-    diskPath = rpmCleanPath(rstrscat(NULL, fl->buildRoot, "/", fileName, NULL));
+    diskPath = rpm::join_path({fl->buildRoot, fileName}, false);
 
     /* Arrange trailing slash on directories */
     if (fl->cur.isDir)
-	diskPath = rstrcat(&diskPath, "/");
+	diskPath += '/';
 
     if (fl->cur.devtype)
 	doGlob = 0;
 
     if (!doGlob) {
-	rc = addFile(fl, diskPath, NULL);
+	rc = addFile(fl, diskPath.c_str(), NULL);
 	goto exit;
     }
 
-    if (rpmGlobPath(diskPath, RPMGLOB_NOCHECK, &argc, &argv))
+    if (rpmGlobPath(diskPath.c_str(), RPMGLOB_NOCHECK, &argc, &argv))
 	goto exit;
 
     for (i = 0; i < argc; i++)
@@ -2200,7 +2201,6 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
     argvFree(argv);
 
 exit:
-    free(diskPath);
     if (rc) {
 	fl->processingFailed = 1;
 	rc = RPMRC_FAIL;
@@ -2364,11 +2364,10 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     appendLineStringBuf(docScript, sdenv);
     appendLineStringBuf(docScript, mkdocdir);
     for (i = 0; i < count; i++) {
-	char *origfile = rpmCleanPath(rstrscat(NULL, basepath, "/",
-					       sd->files[i], NULL));
+	std::string origfile = rpm::join_path({basepath, sd->files[i]}, false);
 	ARGV_t argv = NULL;
 	int argc = 0;
-	if (rpmGlobPath(origfile, RPMGLOB_NOCHECK, &argc, &argv) == 0) {
+	if (rpmGlobPath(origfile.c_str(), RPMGLOB_NOCHECK, &argc, &argv) == 0) {
 	    for (j = 0; j < argc; j++) {
 		appendStringBuf(docScript, "cp -pr '");
 		appendStringBuf(docScript, argv[j]);
@@ -2377,7 +2376,6 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 		appendLineStringBuf(docScript, " ||:");
 	    }
 	}
-	free(origfile);
 	files[i] = argv;
     }
     free(basepath);

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -98,10 +98,9 @@ int rpmMkdirs(const char *root, const char *pathstr);
 char * rpmCleanPath	(char * path);
 
 /** \ingroup rpmfileutil
- * Merge 3 args into path, any or all of which may be a url.
- * The leading part of the first URL encountered is used
- * for the result, other URL prefixes are discarded, permitting
- * a primitive form of URL inheiritance.
+ * Merge 3 args into path.
+ * Contrary to what the argument names and older API docs claim,
+ * THIS DOES NOT HANDLE URL's.
  * @param urlroot	root URL (often path to chroot, or NULL)
  * @param urlmdir	directory URL (often a directory, or NULL)
  * @param urlfile	file URL (often a file, or NULL)

--- a/lib/relocation.cc
+++ b/lib/relocation.cc
@@ -9,6 +9,7 @@
 #include <rpm/rpmstring.h>
 
 #include "rpmfs.hh"
+#include "rpmmacro_internal.hh"
 #include "misc.hh"
 
 #include "debug.h"
@@ -319,16 +320,16 @@ assert(fn != NULL);		/* XXX can't happen */
 		continue;
 
 	    if (relocations[j].newPath) { /* Relocate the path */
-		char *t = NULL;
-		rstrscat(&t, relocations[j].newPath, (dirNames[i] + len), NULL);
-		/* Unfortunately rpmCleanPath strips the trailing slash.. */
-		(void) rpmCleanPath(t);
-		rstrcat(&t, "/");
+		std::string t = rpm::join_path( { relocations[j].newPath,
+						  (dirNames[i] + len) },
+						false);
+		/* join_path() strips the trailing slash, add it back */
+		t += '/';
 
-		rpmlog(RPMLOG_DEBUG,
-		       "relocating directory %s to %s\n", dirNames[i], t);
+		rpmlog(RPMLOG_DEBUG, "relocating directory %s to %s\n",
+				     dirNames[i], t.c_str());
 		free(dirNames[i]);
-		dirNames[i] = t;
+		dirNames[i] = xstrdup(t.c_str());
 		nrelocated++;
 	    }
 	}

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -2172,4 +2172,3 @@ macros::macros(rpmMacroContext mctx) :
 	mc(mctx ? mctx : rpmGlobalMacroContext), lock(mc->mutex)
 {
 }
-

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -20,9 +20,6 @@
 #include <sys/personality.h>
 #endif
 
-#if !defined(isblank)
-#define	isblank(_c)	((_c) == ' ' || (_c) == '\t')
-#endif
 #define	iseol(_c)	((_c) == '\n' || (_c) == '\r')
 
 #define MACROBUFSIZ (BUFSIZ * 2)
@@ -182,7 +179,7 @@ rdcl(char * buf, size_t size, FILE *f)
 	if (*q == 0)
 	    break;			/* no newline found, EOF */
 	if (p == buf) {
-            while (*p && isblank(*p))
+            while (*p && risblank(*p))
                 p++;
             if (*p != '%') {		/* only parse actual macro */
                 *q = '\0';		/* trim trailing \r, \n */
@@ -342,11 +339,11 @@ printExpansion(rpmMacroBuf mb, rpmMacroEntry me, const char * t, const char * te
 }
 
 #define	SKIPBLANK(_s, _c)	\
-	while (((_c) = *(_s)) && isblank(_c)) \
+	while (((_c) = *(_s)) && risblank(_c)) \
 		(_s)++;		\
 
 #define	SKIPNONBLANK(_s, _c)	\
-	while (((_c) = *(_s)) && !(isblank(_c) || iseol(_c))) \
+	while (((_c) = *(_s)) && !(risblank(_c) || iseol(_c))) \
 		(_s)++;		\
 
 #define	COPYNAME(_ne, _s, _c)	\
@@ -676,7 +673,7 @@ doDefine(rpmMacroBuf mb, const char * se, int level, int expandbody, size_t *par
 	}
 
 	/* Trim trailing blanks/newlines */
-	while (--be >= b && (c = *be) && (isblank(c) || iseol(c)))
+	while (--be >= b && (c = *be) && (risblank(c) || iseol(c)))
 	    {};
 	*(++be) = '\0';	/* one too far */
     }
@@ -694,7 +691,7 @@ doDefine(rpmMacroBuf mb, const char * se, int level, int expandbody, size_t *par
 	goto exit;
     }
 
-    if (!isblank(*sbody) && !(*sbody == '\\' && iseol(sbody[1])))
+    if (!risblank(*sbody) && !(*sbody == '\\' && iseol(sbody[1])))
 	rpmMacroBufErr(mb, 0, _("Macro %%%s needs whitespace before body\n"), n);
 
     if (expandbody) {
@@ -1545,7 +1542,7 @@ expandMacro(rpmMacroBuf mb, const char *src, size_t slen)
 	    f = s = setNegateAndCheck(s, &negate, &chkexist);
 	    fe = se;
 	    /* For "%name " macros ... */
-	    if ((c = *fe) && isblank(c))
+	    if ((c = *fe) && risblank(c))
 		if ((lastc = strchr(fe,'\n')) == NULL)
 		    lastc = strchr(fe, '\0');
 	    break;

--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -87,6 +87,16 @@ private:
     std::lock_guard<std::recursive_mutex> lock;
 };
 
+/* Join args into a / separated normalized path. Optionally expand args first */
+std::string join_path(const std::initializer_list<std::string> & args,
+			bool expand = true);
+
+/* Same as expand() but return as normalized path */
+std::string expand_path(const std::initializer_list<std::string> & args);
+
+/* Normalize a path. */
+std::string normalize_path(const std::string & args);
+
 }; /* namespace rpm */
 
 #endif	/* _H_ MACRO_INTERNAL */


### PR DESCRIPTION
The interesting part of this PR are new rpm::join_path(), rpm::expand_path() and rpm::normalize_path() functions which are more powerful C++ native counterparts of rpmGenPath(), rpmGetPath() and rpmCleanPath(), and hopefully with more meaningful names too. 

rpmGenPath() and rpmGetPath() use the C++ versions internally now, which "proves" they work as promised. rpmCleanPath() can't do so because it expects to manipulate the C string buffer passed to it. We'll deprecate it as soon as we get rid of it.

The latter commits replace a few uses of rpmCleanPath() and related C-side functions with C++ native versions to further prove these work as intended, but technically they wouldn't need to be in this PR.