### PR TITLE
Eliminate the need for run() wrapper in the test-suite

### DIFF
--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -112,7 +112,6 @@ setup_env()
 
 run()
 {
-    setup_env
     "$@" \
          --define "_tmppath ${RPMTEST}/tmp" \
          --define "_db_backend ${DBFORMAT}" \
@@ -121,7 +120,6 @@ run()
 
 rundebug()
 {
-    setup_env
     export RPM_CONFIGDIR=${RPMTEST}/@RPM_CONFIGDIR@
     cp ${RPMDATA}/macros.debug ${RPM_CONFIGDIR}/macros.d/
     run "$@"
@@ -131,13 +129,11 @@ rundebug()
 
 runroot()
 {
-    setup_env
     snapshot exec "$@"
 }
 
 runroot_other()
 {
-    setup_env
     snapshot exec "$@"
 }
 
@@ -149,7 +145,6 @@ runroot_user()
             shift 2
         ;;
     esac
-    setup_env
     runroot_other --new-session sudo -iu $RPMUSER "$@"
 }
 

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -113,9 +113,7 @@ setup_env()
 run()
 {
     "$@" \
-         --define "_tmppath ${RPMTEST}/tmp" \
-         --define "_db_backend ${DBFORMAT}" \
-         --dbpath="${RPMTEST}/var/lib/rpm/"
+         --define "_tmppath ${RPMTEST}/tmp"
 }
 
 rundebug()

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -112,8 +112,7 @@ setup_env()
 
 run()
 {
-    "$@" \
-         --define "_tmppath ${RPMTEST}/tmp"
+    "$@"
 }
 
 rundebug()
@@ -127,7 +126,8 @@ rundebug()
 
 runroot()
 {
-    snapshot exec "$@"
+    snapshot exec "$@" \
+             --define "_tmppath /var/tmp"
 }
 
 runroot_other()

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -110,16 +110,11 @@ setup_env()
     fi
 }
 
-run()
-{
-    "$@"
-}
-
 rundebug()
 {
     export RPM_CONFIGDIR=${RPMTEST}/@RPM_CONFIGDIR@
     cp ${RPMDATA}/macros.debug ${RPM_CONFIGDIR}/macros.d/
-    run "$@"
+    "$@"
     rm -f ${RPM_CONFIGDIR}/macros.d/macros.debug
     unset RPM_CONFIGDIR
 }

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -113,9 +113,8 @@ setup_env()
 run()
 {
     setup_env
-    "$@" --define "_buildhost testhost" \
+    "$@" \
          --define "_tmppath ${RPMTEST}/tmp" \
-         --define "_topdir ${RPMTEST}/build" \
          --define "_db_backend ${DBFORMAT}" \
          --dbpath="${RPMTEST}/var/lib/rpm/"
 }
@@ -133,9 +132,7 @@ rundebug()
 runroot()
 {
     setup_env
-    snapshot exec "$@" \
-             --define "_buildhost testhost" \
-             --define "_topdir /build"
+    snapshot exec "$@"
 }
 
 runroot_other()

--- a/tests/data/macros.testenv
+++ b/tests/data/macros.testenv
@@ -1,3 +1,4 @@
 # root's macro config in the test-environment
 %_buildhost testhost
 %_topdir %{getenv:RPMTEST}/build
+%_tmppath %{getenv:RPMTEST}/tmp

--- a/tests/data/macros.testenv
+++ b/tests/data/macros.testenv
@@ -1,0 +1,3 @@
+# root's macro config in the test-environment
+%_buildhost testhost
+%_topdir %{getenv:RPMTEST}/build

--- a/tests/local.at
+++ b/tests/local.at
@@ -30,10 +30,12 @@ LD_PRELOAD=${ASANLIB} ASAN_OPTIONS=detect_leaks=0 ${PYTHON} test.py
 ]])
 
 m4_define([RPMTEST_CHECK],[
+setup_env
 AT_CHECK($@)
 ])
 
 m4_define([RPMTEST_CHECK_UNQUOTED],[
+setup_env
 AT_CHECK_UNQUOTED($@)
 ])
 
@@ -61,6 +63,7 @@ RPMTEST_CHECK([RPMPY_RUN([$1])], [], [$2], [$3])
 m4_define([RPMPY_TEST],[
 AT_SETUP([$1])
 AT_KEYWORDS([python])
+setup_env
 RPMDB_INIT
 RPMPY_CHECK([$2], [$3], [$4])
 RPMTEST_CLEANUP

--- a/tests/mktree.common
+++ b/tests/mktree.common
@@ -23,4 +23,7 @@ make_install()
 
     mkdir -p $DESTDIR/build
     ln -sf ../data/SOURCES $DESTDIR/build/
+
+    # append in case Dockerfile put something in there already
+    cat @CMAKE_CURRENT_SOURCE_DIR@/data/macros.testenv >> $DESTDIR/root/.rpmmacros
 }

--- a/tests/pinned/common/buildrepr.sh
+++ b/tests/pinned/common/buildrepr.sh
@@ -4,7 +4,6 @@ runroot rpmbuild -bb --quiet \
 	--define "optflags -O2 -g" \
 	--define "_target_platform noarch-linux" \
 	--define "_binary_payload w.ufdio" \
-	--define "_buildhost localhost" \
 	--define "use_source_date_epoch_as_buildtime 1" \
 	--define "source_date_epoch_from_changelog 1" \
 	--define "build_mtime_policy clamp_to_source_date_epoch" \

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -25,7 +25,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild \
+rpmbuild \
   --define "packager Iam" \
   -ba ${RPMDATA}/SPECS/hello.spec
 ],
@@ -339,7 +339,7 @@ AT_SETUP([rpmbuild dir layout])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
-run rpmbuild \
+rpmbuild \
 	-bi --target noarch --quiet \
 	${RPMDATA}/SPECS/simple.spec
 runroot_other find /build/BUILD|sort
@@ -357,7 +357,7 @@ runroot_other find /build/BUILD|sort
 [ignore])
 
 RPMTEST_CHECK([
-run rpmbuild \
+rpmbuild \
 	-bi --target noarch --quiet \
 	--with setup \
 	${RPMDATA}/SPECS/simple.spec
@@ -386,7 +386,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild \
+rpmbuild \
   -ba ${RPMDATA}/SPECS/hello-auto.spec
 ],
 [0],
@@ -399,7 +399,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild -D="nopatches 1" \
+rpmbuild -D="nopatches 1" \
   -bp ${RPMDATA}/SPECS/hello-auto.spec
 ],
 [0],
@@ -526,7 +526,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild \
+rpmbuild \
   -bp ${RPMDATA}/SPECS/autosetup-noroot.spec
 ],
 [0],
@@ -535,7 +535,7 @@ run rpmbuild \
 
 RPMTEST_CHECK([
 
-run rpmbuild \
+rpmbuild \
   -bp ${RPMDATA}/SPECS/autosetup-singleroot.spec
 ],
 [0],
@@ -543,7 +543,7 @@ run rpmbuild \
 [ignore])
 
 RPMTEST_CHECK([
-run rpmbuild \
+rpmbuild \
   -bp ${RPMDATA}/SPECS/autosetup-singleroot1.spec
 ],
 [0],
@@ -551,7 +551,7 @@ run rpmbuild \
 [ignore])
 
 RPMTEST_CHECK([
-run rpmbuild \
+rpmbuild \
   -bp ${RPMDATA}/SPECS/autosetup-singleroot2.spec
 ],
 [0],
@@ -564,7 +564,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild \
+rpmbuild \
   -ba --quiet ${RPMDATA}/SPECS/hello-autopatch.spec
 ],
 [0],
