### PR TITLE
Listen to stderr on Sequoia signing tests too

### DIFF
--- a/tests/mktree.common
+++ b/tests/mktree.common
@@ -26,4 +26,7 @@ make_install()
 
     # append in case Dockerfile put something in there already
     cat @CMAKE_CURRENT_SOURCE_DIR@/data/macros.testenv >> $DESTDIR/root/.rpmmacros
+    # gpg-connect-agent is very, very unhappy if this doesn't exist
+    mkdir -p $DESTDIR/root/.gnupg
+    chmod 700 $DESTDIR/root/.gnupg
 }

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1386,8 +1386,6 @@ gpgconf --kill gpg-agent
 RPMTEST_CLEANUP
 
 # Signing test(s) using Sequoia
-# stderr is ignored due to noisy failures from gpgconf which we don't
-# care about in this test...
 AT_SETUP([rpmsign --addsign sequoia])
 AT_KEYWORDS([rpmsign sequoia signature])
 AT_SKIP_IF([test x$PGP = xdummy])
@@ -1433,7 +1431,7 @@ DELSIGN
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],
-[ignore])
+[])
 
 RPMTEST_CHECK([
 runroot rpmsign --addsign --key-id 152bb32fd9ca982797e835cfb0645aec757bf69e /tmp/hello-2.0-1.x86_64.rpm
@@ -1445,7 +1443,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
 ],
-[ignore])
+[])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmsign --addsign multisig v4])
@@ -1584,7 +1582,7 @@ runroot rpmsign --addsign /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm
 ],
 [0],
 [],
-[ignore])
+[])
 
 RPMTEST_CHECK([
 runroot rpmkeys -K /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm
@@ -1614,7 +1612,7 @@ runroot rpmsign --resign --rpmv4 \
 ],
 [0],
 [],
-[ignore])
+[])
 
 RPMTEST_CHECK([
 runroot rpmkeys -K /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm


### PR DESCRIPTION
We were ignoring stderr on all rpmsign tests with Sequoia because of very noisy error messages from gpg-connect-agent that were not relevant to the functionality at all. Turns out these errors were caused by missing ~/.gnupg directory, for whatever reason the agent doesn't create it automatically. Make sure it's present on the test-image root account.