### PR TITLE
Make macros::expand_numeric return int64_t

### DIFF
--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -66,8 +66,8 @@ public:
     std::pair<int,std::string> expand_this(const char *n, ARGV_const_t args,
 					int flags = 0);
     /* Expand macros to numeric value, with a return code (rc, number) */
-    std::pair<int,int> expand_numeric(const std::string & src, int flags = 0);
-    std::pair<int,int> expand_numeric(const std::initializer_list<std::string> & src,
+    std::pair<int,int64_t> expand_numeric(const std::string & src, int flags = 0);
+    std::pair<int,int64_t> expand_numeric(const std::initializer_list<std::string> & src,
 					int flags = 0);
     void init(const char *macrofiles);
     bool is_defined(const char *n);


### PR DESCRIPTION
While we can't change the C API there is really no reason to add a new 32 bit API. Changing now while it is still internal.