@@ -639,7 +639,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild \
+rpmbuild \
   --define "packager Iam" \
   --rebuild ${RPMDATA}/SRPMS/hello-1.0-1.src.rpm
 ],
@@ -661,8 +661,8 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild -bi ${RPMDATA}/SPECS/hello.spec &> /dev/null
-run rpmbuild --quiet -bl --short-circuit ${RPMDATA}/SPECS/hello.spec
+rpmbuild -bi ${RPMDATA}/SPECS/hello.spec &> /dev/null
+rpmbuild --quiet -bl --short-circuit ${RPMDATA}/SPECS/hello.spec
 ],
 [0],
 [],
@@ -763,7 +763,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild \
+rpmbuild \
   -ta "${RPMDATA}/SOURCES/hello-2.0.tar.gz"
 ],
 [0],
@@ -2653,7 +2653,7 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
 
-run rpmbuild \
+rpmbuild \
   --quiet -bd ${RPMDATA}/SPECS/hello.spec
 ls ls ${RPMTEST}/build/*/*.rpm | wc --lines
 ],

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -34,6 +34,14 @@ run rpmbuild \
 [ignore])
 
 RPMTEST_CHECK([
+runroot rpm -qp --qf "%{buildhost}\n" /build/SRPMS/hello-1.0-1.src.rpm
+],
+[0],
+[testhost
+],
+[])
+
+RPMTEST_CHECK([
 
 runroot rpm -qp --qf "%{license}\n" /build/SRPMS/hello-1.0-1.src.rpm
 runroot rpm -qp --qf "%{license}\n" /build/RPMS/*/hello-1.0-1.*.rpm

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -83,7 +83,7 @@ AT_KEYWORDS([rpmdb])
 
 # This needs to run *without* RPMDB_INIT to test behavior on read-only mount
 RPMTEST_CHECK([
-run rpmdb --exportdb --dbpath ${RPMTEST}/data/misc/ > rdonly.list
+run rpmdb --exportdb > rdonly.list
 test -s rdonly.list
 ],
 [0],

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -83,7 +83,7 @@ AT_KEYWORDS([rpmdb])
 
 # This needs to run *without* RPMDB_INIT to test behavior on read-only mount
 RPMTEST_CHECK([
-run rpmdb --exportdb > rdonly.list
+rpmdb --exportdb > rdonly.list
 test -s rdonly.list
 ],
 [0],

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -867,7 +867,7 @@ for e in 1 2; do
     runroot_other cp /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm /tmp/epoch${e}.rpm
 done
 # for testing sanity
-echo '%_query_all_fmt %%{nevra}' > ${HOME}/.rpmmacros
+echo '%_query_all_fmt %%{nevra}' >> ${HOME}/.rpmmacros
 
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -10,7 +10,7 @@ RPMDB_INIT
 RPMTEST_CHECK([[
 rm -f ~/.config/rpm
 touch ~/.rpmmacros
-runroot rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
+rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
 ]],
 [0],
 [~/.rpmmacros
@@ -20,7 +20,7 @@ runroot rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
 # prefer new style if it exists
 RPMTEST_CHECK([[
 mkdir -p ~/.config/rpm
-runroot rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
+rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
 ]],
 [0],
 [~/.config/rpm/macros
@@ -59,7 +59,7 @@ RPMTEST_CLEANUP
 AT_SETUP([simple rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --define "this that" --eval '%{this}' --eval '%not_defined' --eval '%{not_defined}' --eval '%{}'
+rpm --define "this that" --eval '%{this}' --eval '%not_defined' --eval '%{not_defined}' --eval '%{}'
 ],
 [0],
 [that
@@ -71,7 +71,7 @@ runroot rpm --define "this that" --eval '%{this}' --eval '%not_defined' --eval '
 # This behavior is relied on by countless specs and various rpm internals
 # too, and most likely can never be changed.
 RPMTEST_CHECK([
-runroot rpm --eval '%{not_defined}'
+rpm --eval '%{not_defined}'
 ],
 [0],
 [%{not_defined}
@@ -83,7 +83,7 @@ RPMTEST_CLEANUP
 AT_SETUP([invalid rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --eval '%define _ that'
+rpm --eval '%define _ that'
 ],
 [1],
 [],
@@ -95,8 +95,8 @@ RPMTEST_CLEANUP
 AT_SETUP([invalid rpm --define])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --define "_ that"
-runroot rpm --define "undefine that"
+rpm --define "_ that"
+rpm --define "undefine that"
 ],
 [1],
 [],
@@ -108,8 +108,8 @@ RPMTEST_CLEANUP
 AT_SETUP([rpm --undefine])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --define "this that" --eval '1. %{this}' --undefine 'this' --eval '2. %{this'}
-runroot rpm --eval '1. %{this}' --define "this that" --eval '2. %{this}' --undefine 'this' --eval '3. %{this'}
+rpm --define "this that" --eval '1. %{this}' --undefine 'this' --eval '2. %{this'}
+rpm --eval '1. %{this}' --define "this that" --eval '2. %{this}' --undefine 'this' --eval '3. %{this'}
 ],
 [0],
 [1. that
@@ -123,7 +123,7 @@ RPMTEST_CLEANUP
 AT_SETUP([simple true conditional rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --define "this that" --eval '%{?this}'
+rpm --define "this that" --eval '%{?this}'
 ],
 [0],
 [that
@@ -133,7 +133,7 @@ RPMTEST_CLEANUP
 AT_SETUP([simple false conditional rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --define "this that" --eval '%{?that}'
+rpm --define "this that" --eval '%{?that}'
 ],
 [0],
 [
@@ -143,7 +143,7 @@ RPMTEST_CLEANUP
 AT_SETUP([nested macro in name])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --define "this that" --define "that_that foo" --eval '%{expand:%{%{this}_that}}'
+rpm --define "this that" --define "that_that foo" --eval '%{expand:%{%{this}_that}}'
 ],
 [0],
 [foo
@@ -153,7 +153,7 @@ RPMTEST_CLEANUP
 AT_SETUP([recursive macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --define 'aaa %aaa' --eval '%aaa'
+rpm --define 'aaa %aaa' --eval '%aaa'
 ],
 [1],
 [],
@@ -164,7 +164,7 @@ RPMTEST_CLEANUP
 AT_SETUP([recursive expression])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --define 'aaa %\\[%aaa\\]' --eval '%aaa'
+rpm --define 'aaa %\\[%aaa\\]' --eval '%aaa'
 ],
 [1],
 [],
@@ -176,7 +176,7 @@ AT_SETUP([parametrized macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 RPMDB_INIT
-cat << EOF > ${RPMTEST}/mtest
+cat << EOF > mtest
 %bar() bar
 %foo()\\
 %bar\\
@@ -191,7 +191,7 @@ foo 4\\
 foo 5
 EOF
 
-runroot rpm --eval '%{load:/mtest}%{foo}'
+rpm --eval '%{load:mtest}%{foo}'
 ],
 [0],
 [
@@ -212,7 +212,7 @@ RPMTEST_CLEANUP
 AT_SETUP([parametrized macro 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define '%bar() "Bar %#: %{?1} %{?2}"' \
     --define '%foo() "Foo %#: %{?1} %{?2}" %bar a' \
     --eval '%foo 1 2'
@@ -225,7 +225,7 @@ RPMTEST_CLEANUP
 AT_SETUP([parametrized macro 3])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define '%foo() 1:%1 2:%2' \
     --eval '%foo %nil bar'
 ],
@@ -237,7 +237,7 @@ RPMTEST_CLEANUP
 AT_SETUP([parametrized macro 4])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define '%bar yyy' \
     --define '%foo() %1' \
     --eval '%foo %bar' \
@@ -252,7 +252,7 @@ RPMTEST_CLEANUP
 AT_SETUP([parametrized macro 5])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define '%foo() %#:%{?1:"%1"}%{?2: "%2"}' \
     --define 'bar zzz' \
     --eval '%foo 1' \
@@ -288,7 +288,7 @@ RPMTEST_CLEANUP
 AT_SETUP([parametrized macro 6])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define '%foo(-) %{*}' \
     --eval '%foo 5 a -z -b2'
 ],
@@ -300,7 +300,7 @@ RPMTEST_CLEANUP
 AT_SETUP([parametrized macro 7])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define '%foo(zb:) %{**}' \
     --eval '%foo 5 a -z -b2'
 ],
@@ -312,7 +312,7 @@ RPMTEST_CLEANUP
 AT_SETUP([parametrized macro 8])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define 'foo(e:) %global bar %(/bin/echo %**)' \
     --eval '%{foo arg}' \
     --eval '%bar'
@@ -326,7 +326,7 @@ RPMTEST_CLEANUP
 AT_SETUP([uncompress macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define "__rpmuncompress /my/bin/rpmuncompress" \
     --eval "%{uncompress:/data/SOURCES/hello-2.0.tar.gz}"
 ],
@@ -458,9 +458,9 @@ AT_KEYWORDS([macros])
 AT_SKIP_IF([test -z "$(nproc 2>/dev/null)"])
 RPMTEST_CHECK([
 mem=$(expr $(getconf PAGESIZE) \* $(getconf _PHYS_PAGES) / 1024 / 1024)
-expr $(runroot rpm --eval "%{getncpus}") = $(nproc)
-expr $(runroot rpm --define "_smp_tasksize_thread ${mem}" --eval "%{getncpus:thread}") = 1
-expr $(runroot rpm --define "_smp_tasksize_proc ${mem}" --eval "%{getncpus:proc}") = 1
+expr $(rpm --eval "%{getncpus}") = $(nproc)
+expr $(rpm --define "_smp_tasksize_thread ${mem}" --eval "%{getncpus:thread}") = 1
+expr $(rpm --define "_smp_tasksize_proc ${mem}" --eval "%{getncpus:proc}") = 1
 ],
 [ignore],
 [1
@@ -473,7 +473,7 @@ RPMTEST_CLEANUP
 AT_SETUP([basename macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --eval "%{basename:/data/SOURCES/hello-2.0.tar.gz}"
 ],
 [0],
@@ -484,7 +484,7 @@ RPMTEST_CLEANUP
 AT_SETUP([shrink macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --eval "%{shrink:  h e  l   lo  }"
 ],
 [0],
@@ -495,7 +495,7 @@ RPMTEST_CLEANUP
 AT_SETUP([suffix macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --eval "%{suffix:/data/SOURCES/hello-2.0.tar.gz}"
 ],
 [0],
@@ -506,7 +506,7 @@ RPMTEST_CLEANUP
 AT_SETUP([url2path macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --eval "%{url2path:http://hello.org/releases/hello-2.0.tar.gz}"
 ],
 [0],
@@ -517,10 +517,10 @@ RPMTEST_CLEANUP
 AT_SETUP([macrobody macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define "somedir %{_exec_prefix}/%{_lib}" \
     --eval "%{macrobody:somedir}"
-runroot rpm \
+rpm \
     --define "something somedir" \
     --define "somedir %{_exec_prefix}/%{_lib}" \
     --eval "%{macrobody:%{something}}"
@@ -534,7 +534,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmversion macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --eval "%{rpmversion}"
+rpm --eval "%{rpmversion}"
 ],
 [0],
 [AT_PACKAGE_VERSION
@@ -545,41 +545,41 @@ RPMTEST_CLEANUP
 AT_SETUP([builtin macro arguments])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --eval "%{dirname}"
-runroot rpm --eval "%{dirname:}"
-runroot rpm --eval "%{dirname:dir}"
-runroot rpm --eval "%{dirname dir}"
-runroot rpm --eval "%dirname"
-runroot rpm --eval "%dirname dir"
-runroot rpm --eval "%dirname /"
-runroot rpm --eval "%dirname ./"
-runroot rpm --eval "%dirname .."
-runroot rpm --eval "%dirname ../"
-runroot rpm --eval "%dirname ../foo"
-runroot rpm --eval "%dirname /foo"
-runroot rpm --eval "%dirname /foo/"
-runroot rpm --eval "%dirname /foo/foobar"
-runroot rpm --eval "%dirname /foo/foobar/"
-runroot rpm --eval "%basename /foo/foobar"
-runroot rpm --eval "%basename /foo/foobar/"
-runroot rpm --eval "%basename /"
-runroot rpm --eval "%basename foobar/"
-runroot rpm --eval "%basename foobar"
-runroot rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
-runroot rpm --eval "%{uncompress}"
-runroot rpm --eval "%{uncompress:}"
-runroot rpm --eval "%{getconfdir:}"
-runroot rpm --eval "%{getconfdir:5}"
-runroot rpm --eval "%{define:}"
-runroot rpm --eval "%{define:foo}"
-runroot rpm --eval "%{define:foo bar}%{foo}"
-runroot rpm --eval "%{define foo}"
-runroot rpm --eval "%{define foo bar baz\baz}%{foo}"
-runroot rpm --eval "%{dump:foo}"
-runroot rpm --eval "%{shrink:%%%%}"
-runroot rpm --eval "%{shrink %%%%}"
-runroot rpm --eval "%shrink %%%%"
-runroot rpm --eval "%verbose foo"
+rpm --eval "%{dirname}"
+rpm --eval "%{dirname:}"
+rpm --eval "%{dirname:dir}"
+rpm --eval "%{dirname dir}"
+rpm --eval "%dirname"
+rpm --eval "%dirname dir"
+rpm --eval "%dirname /"
+rpm --eval "%dirname ./"
+rpm --eval "%dirname .."
+rpm --eval "%dirname ../"
+rpm --eval "%dirname ../foo"
+rpm --eval "%dirname /foo"
+rpm --eval "%dirname /foo/"
+rpm --eval "%dirname /foo/foobar"
+rpm --eval "%dirname /foo/foobar/"
+rpm --eval "%basename /foo/foobar"
+rpm --eval "%basename /foo/foobar/"
+rpm --eval "%basename /"
+rpm --eval "%basename foobar/"
+rpm --eval "%basename foobar"
+rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
+rpm --eval "%{uncompress}"
+rpm --eval "%{uncompress:}"
+rpm --eval "%{getconfdir:}"
+rpm --eval "%{getconfdir:5}"
+rpm --eval "%{define:}"
+rpm --eval "%{define:foo}"
+rpm --eval "%{define:foo bar}%{foo}"
+rpm --eval "%{define foo}"
+rpm --eval "%{define foo bar baz\baz}%{foo}"
+rpm --eval "%{dump:foo}"
+rpm --eval "%{shrink:%%%%}"
+rpm --eval "%{shrink %%%%}"
+rpm --eval "%shrink %%%%"
+rpm --eval "%verbose foo"
 ],
 [0],
 [.
@@ -624,7 +624,7 @@ RPMTEST_CLEANUP
 AT_SETUP([macro arguments])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define 'zzz xxx' \
     --eval '%{defined zzz}' \
     --eval '%{defined:zzz}' \
@@ -643,7 +643,7 @@ runroot rpm \
 ])
 
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define 'zzz xxx' \
     --eval '%zzz' \
     --eval '%{zzz}' \
@@ -667,7 +667,7 @@ RPMTEST_CLEANUP
 AT_SETUP([string functions])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --eval "%sub cd6317ba61e6c27b92d6bbdf2702094ff3c0c732 1 7" \
     --eval "%sub cd6317ba61e6c27b92d6bbdf2702094ff3c0c732 7 -7" \
     --eval "%sub cd6317ba61e6c27b92d6bbdf2702094ff3c0c732 -7" \
@@ -700,7 +700,7 @@ RPMTEST_CLEANUP
 AT_SETUP([expr macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define "aaa 5" \
     --define "bbb 0" \
     --eval '%{expr:4*1024}' \
@@ -742,16 +742,16 @@ RPMTEST_CLEANUP
 AT_SETUP([expr macro 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --eval '%{expr:"a"*1}'
-runroot rpm --eval '%{expr:(5+1)*4)}'
-runroot rpm --eval '%{expr:"a"=!"b"}'
-runroot rpm --eval '%{expr:4+}'
-runroot rpm --eval '%{expr:bare}'
-runroot rpm --eval '%{expr:1/0}'
-runroot rpm --eval '%{expr:0 < 1 ? 2 : 1*"a"}'
-runroot rpm --eval '%{expr:0 < 1 ? 1*"a" : 2}'
-runroot rpm --eval '%{expr:0 < 1 ? 2 : "a"}'
-runroot rpm --eval '%{expr:0 < 1 ? "a" : 2}'
+rpm --eval '%{expr:"a"*1}'
+rpm --eval '%{expr:(5+1)*4)}'
+rpm --eval '%{expr:"a"=!"b"}'
+rpm --eval '%{expr:4+}'
+rpm --eval '%{expr:bare}'
+rpm --eval '%{expr:1/0}'
+rpm --eval '%{expr:0 < 1 ? 2 : 1*"a"}'
+rpm --eval '%{expr:0 < 1 ? 1*"a" : 2}'
+rpm --eval '%{expr:0 < 1 ? 2 : "a"}'
+rpm --eval '%{expr:0 < 1 ? "a" : 2}'
 ],
 [1],
 [],
@@ -776,7 +776,7 @@ RPMTEST_CLEANUP
 AT_SETUP([ternary expressions])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --eval '%{expr: 0 ? 2 : 3}' \
     --eval '%{expr: 1 ? 2 : 3}' \
     --eval '%{expr: 0 ? 0 ? 3 : 4 : 0 ? 6 : 7}' \
@@ -806,7 +806,7 @@ RPMTEST_CLEANUP
 AT_SETUP([expression macro level])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
 	--define 'expopt(r) %[%{undefined yyy} ? "aa " : "bb "]%{-r:the -r option was set}%{!-r:the -r option was not set}' \
 	--eval '%expopt' \
 	--eval '%expopt -r' \
@@ -823,7 +823,7 @@ bb the -r option was set
 [])
 
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
 	--define 'expopt(r) %{expr:%{undefined yyy} ? "aa " : "bb "}%{-r:the -r option was set}%{!-r:the -r option was not set}' \
 	--eval '%expopt' \
 	--eval '%expopt -r' \
@@ -843,7 +843,7 @@ RPMTEST_CLEANUP
 AT_SETUP([short circuiting])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --eval '%{expr: 0 && 1 / 0}' \
     --eval '%{expr: 1 || 1 / 0}' \
     --eval '%{expr: 1 ? 2 : 1 / 0}' \
@@ -859,7 +859,7 @@ RPMTEST_CLEANUP
 AT_SETUP([shell expansion])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --eval "%(echo foo)"
 ],
 [0],
@@ -870,7 +870,7 @@ RPMTEST_CLEANUP
 AT_SETUP([expression expansion 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
     --define "aaa 5" \
     --define "bbb 0" \
     --eval '%[4*1024]' \
@@ -898,11 +898,11 @@ RPMTEST_CLEANUP
 AT_SETUP([expression expansion 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([[
-runroot rpm --define "aaa hello" --eval '%[%aaa]'
-runroot rpm --eval '%[%{foo]'
-runroot rpm --eval '%[v""]'
-runroot rpm --eval '%[v"1" + v"2"]'
-runroot rpm --eval '%[v"1" / v"2"]'
+rpm --define "aaa hello" --eval '%[%aaa]'
+rpm --eval '%[%{foo]'
+rpm --eval '%[v""]'
+rpm --eval '%[v"1" + v"2"]'
+rpm --eval '%[v"1" / v"2"]'
 ]],
 [1],
 [],
@@ -922,7 +922,7 @@ RPMTEST_CLEANUP
 AT_SETUP([expression version comparison])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
     --eval '%[v"1.0" == v"1.0"]' \
     --eval '%[v"1.0~rc" < v"1.0"]' \
     --eval '%[v"1.0~rc" > v"1.0"]' \
@@ -940,7 +940,7 @@ RPMTEST_CLEANUP
 AT_SETUP([simple lua --eval])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-runroot rpm --eval '%{lua:print(5*5)}'
+rpm --eval '%{lua:print(5*5)}'
 ],
 [0],
 [25
@@ -968,7 +968,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua macro arguments])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
 	--define "foo(a:) %{lua:print(opt.a, arg[1])}" \
 	--define "bar() %{lua:print(rpm.expand('%foo -a'..arg[2]..' '..arg[1]))}" \
 	--eval '%bar 5 3'
@@ -981,7 +981,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua macros table])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
 	--define "qtst() %{lua:for i=1, #arg do print(' '..i..':'..arg[i]) end}"\
 	--eval "%{lua:print(macros.with('zap'), macros.without('zap'))}" \
 	--eval "%{lua:print(macros.aaa)}" \
@@ -1010,7 +1010,7 @@ that
 ])
 
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
 	--eval "%{lua:macros.defined({1,2,{}})}"
 ]],
 [1],
@@ -1022,7 +1022,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua macros recursion])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
 	--define "%recurse() %{lua:io.write(' '..#arg); if #arg < 16 then table.insert(arg, #arg); macros.recurse(arg) end;}" \
 	--eval "%recurse"
 ]],
@@ -1034,7 +1034,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua rpm extensions 1])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-runroot rpm --eval '%{lua: rpm.define("foo bar") print(rpm.expand("%{foo}"))}'
+rpm --eval '%{lua: rpm.define("foo bar") print(rpm.expand("%{foo}"))}'
 ],
 [0],
 [bar
@@ -1044,7 +1044,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua rpm extensions 2])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-runroot rpm --eval '%{lua: print(rpm.vercmp("1.0", "2.0"))}'
+rpm --eval '%{lua: print(rpm.vercmp("1.0", "2.0"))}'
 ],
 [0],
 [-1
@@ -1054,7 +1054,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua rpm isdefined])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
 	--eval '%{lua: print(rpm.isdefined("with"))}' \
 	--eval '%{lua: print(rpm.isdefined("nil"))}' \
 	--eval '%{lua: print(rpm.isdefined("ponies"))}'
@@ -1069,7 +1069,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua rpm split/unsplitargs])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
 	--eval '%{lua: local a=rpm.splitargs("1 2 3");a[2]=" " .. a[2] .. " ";print(rpm.unsplitargs(a))}' \
 | tr '\037' :
 ]],
@@ -1081,7 +1081,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua posix extensions])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
   --eval '%{lua: posix.putenv("LUATEST=ok") print(posix.getenv("LUATEST"))}'
 ],
 [0],
