### PR TITLE
Fix regression on build-id generation from compressed ELF files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,7 @@ if (LIBELF_FOUND)
 endif()
 if (LIBDW_FOUND)
 	set(HAVE_LIBDW 1)
+	check_library_exists(dw dwelf_elf_begin "" HAVE_DWELF_ELF_BEGIN)
 endif()
 
 check_symbol_exists(GLOB_ONLYDIR "glob.h" HAVE_GLOB_ONLYDIR)


### PR DESCRIPTION
Another cmake fallout - we even have the define in config.h.in but the actual test was missing, causing us to never use the compression aware dwelf_elf_begin() version.

The only reproducer I'm aware of is a kernel module, and we don't want to pull in the huge kernel-devel to the test CI for this. Manually verified that cmake looks for and finds it:

	-- Looking for dwelf_elf_begin in dw
	-- Looking for dwelf_elf_begin in dw - found

And building kernel module, before:

$ rpm -qpl /home/pmatilai/rpmbuild/RPMS/x86_64/kmod-lkm_example-1.0-1.x86_64.rpm /lib/modules/6.11.8-300.fc41.x86_64/lkm_example/lkm_example.ko.xz

After:

$ rpm -qpl /home/pmatilai/rpmbuild/RPMS/x86_64/kmod-lkm_example-1.0-1.x86_64.rpm /lib/modules/6.11.8-300.fc41.x86_64/lkm_example/lkm_example.ko.xz /usr/lib/.build-id
/usr/lib/.build-id/db
/usr/lib/.build-id/db/f83477ef46b0e51abd5cc1b9382be1330083c4

Fixes: RHEL-54000