### PR TITLE
Exempt src.rpm packages from file signature business

### DIFF
--- a/lib/psm.cc
+++ b/lib/psm.cc
@@ -150,6 +150,7 @@ rpmRC rpmInstallSourcePackage(rpmts ts, FD_t fd,
     Header h = NULL;
     rpmpsm psm = NULL;
     rpmte te = NULL;
+    rpmPlugins origplugins = NULL;
     rpmRC rpmrc;
     int specix = -1;
 
@@ -204,12 +205,20 @@ rpmRC rpmInstallSourcePackage(rpmts ts, FD_t fd,
 	    rpmfsSetAction(fs, i, FA_CREATE);
     }
 
+    /* Don't run any plugins */
+    origplugins = ts->plugins;
+    ts->plugins = rpmpluginsNew(ts);
+
     psm = rpmpsmNew(ts, te, PKG_INSTALL);
 
     if (rpmpsmUnpack(psm) == RPMRC_OK)
 	rpmrc = RPMRC_OK;
 
     rpmpsmFree(psm);
+
+    /* Restore plugins */
+    rpmpluginsFree(ts->plugins);
+    ts->plugins = origplugins;
 
 exit:
     if (rpmrc == RPMRC_OK && specix >= 0) {

--- a/lib/rpminstall.cc
+++ b/lib/rpminstall.cc
@@ -667,6 +667,7 @@ restart:
 	rpmcliProgressState = 0;
 	rpmcliProgressTotal = 0;
 	rpmcliProgressCurrent = 0;
+	rpmtsEmpty(ts);
 	for (i = 0; i < eiu->numSRPMS; i++) {
 	    if (eiu->sourceURL[i] != NULL) {
 	        rc = RPMRC_OK;

--- a/sign/rpmgensig.cc
+++ b/sign/rpmgensig.cc
@@ -698,6 +698,12 @@ static int rpmSign(const char *rpm, int deleting, int flags)
 	    flags &= ~(RPMSIGN_FLAG_RPMV4|RPMSIGN_FLAG_RPMV3);
     }
 
+    if (headerIsSource(h)) {
+	rpmlog(RPMLOG_DEBUG,
+	    _("File signatures not applicable to src.rpm: %s\n"), rpm);
+	flags &= ~(RPMSIGN_FLAG_IMA | RPMSIGN_FLAG_FSVERITY);
+    }
+
     origSigSize = headerSizeof(sigh, HEADER_MAGIC_YES);
     unloadImmutableRegion(&sigh, RPMTAG_HEADERSIGNATURES);
 

--- a/tests/rpmdevel.at
+++ b/tests/rpmdevel.at
@@ -43,12 +43,15 @@ runroot rpmbuild --quiet -bb \
 	/data/SPECS/simple.spec \
 	/data/SPECS/fakeshell.spec
 
+runroot rpmbuild --quiet -bs \
+	/data/SPECS/simple.spec
+
 runroot rpm -U /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm
 
 cmake /data/debugplugin && make && make install DESTDIR=${RPMTEST}
 
 RPMTEST_CHECK([
-runroot rpm -U /build/RPMS/noarch/simple-1.0-1.noarch.rpm
+runroot rpm -U /build/RPMS/noarch/simple-1.0-1.noarch.rpm /build/SRPMS/simple-1.0-1.src.rpm
 ],
 [0],
 [],
@@ -70,5 +73,14 @@ debug_psm_post: simple-1.0-1.noarch:0
 debug_tsm_post: 0
 debug_cleanup
 ])
-RPMTEST_CLEANUP
 
+RPMTEST_CHECK([
+runroot rpm -i /build/SRPMS/simple-1.0-1.src.rpm
+],
+[0],
+[],
+[debug_init
+debug_cleanup
+])
+
+RPMTEST_CLEANUP

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -603,14 +603,19 @@ RPMTEST_CLEANUP
 AT_SETUP([rpm -U *.src.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
-
-runroot rpm \
+rpm \
+  --define "_topdir $PWD/build" \
   -U /data/SRPMS/hello-1.0-1.src.rpm
+ls build/*
 ],
 [0],
-[ignore],
-[ignore])
+[build/SOURCES:
+hello-1.0.tar.gz
+
+build/SPECS:
+hello.spec
+],
+[])
 RPMTEST_CLEANUP
 
 # ------------------------------
@@ -618,14 +623,19 @@ RPMTEST_CLEANUP
 AT_SETUP([rpm -i *.src.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
-
-runroot rpm \
+rpm \
+  --define "_topdir $PWD/build" \
   -i /data/SRPMS/hello-1.0-1.src.rpm
+ls build/*
 ],
 [0],
-[ignore],
-[ignore])
+[build/SOURCES:
+hello-1.0.tar.gz
+
+build/SPECS:
+hello.spec
+],
+[])
 RPMTEST_CLEANUP
 
 # ------------------------------

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -639,6 +639,33 @@ hello.spec
 RPMTEST_CLEANUP
 
 # ------------------------------
+# Check if rpm -i *.src.rpm *.rpm works
+AT_SETUP([rpm -i *.src.rpm *.rpm])
+AT_KEYWORDS([install])
+RPMTEST_CHECK([
+RPMDB_INIT
+
+runroot rpm \
+  --define "_topdir /tmp/build" \
+  --ignorearch --ignoreos --nodeps \
+  -i /data/SRPMS/hello-1.0-1.src.rpm \
+     /data/RPMS/hello-2.0-1.x86_64.rpm
+runroot rpm -q hello; echo
+runroot_other sh -c 'ls /tmp/build/*'
+],
+[0],
+[hello-2.0-1.x86_64
+
+/tmp/build/SOURCES:
+hello-1.0.tar.gz
+
+/tmp/build/SPECS:
+hello.spec
+],
+[])
+RPMTEST_CLEANUP
+
+# ------------------------------
 # Various error behavior tests
 #
 AT_SETUP([rpm -i <nonexistent file>])

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1908,4 +1908,19 @@ rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" hello-2.0-1.x86_64-badima.rpm
 /usr/share/doc/hello-2.0/README:(none)
 ],
 [])
+
+RPMTEST_CHECK([
+cp /data/SRPMS/hello-1.0-1.src.rpm /tmp/
+rpmsign --debug --key-id 4344591E1964C5FC \
+	--addsign --signfiles --fskpath=/data/keys/privkey.pem \
+	/tmp/hello-1.0-1.src.rpm 2>&1 | grep "File signatures not applicable"
+# Avoid spurious NOKEY warning
+rpmsign --delsign /tmp/hello-1.0-1.src.rpm
+rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" /tmp/hello-1.0-1.src.rpm
+],
+[0],
+[D: File signatures not applicable to src.rpm: /tmp/hello-1.0-1.src.rpm
+hello-1.0.tar.gz:(none)
+],
+[])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Don't add file signatures to source packages and if they happen to be present (i.e. built with an older rpm version), ignore them when unpacking (by not running plugins at all for source packages).

AC (taken from [original bug](https://bugzilla.redhat.com/show_bug.cgi?id=2316785)):
- IMA signature don't make any sense on src.rpm files - so Fedora shouldn't be signing them, and rpm shouldn't let them
- Even if the assertion above fails and you somehow end up with an src.rpm with IMA signatures on it, rpm should not barf up on it