### PR TITLE
plugins: extend API to allow file install

### DIFF
--- a/include/rpm/rpmplugin.h
+++ b/include/rpm/rpmplugin.h
@@ -60,6 +60,12 @@ typedef rpmRC (*plugin_fsm_file_prepare_func)(rpmPlugin plugin, rpmfi fi,
 					      int fd, const char* path,
 					      const char *dest,
 					      mode_t file_mode, rpmFsmOp op);
+typedef rpmRC (*plugin_fsm_file_install_func)(rpmPlugin plugin, rpmfi fi, int dirfd,
+                                              const char *path, mode_t file_mode, rpmFsmOp op);
+typedef rpmRC (*plugin_fsm_file_archive_reader_func)(rpmPlugin plugin,
+						     FD_t payload,
+						     rpmfiles files, rpmfi *fi);
+
 
 typedef struct rpmPluginHooks_s * rpmPluginHooks;
 struct rpmPluginHooks_s {
@@ -80,6 +86,8 @@ struct rpmPluginHooks_s {
     plugin_fsm_file_pre_func		fsm_file_pre;
     plugin_fsm_file_post_func		fsm_file_post;
     plugin_fsm_file_prepare_func	fsm_file_prepare;
+    plugin_fsm_file_install_func	fsm_file_install;
+    plugin_fsm_file_archive_reader_func	fsm_file_archive_reader;
 };
 
 #ifdef __cplusplus

--- a/include/rpm/rpmtypes.h
+++ b/include/rpm/rpmtypes.h
@@ -103,11 +103,12 @@ typedef struct FD_s * FD_t;
  * Package read return codes.
  */
 typedef	enum rpmRC_e {
-    RPMRC_OK		= 0,	/*!< Generic success code */
-    RPMRC_NOTFOUND	= 1,	/*!< Generic not found code. */
-    RPMRC_FAIL		= 2,	/*!< Generic failure code. */
-    RPMRC_NOTTRUSTED	= 3,	/*!< Signature is OK, but key is not trusted. */
-    RPMRC_NOKEY		= 4	/*!< Public key is unavailable. */
+    RPMRC_OK			= 0,	/*!< Generic success code */
+    RPMRC_NOTFOUND		= 1,	/*!< Generic not found code. */
+    RPMRC_FAIL			= 2,	/*!< Generic failure code. */
+    RPMRC_NOTTRUSTED		= 3,	/*!< Signature is OK, but key is not trusted. */
+    RPMRC_NOKEY			= 4,	/*!< Public key is unavailable. */
+    RPMRC_PLUGIN_CONTENTS	= 5,	/*!< fsm_file_pre plugin is handling content */
 } rpmRC;
 
 #ifdef __cplusplus

--- a/lib/rpmplugins.hh
+++ b/lib/rpmplugins.hh
@@ -164,4 +164,23 @@ rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
                                    int fd, const char *path, const char *dest,
                                    mode_t mode, rpmFsmOp op);
 
+/** \ingroup rpmplugins
+ * Call the fsm file install plugin hook
+ * @param plugins	plugins structure
+ * @param fi		file info iterator (or NULL)
+ * @param dirfd         file object directory file descriptor
+ * @param path		file object path
+ * @param file_mode	file object mode
+ * @param op		file operation + associated flags
+ * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ */
+RPM_GNUC_INTERNAL
+rpmRC rpmpluginsCallFsmFileInstall(rpmPlugins plugins, rpmfi fi,
+				   int dirfd, const char *path,
+                                   mode_t file_mode, rpmFsmOp op);
+
+RPM_GNUC_INTERNAL
+rpmRC rpmpluginsCallFsmFileArchiveReader(rpmPlugins plugins, FD_t payload,
+					 rpmfiles files, rpmfi *fi);
+
 #endif	/* _PLUGINS_H */


### PR DESCRIPTION
Extend the plugin API with two new methods:
- plugin_fsm_file_install_func
- plugin_fsm_file_archive_reader_func

The first one allows a plugin to take care of the file install, the second instead allows a plugin to handle the archive read.

This is used in the "reflink" plugin which uses CoW to extract archives