### PR TITLE
Update CI to Fedora 41, disable updates by default

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -1,13 +1,14 @@
 # Supported Fedora releases: 40 41
-FROM registry.fedoraproject.org/fedora:40 AS base
+FROM registry.fedoraproject.org/fedora:41 AS base
 MAINTAINER rpm-maint@lists.rpm.org
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
 RUN rpm --quiet -q fedora-repos-modular && rpm -e fedora-repos-modular ||:
 RUN sed -i -e "s:^enabled=.$:enabled=0:g" /etc/yum.repos.d/*openh264.repo
+# updates disabled for a stable environment
+RUN sed -i -e "s:^enabled=.$:enabled=0:g" /etc/yum.repos.d/*updates*.repo
 # dummy for controlling per-repo gpgcheck via Semaphore setup
 RUN sed -i -e "s:^gpgcheck=.$:gpgcheck=1:g" /etc/yum.repos.d/*.repo
-RUN dnf -y update
 RUN dnf -y install \
   autoconf \
   bubblewrap \
@@ -53,8 +54,10 @@ RUN dnf -y install \
   pandoc \
   sequoia-sq \
   libasan \
-  libubsan \
-  && dnf clean all
+  libubsan
+# If updates to specific packages are needed, do it here
+# RUN dnf --enablerepo=updates update ...
+RUN dnf clean all
 
 RUN echo "%_dbpath $(rpm --eval '%_dbpath')" > /root/.rpmmacros
 


### PR DESCRIPTION
We basically always want to run the latest stable release, but the newer the release the more update churn there is, and that sort of instability is bad for CI. To counter that, disable updates by default. If and when we need specific updates to components, we now do it explicitly. This seems like the best of both worlds really.

Technically this is two different changes, one to bump the Fedora version and another to disable updates, but if they are separated then time goes backwards for that one commit so I think it's better to just have this as one commit.