@@ -1092,7 +1092,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua script exit behavior])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
   --eval '%{lua: os.exit()}))}'
 ],
 [1],
@@ -1104,7 +1104,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua script redirect2null])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
   --eval '%{lua: posix.redirect2null()}))}'
 ],
 [1],
@@ -1133,7 +1133,7 @@ AT_SETUP([lua auto-print])
 AT_KEYWORDS([macros lua])
 RPMDB_INIT
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
     --define 'foo() %{lua:return string.reverse(arg[1])}' \
     --eval '%foo hello' \
     --eval '%{lua:return 1, 2, 3}'
@@ -1147,7 +1147,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua rpm version objects])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
   --eval '%{lua: v1 = rpm.ver("1:4.16-5"); print(v1, v1.e, v1.v, v1.r)}' \
   --eval '%{lua: v1 = rpm.ver("4.16-1"); print(v1, v1.e, v1.v, v1.r)}' \
   --eval '%{lua: v1 = rpm.ver("4.16"); print(v1, v1.e, v1.v, v1.r)}' \
@@ -1165,7 +1165,7 @@ AT_SETUP([lua rpm io stream])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --eval '%{lua: local f = rpm.open("zzz", "w+"); f:write("gggg"); print(f:seek("cur")); f:close()}' \
   --eval '%{lua: local f = rpm.open("zzz"); print(f:read()); f:close()}' \
   --eval '%{lua: local f = rpm.open("/data/SOURCES/hello-2.0.tar.gz"); f:reopen("r.gzip"); f:seek("cur", 6); print(f:read(3)); f:close()}'
