### PR TITLE
Vacuum the sqlite rpmdb if necessary

### DIFF
--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -683,3 +683,20 @@ runroot rpm -q 'versiontest-1.0~2-1'
 [])
 
 RPMTEST_CLEANUP
+
+# ------------------------------
+AT_SETUP([rpmdb vacuum])
+AT_KEYWORDS([install rpmdb sqlite])
+RPMDB_INIT
+RPMTEST_CHECK([
+runroot rpm -U --noscripts --nodeps --ignorearch --noverify \
+  /data/RPMS/hello-1.0-1.i386.rpm
+runroot rpm -D "_sqlite_vacuum_kb 1" -vv -U --noscripts --nodeps --ignorearch \
+  /data/RPMS/hello-2.0-1.i686.rpm 2>&1 | grep VACUUM
+],
+[0],
+[D: VACUUM: 0
+D: rpmdb sqlite backend VACUUM maxfree: 1kB, free: 8kB -> 0kB
+],
+[])
+RPMTEST_CLEANUP


### PR DESCRIPTION
Check if there is 20MB in free pages and then execute a VACUUM command. The threshold can be controlled by the _sqlite_vacuum macro. Don't add this to the macros file on purpose as we don't want people to get involved with such details. Here it is mainly used for testing.

Using a 20 MB threshold should prevent the vacuuming to happend too often while still triggering after large transactions. As we install new headers first and then remove the old ones transactions leave behind large amounts of free pages.

We do not use PRAGMA auto_vacuum here as it does not defrag the database and only frees empty pages. So it still requires running VACUUM from time to time. Freeing the empty pages would get rid of the condition we use here for running VACUUM.

Using pure C for the macro expansion on purpopse in case we want to back port this.

Resolves: #3309