### PR TITLE
Tell sequoia-sq to create binary signatures too

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -631,7 +631,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 	%{__sq} sign \
         %{?_openpgp_sign_id:--signer-key %{_openpgp_sign_id}} \
 	%{?_sq_sign_cmd_extra_args} \
-        --detached --output %{shescape:%{?__signature_filename}} \
+        --binary --detached --output %{shescape:%{?__signature_filename}} \
         %{?__plaintext_filename:-- %{shescape:%{__plaintext_filename}}}
 
 %__openpgp_sign_path %{expand:%{__%{_openpgp_sign}}}


### PR DESCRIPTION
GnuPG defaults to binary so there was no option to copy/translate to Sequoia-sq, so this behavior difference got missed. ASCII-armored would work just as well, but lets be consistent.