@@ -1180,7 +1180,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua functions in expressions])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
   --eval '%[lua:string.reverse("hello")]'
 ]],
 [0],
@@ -1191,7 +1191,7 @@ RPMTEST_CLEANUP
 AT_SETUP([lua hooks])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
-runroot rpm \
+rpm \
   --eval '%{lua:
 function regtest(n) for _,v in ipairs(n) do print(" "..type(v)..":"..v);end;end
 local h = rpm.register("test", regtest)
@@ -1209,7 +1209,7 @@ AT_SETUP([%define + %undefine in nested levels 1])
 AT_KEYWORDS([macros define undefine])
 RPMTEST_CHECK([
 # basic %define in nested scoping level
-runroot rpm \
+rpm \
     --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand:%undefine xxx} %{echo:%xxx}' \
     --eval .'%foo'.
 ],
@@ -1224,7 +1224,7 @@ AT_SETUP([%define + %undefine in nested levels 2])
 AT_KEYWORDS([macros define])
 RPMTEST_CHECK([
 # %define macro once in a nested scope
-runroot rpm \
+rpm \
     --define '%foo() %{expand:%define xxx 1} %{echo:%xxx}' \
     --eval .'%foo'. \
     --eval '%xxx'
@@ -1240,7 +1240,7 @@ AT_SETUP([%define + %undefine in nested levels 3])
 AT_KEYWORDS([macros define])
 RPMTEST_CHECK([
 # %define macro twice in a nested scope
-runroot rpm \
+rpm \
     --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %define xxx 2} %{echo:%xxx}' \
     --eval .'%foo'. \
     --eval '%xxx'
@@ -1253,7 +1253,7 @@ runroot rpm \
 ])
 
 RPMTEST_CHECK([
-runroot rpm --define "aa 0" --define "my() %{define:aa 1}%{define:aa 2}" --eval "%my" --eval "%aa"
+rpm --define "aa 0" --define "my() %{define:aa 1}%{define:aa 2}" --eval "%my" --eval "%aa"
 ],
 [0],
 [
@@ -1267,7 +1267,7 @@ AT_KEYWORDS([macros define global])
 RPMTEST_CHECK([
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 # %define in a nested level covered by %global
-runroot rpm \
+rpm \
     --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %global xxx 2} %{echo:%xxx}' \
     --eval .'%foo'. \
     --eval '%xxx' \
@@ -1287,7 +1287,7 @@ RPMTEST_CLEANUP
 AT_SETUP([%define in conditional macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
     --define 'dofoo() true'\
     --eval '.%{!?foo: %define foo bar}.'\
     --eval '%foo' \
@@ -1305,10 +1305,10 @@ RPMTEST_CLEANUP
 AT_SETUP([%verbose macro])
 AT_KEYWORDS([macros verbose])
 RPMTEST_CHECK([
-runroot rpm --eval '%{verbose}'
-runroot rpm -v --eval '%{verbose}'
-runroot rpm --eval '%{verbose:zzz}'
-runroot rpm -v --eval '%{verbose:zzz}'
+rpm --eval '%{verbose}'
+rpm -v --eval '%{verbose}'
+rpm --eval '%{verbose:zzz}'
+rpm -v --eval '%{verbose:zzz}'
 ],
 [0],
 [0
@@ -1321,7 +1321,7 @@ RPMTEST_CLEANUP
 AT_SETUP([%exists macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
 	--eval "%{exists:/data}" \
 	--eval "%{exists:/zzz}" \
 	--eval "%{exists}"
@@ -1337,7 +1337,7 @@ RPMTEST_CLEANUP
 AT_SETUP([%shescape macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
 	--eval "%{shescape:foo's}"
 ],
 [0],
@@ -1349,7 +1349,7 @@ RPMTEST_CLEANUP
 AT_SETUP([%shescape macro with multiple arguments])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
 	--eval "%{shescape foo bar's}"
 ],
 [0],
@@ -1361,7 +1361,7 @@ RPMTEST_CLEANUP
 AT_SETUP([macro with a line starting by "{"])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --macros "/data/macros.testfile" \
+rpm --macros "/data/macros.testfile" \
 	--eval "%first" --eval "%second"],
 [0],
 [macro_1
@@ -1373,7 +1373,7 @@ RPMTEST_CLEANUP
 AT_SETUP([macro with %if-%endif])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpmspec -q --qf "%{summary}\n%{description}\n" /data/SPECS/iftest.spec
+rpmspec -q --qf "%{summary}\n%{description}\n" /data/SPECS/iftest.spec
 ],
 [0],
 [macro 1
@@ -1409,7 +1409,7 @@ RPMTEST_CLEANUP
 AT_SETUP([macro comments])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
 	--macros /data/macros.testfile \
 	--eval "%{comment1}" \
 	--eval "%{comment2}"
@@ -1428,7 +1428,7 @@ RPMTEST_CLEANUP
 AT_SETUP([macro comments 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
 	--macros /data/macros.testfile \
 	--eval "%{comment3}"
 ],
@@ -1443,7 +1443,7 @@ RPMTEST_CLEANUP
 AT_SETUP([macro file empty lines])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm \
+rpm \
 	--macros /data/macros.testfile \
 	--eval "%{empty0}"
 ],
@@ -1461,7 +1461,7 @@ AT_SETUP([macro traceback])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 for o in "-v" ""; do
-    runroot rpm $o \
+    rpm $o \
 	--define "err %{error:bad}" \
 	--define "bar %err" \
 	--define "foo %bar zz" \
@@ -1484,7 +1484,7 @@ AT_SETUP([error macro return])
 AT_KEYWORDS([macros lua])
 
 RPMTEST_CHECK([
-runroot rpm --eval '%{error:fail}'
+rpm --eval '%{error:fail}'
 ],
 [1],
 [],
@@ -1492,7 +1492,7 @@ runroot rpm --eval '%{error:fail}'
 ])
 
 RPMTEST_CHECK([
-runroot rpm --eval '%{lua:rpm.expand("%{error:fail}")}'
+rpm --eval '%{lua:rpm.expand("%{error:fail}")}'
 ],
 [1],
 [],
@@ -1501,7 +1501,7 @@ error: lua script failed: [string "<lua>"]:1: error expanding macro
 ]])
 
 RPMTEST_CHECK([
-runroot rpm --eval '%{lua:macros.error({"fail"})}'
+rpm --eval '%{lua:macros.error({"fail"})}'
 ],
 [1],
 [],
@@ -1513,7 +1513,7 @@ RPMTEST_CLEANUP
 AT_SETUP([no space left on stdout])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-runroot rpm --eval 1 >/dev/full
+rpm --eval 1 >/dev/full
 ],
 [1],
 [],

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -338,8 +338,7 @@ RPMTEST_CLEANUP
 AT_SETUP([uncompress 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-RPMDB_INIT
-runroot_other ${RPM_CONFIGDIR_PATH}/rpmuncompress /data/SOURCES/hello-2.0.tar.gz | tar t
+${RPM_CONFIGDIR_PATH}/rpmuncompress /data/SOURCES/hello-2.0.tar.gz | tar t
 ],
 [0],
 [hello-2.0/
@@ -356,8 +355,8 @@ AT_SETUP([uncompress 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 RPMDB_INIT
-echo xxxxxxxxxxxxxxxxxxxxxxxxx > ${RPMTEST}/tmp/"some%%ath"
-runroot_other ${RPM_CONFIGDIR_PATH}/rpmuncompress "/tmp/some%%ath"
+echo xxxxxxxxxxxxxxxxxxxxxxxxx > "some%%ath"
+${RPM_CONFIGDIR_PATH}/rpmuncompress "some%%ath"
 ],
 [0],
 [xxxxxxxxxxxxxxxxxxxxxxxxx
@@ -366,40 +365,39 @@ RPMTEST_CLEANUP
 
 AT_SETUP([uncompress 3])
 AT_KEYWORDS([macros rpmuncompress])
-RPMDB_INIT
 
 RPMTEST_CHECK([
-runroot_other ${RPM_CONFIGDIR_PATH}/rpmuncompress -x -C /tmp/test-1.2.3 /data/SOURCES/test-1.2.3.zip
+${RPM_CONFIGDIR_PATH}/rpmuncompress -x -C test-1.2.3 /data/SOURCES/test-1.2.3.zip
 ],
 [0],
 [])
 
 RPMTEST_CHECK([
-runroot_other ${RPM_CONFIGDIR_PATH}/rpmuncompress -x -C /tmp/test-1.2.3-7 /data/SOURCES/test-1.2.3.7z
+${RPM_CONFIGDIR_PATH}/rpmuncompress -x -C test-1.2.3-7 /data/SOURCES/test-1.2.3.7z
 ],
 [0],
 [])
 
 
 RPMTEST_CHECK([
-runroot_other find /tmp/test-1.2.3 | sort
+find test-1.2.3 | sort
 ],
 [0],
-[/tmp/test-1.2.3
-/tmp/test-1.2.3/.gitignore
-/tmp/test-1.2.3/README.txt
-/tmp/test-1.2.3/src
-/tmp/test-1.2.3/src/README.txt
+[test-1.2.3
+test-1.2.3/.gitignore
+test-1.2.3/README.txt
+test-1.2.3/src
+test-1.2.3/src/README.txt
 ])
 RPMTEST_CHECK([
-runroot_other find /tmp/test-1.2.3-7 | sort
+find test-1.2.3-7 | sort
 ],
 [0],
-[/tmp/test-1.2.3-7
-/tmp/test-1.2.3-7/.gitignore
-/tmp/test-1.2.3-7/README.txt
-/tmp/test-1.2.3-7/src
-/tmp/test-1.2.3-7/src/README.txt
+[test-1.2.3-7
+test-1.2.3-7/.gitignore
+test-1.2.3-7/README.txt
+test-1.2.3-7/src
+test-1.2.3-7/src/README.txt
 ])
 RPMTEST_CLEANUP
 
@@ -949,10 +947,9 @@ RPMTEST_CLEANUP
 
 AT_SETUP([lua glob])
 RPMTEST_CHECK([
-RPMDB_INIT
-runroot_other mkdir -p aaa/{123,223,323,322,321}
-runroot rpm --eval "%{lua:for i,p in ipairs(rpm.glob('aaa/3*')) do print(p..'\\n') end}"
-runroot rpm --eval "%{lua:for i,p in ipairs(rpm.glob('aaa/b*', 'c')) do print(p..'\\n') end}"
+mkdir -p aaa/{123,223,323,322,321}
+rpm --eval "%{lua:for i,p in ipairs(rpm.glob('aaa/3*')) do print(p..'\\n') end}"
+rpm --eval "%{lua:for i,p in ipairs(rpm.glob('aaa/b*', 'c')) do print(p..'\\n') end}"
 ],
 [0],
 [aaa/321
@@ -1525,7 +1522,7 @@ AT_SETUP([rpmlua])
 AT_KEYWORDS([lua])
 RPMTEST_SETUP
 RPMTEST_CHECK([
-runroot_other rpmlua /data/t1.lua a b
+rpmlua /data/t1.lua a b
 ],
 [0],
 [hello world
@@ -1538,7 +1535,7 @@ b
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua --opts=ot: /data/t1.lua -- -t1 a
+rpmlua --opts=ot: /data/t1.lua -- -t1 a
 ],
 [0],
 [hello world
@@ -1550,7 +1547,7 @@ a
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua -e "print(macros.basename('/some/thing'))"
+rpmlua -e "print(macros.basename('/some/thing'))"
 ],
 [0],
 [thing
@@ -1558,7 +1555,7 @@ runroot_other rpmlua -e "print(macros.basename('/some/thing'))"
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua -e "for i, v in ipairs({'true', 'false', 'grue'}) do print(rpm.execute('/bin/'..v)) end"
+rpmlua -e "for i, v in ipairs({'true', 'false', 'grue'}) do print(rpm.execute('/bin/'..v)) end"
 ],
 [0],
 [0.0
@@ -1568,7 +1565,7 @@ nil	No such file or directory	2.0
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect2null(-1); print(string.format("%s\t%s\t%s", a,b,c)); io.flush() else posix.wait(pid) end'
+rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect2null(-1); print(string.format("%s\t%s\t%s", a,b,c)); io.flush() else posix.wait(pid) end'
 ],
 [0],
 [nil	Bad file descriptor	9.0
@@ -1591,9 +1588,8 @@ RPMTEST_CLEANUP
 
 AT_SETUP([lua rpm spawn])
 AT_KEYWORDS([macros lua])
-RPMDB_INIT
 RPMTEST_CHECK([
-runroot_other rpmlua -e "rpm.spawn({'echo', '1', '2', '3'})"
+rpmlua -e "rpm.spawn({'echo', '1', '2', '3'})"
 ],
 [0],
 [1 2 3
@@ -1601,7 +1597,7 @@ runroot_other rpmlua -e "rpm.spawn({'echo', '1', '2', '3'})"
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua \
+rpmlua \
 	-e "rpm.spawn({'echo', '1', '2', '3'}, {stdout='/dev/null'})"
 ],
 [0],
@@ -1609,7 +1605,7 @@ runroot_other rpmlua \
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua \
+rpmlua \
 	-e "rpm.spawn({'ls', '/notthere'})"
 ],
 [0],
@@ -1618,7 +1614,7 @@ runroot_other rpmlua \
 ])
 
 RPMTEST_CHECK([
-runroot_other rpmlua \
+rpmlua \
 	-e "rpm.spawn({'ls', '/notthere'}, {stderr='/dev/null'})"
 ],
 [0],
@@ -1626,7 +1622,7 @@ runroot_other rpmlua \
 [])
 
 RPMTEST_CHECK([
-runroot_other rpmlua \
+rpmlua \
 	-e "rpm.spawn({'ls', '/notthere'}, {garbage='bbb'})"
 ],
 [255],
@@ -1635,7 +1631,7 @@ runroot_other rpmlua \
 ]])
 
 RPMTEST_CHECK([
-runroot_other rpmlua -e "rpm.spawn('echo', '1', '2', '3')"
+rpmlua -e "rpm.spawn('echo', '1', '2', '3')"
 ],
 [255],
 [],
@@ -1643,7 +1639,7 @@ runroot_other rpmlua -e "rpm.spawn('echo', '1', '2', '3')"
 ]])
 
 RPMTEST_CHECK([
-runroot_other rpmlua -e "print(rpm.spawn({'cat'}, {stdin='aaa'}))"
+rpmlua -e "print(rpm.spawn({'cat'}, {stdin='aaa'}))"
 ],
 [0],
 [nil	No such file or directory	2.0
@@ -1651,8 +1647,8 @@ runroot_other rpmlua -e "print(rpm.spawn({'cat'}, {stdin='aaa'}))"
 [])
 
 RPMTEST_CHECK([
-echo 1 2 3 > ${RPMTEST}/aaa
-runroot_other rpmlua -e "rpm.spawn({'cat'}, {stdin='aaa'})"
+echo 1 2 3 > aaa
+rpmlua -e "rpm.spawn({'cat'}, {stdin='aaa'})"
 ],
 [0],
 [1 2 3

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1118,7 +1118,7 @@ AT_SETUP([lua library path])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 RPMDB_INIT
-f=$(run rpm --eval "%{_rpmconfigdir}/lua/foo.lua")
+f=$(rpm --eval "%{_rpmconfigdir}/lua/foo.lua")
 echo "bar = 'graak'" > ${RPMTEST}/${f}
 runroot rpm \
   --eval '%{lua:require "foo"; print(bar)}'
@@ -1396,7 +1396,7 @@ thing
 %bad-name 123
 EOF
 
-run rpm --macros "macros.bad" --eval "%foo"
+rpm --macros "macros.bad" --eval "%foo"
 ],
 [0],
 [bar
@@ -1664,7 +1664,7 @@ AT_SETUP([rpmlua hooks])
 AT_KEYWORDS([lua])
 
 RPMTEST_CHECK([
-run rpm --load /data/macros.hooks \
+rpm --load /data/macros.hooks \
 	--eval "%hook_this"
 ],
 [0],

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -23,7 +23,7 @@ AT_SETUP([rpm --qf -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -q --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
   -p /data/RPMS/hello-2.0-1.i686.rpm
 ],
@@ -38,7 +38,7 @@ AT_SETUP([rpm --qf -p *.src.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -q --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
   -p /data/SRPMS/hello-1.0-1.src.rpm
 ],
@@ -53,7 +53,7 @@ AT_SETUP([rpm -qp <glob>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -qp "/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm"
 ],
 [0],
@@ -68,10 +68,10 @@ AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
 
-cp "${RPMTEST}/data/RPMS/hello-1.0-1.i386.rpm" \
-   "${RPMTEST}/tmp/fallback-[[123]].0-1.i386.rpm"
+cp "/data/RPMS/hello-1.0-1.i386.rpm" \
+   "/tmp/fallback-[[123]].0-1.i386.rpm"
 
-runroot rpm \
+rpm \
   -qp "/tmp/fallback-[[123]].0-1.i386.rpm"
 ],
 [0],
@@ -84,7 +84,7 @@ AT_SETUP([rpm -qp <notfound>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -qp /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
       /data/RPMS/hello-not-there-2.0-1.x86_64.rpm \
       /data/RPMS/hello-not-there-3.0-1.x86_64.rpm
@@ -101,7 +101,7 @@ AT_SETUP([rpm -qp <glob notfound>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -qp "/data/RPMS/hello-not-there-*.x86_64.rpm" \
       /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
       /data/RPMS/hello-not-there-2.0-1.x86_64.rpm
@@ -119,7 +119,7 @@ AT_SETUP([rpm -ql -p *.src.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -ql \
   -p /data/SRPMS/hello-1.0-1.src.rpm
 ],
@@ -135,7 +135,7 @@ AT_SETUP([rpm -ql multiple *.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -ql \
   /data/SRPMS/hello-1.0-1.src.rpm /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -153,7 +153,7 @@ AT_SETUP([rpm -qp --dump])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -qp --dump \
   /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
@@ -172,7 +172,7 @@ AT_SETUP([rpmspec -q])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpmspec \
+rpmspec \
   -q --qf "%{name}" /data/SPECS/hello.spec
 ],
 [0],
@@ -185,7 +185,7 @@ AT_SETUP([rpm -ql -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -ql \
   -p /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -203,12 +203,12 @@ AT_SETUP([rpm -qp <manifest>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-cat << EOF > ${RPMTEST}/query.mft
+cat << EOF > query.mft
 /data/RPMS/hello-1.0-1.i386.rpm
 /data/RPMS/hello-1.0-1.ppc64.rpm
 /data/RPMS/foo-1.0-1.noarch.rpm
 EOF
-runroot rpm -qp --qf "%{nvr}\n" /query.mft
+rpm -qp --qf "%{nvr}\n" query.mft
 ],
 [0],
 [hello-1.0-1
@@ -225,7 +225,7 @@ AT_SETUP([rpm -q --scripts -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   -q --scripts \
   -p /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -346,7 +346,7 @@ AT_SETUP([integer array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%{filemodes}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -363,7 +363,7 @@ AT_SETUP([formatted filesbypkg query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%-10{=NAME} %{FILENAMES}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -380,7 +380,7 @@ AT_SETUP([hex formatted integer array extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%5{longfilesizes:hex}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -412,7 +412,7 @@ AT_KEYWORDS([query signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
     --queryformat="%{rsaheader:pgpsig}" \
     -qp /data/RPMS/hello-2.0-1.x86_64-signed.rpm
 ],
@@ -444,7 +444,7 @@ AT_SETUP([string array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%{basenames} ]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -472,7 +472,7 @@ AT_SETUP([empty string array extension array format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%{filenames}]]" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
 ],
@@ -486,7 +486,7 @@ AT_SETUP([empty string array extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="%{filenames}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
 ],
@@ -500,7 +500,7 @@ AT_SETUP([different sizes arrays query 1])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%{basenames} %{changelogname}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -517,7 +517,7 @@ AT_SETUP([different sizes arrays query 2])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%{name} %{changelogtime}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -532,7 +532,7 @@ AT_SETUP([different sizes arrays query 3])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%{name} %{basenames}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -547,7 +547,7 @@ AT_SETUP([different sizes arrays query 4])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="[[%{=name} %{basenames}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -564,7 +564,7 @@ AT_SETUP([non-existent string tag])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="%{vendor}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
 ],
@@ -592,7 +592,7 @@ AT_SETUP([conditional queryformat])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="%|name?{%{name}}:{no}| %|installtime?{%{installtime}}:{(not installed)}|" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
 ],
@@ -606,7 +606,7 @@ AT_SETUP([invalid tag query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="%{notag}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
 ],
@@ -621,7 +621,7 @@ AT_SETUP([invalid data for format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="%{name:depflags}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
 ],
@@ -635,7 +635,7 @@ AT_SETUP([invalid format width query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat="%ss{size}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
 ],
@@ -649,7 +649,7 @@ AT_SETUP([xml format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm -qp --xml  /data/RPMS/hello-2.0-1.x86_64.rpm
+rpm -qp --xml  /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
 [<rpmHeader>
@@ -949,7 +949,7 @@ AT_SETUP([json format 1])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm -qp --json  /data/RPMS/hello-2.0-1.x86_64.rpm
+rpm -qp --json  /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
 [[{
@@ -1211,7 +1211,7 @@ AT_SETUP([query file attribute filtering])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpmbuild -bb --quiet \
+rpmbuild -bb --quiet \
   /data/SPECS/vattrtest.spec
 
 pkg="/build/RPMS/noarch/vattrtest-1.0-1.noarch.rpm"
@@ -1266,13 +1266,13 @@ AT_SETUP([formatting name humansi, humaniec])
 AT_KEYWORDS([query, humansi, humaniec])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat '%{SIZE:humansi} %{SIZE:humaniec}\n' \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
-runroot rpm \
+rpm \
   --queryformat '%{SIZE:humansi} %{SIZE:humaniec}\n' \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
-runroot rpm \
+rpm \
   --queryformat '%{SIZE:humansi} %{SIZE:humaniec}\n' \
   -qp /data/SRPMS/foo-1.0-1.src.rpm
 ],
@@ -1289,7 +1289,7 @@ AT_SETUP([incomplete escape sequence for format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm \
+rpm \
   --queryformat='%{NAME}\n\' \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
 ],
@@ -1305,7 +1305,7 @@ AT_KEYWORDS([query])
 RPMDB_INIT
 
 RPMTEST_CHECK([
-runroot rpmspec -q --qf "[[%{*:tagnum}\n]]" --srpm /data/SPECS/mini.spec
+rpmspec -q --qf "[[%{*:tagnum}\n]]" --srpm /data/SPECS/mini.spec
 ],
 [0],
 [100
@@ -1323,7 +1323,7 @@ runroot rpmspec -q --qf "[[%{*:tagnum}\n]]" --srpm /data/SPECS/mini.spec
 [])
 
 RPMTEST_CHECK([
-runroot rpmspec -q --qf "[[%{*:tagname}\n]]" --srpm /data/SPECS/mini.spec
+rpmspec -q --qf "[[%{*:tagname}\n]]" --srpm /data/SPECS/mini.spec
 ],
 [0],
 [Headeri18ntable

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -12,7 +12,7 @@ AT_BANNER([RPM Spec Tool])
 AT_SETUP([rpmspec --query Requires])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex}\n]' \
   /data/SPECS/test-parsebits.spec
 ]],
@@ -37,7 +37,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(,)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(,): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -52,7 +52,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(;)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(;): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -67,7 +67,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(junk)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(junk): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -82,7 +82,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(pre,junk)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(pre,junk): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -97,7 +97,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(junk,pre)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(junk,pre): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -112,7 +112,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(,pre)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(,pre): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -127,7 +127,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(pre,)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(pre,): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -142,7 +142,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(pre,,postun)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(pre,,postun): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -157,7 +157,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(pre,,junk)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(pre,,junk): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -172,7 +172,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(;pre)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(;pre): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -187,7 +187,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(pre;)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(pre;): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -202,7 +202,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(pre;postun)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(pre;postun): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -217,7 +217,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --query Requires(pre;junk)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
-runroot rpmspec --query \
+rpmspec --query \
   --define 'extra Requires(pre;junk): bad' \
   --qf '[%{REQUIRENAME} %{REQUIREFLAGS:hex} %{REQUIREVERSION}\n]' \
   /data/SPECS/test-parsebits.spec
@@ -231,7 +231,7 @@ RPMTEST_CLEANUP
 
 AT_SETUP([rpmspec --parse])
 AT_KEYWORDS([rpmspec])
-RPMTEST_CHECK([runroot rpmspec --parse /data/SPECS/foo.spec],
+RPMTEST_CHECK([rpmspec --parse /data/SPECS/foo.spec],
 [0],
 [
 
@@ -273,8 +273,8 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --srpm provides])
 AT_KEYWORDS([rpmspec])
 RPMTEST_CHECK([
-runroot rpmspec -q --srpm --provides /data/SPECS/foo.spec
-runroot rpmspec -q --srpm --provides --with bus /data/SPECS/foo.spec
+rpmspec -q --srpm --provides /data/SPECS/foo.spec
+rpmspec -q --srpm --provides --with bus /data/SPECS/foo.spec
 ],
 [0],
 [foo = 1.0-1
@@ -363,7 +363,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec -q --rpms and --srpm])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([
-runroot rpmspec -q --rpms --target s390x \
+rpmspec -q --rpms --target s390x \
 	/data/SPECS/hello.spec
 ],
 [0],
@@ -372,7 +372,7 @@ runroot rpmspec -q --rpms --target s390x \
 [])
 
 RPMTEST_CHECK([
-runroot rpmspec -q --srpm \
+rpmspec -q --srpm \
 	/data/SPECS/hello.spec
 ],
 [0],

--- a/tests/rpmvercmp.at
+++ b/tests/rpmvercmp.at
@@ -2,7 +2,7 @@
 
 m4_define([RPMVERCMP],[
 RPMTEST_CHECK([
-runroot rpm --eval '%{lua: print(rpm.vercmp("$1", "$2"))}'], [0], [$3
+rpm --eval '%{lua: print(rpm.vercmp("$1", "$2"))}'], [0], [$3
 ], [])
 ])
 


### PR DESCRIPTION
Details in commit messages, but short summary: move the test-suite rpm configuration from --define's to a permanent file, and setup_env calls from the wrapper functions to RPMTEST_CHECK*(). As a result, run() becomes entirely redundant can be removed - that is, for a large class of tests, you can just use commands directly without any extra fubar.