### PR TITLE
Implement rpmkeys --rebuild

### DIFF
--- a/docs/man/rpmkeys.8.md
+++ b/docs/man/rpmkeys.8.md
@@ -27,6 +27,8 @@ The general forms of rpm digital signature commands are
 
 **rpmkeys** {**-e\|\--erase\|-d\|\--delete**} *FINGERPRINT \...*
 
+**rpmkeys** {**\--rebuild**} \[*\--drop_backends*\] \[*--\include_backend_backend BACKEND*\] \[*--\include_backend_backend BACKEND*\]
+
 **rpmkeys** {**-K\|\--checksig**} *PACKAGE\_FILE \...*
 
 The **\--checksig** option checks all the digests and signatures
@@ -63,6 +65,22 @@ as Sequoia or GnuPG. For example:
 Erase the key(s) designated by *FINGERPRINT*. For example:
 
 **rpmkeys** **\--erase 771b18d3d7baa28734333c424344591e1964c5fc**
+
+Rebuild the key storage:
+
+**rpmkeys** **\--rebuild**
+
+Recreate the public key storage. Update to the latest format and drop
+unreadable keys. This will fail if there are public keys in other
+storage backends.
+
+Adding **\--drop_backends** will delete those keys during rebuilding.
+
+Adding **\--include_backend BACKEND** will keep the keys from the given
+backend and add it to the configured one during rebuilding.
+The parameter can be given more than once. Valid values for the backends
+are **rpmdb**, **fs**, **openpgp**. This can be used to convert from
+one key storage to another.
 
 SEE ALSO
 ========

--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -134,6 +134,15 @@ rpmPubkey rpmPubkeyFree(rpmPubkey key);
  */
 rpmPubkey rpmPubkeyLink(rpmPubkey key);
 
+
+/** \ingroup rpmkeyring
+ * Return pubkey as raw bytes
+ * @param key           Pubkey
+ * @param pkt		key data
+ * @param pktlen	Length of key data
+ */
+void rpmPubkeyRawData(rpmPubkey key, unsigned const char ** pkt, size_t * pktlen);
+
 /** \ingroup rpmkeyring
  * Return base64 encoding of pubkey
  * @param key           Pubkey

--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -23,7 +23,8 @@ extern "C" {
 typedef enum rpmKeyringModifyMode_e {
     RPMKEYRING_ADD	= 1,
     RPMKEYRING_REPLACE	= 2,
-    RPMKEYRING_DELETE	= 3
+    RPMKEYRING_DELETE	= 3,
+    RPMKEYRING_MERGE	= 4,
 } rpmKeyringModifyMode;
 
 

--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -41,6 +41,13 @@ rpmKeyring rpmKeyringNew(void);
 rpmKeyring rpmKeyringFree(rpmKeyring keyring);
 
 /** \ingroup rpmkeyring
+ * Check if there are no keys in the keyring.
+ * @param keyring	keyring handle
+ * @return		1 if keyring is empy, 0 otherwise
+ */
+int rpmKeyringIsEmpty(rpmKeyring keyring);
+
+/** \ingroup rpmkeyring
  * Add a public key to keyring.
  * @param keyring	keyring handle
  * @param key		pubkey handle

--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -754,6 +754,8 @@ rpmtsi rpmtsiInit(rpmts ts);
  */
 rpmte rpmtsiNext(rpmtsi tsi, rpmElementTypes types);
 
+rpmRC rpmtsRebuildKeystore(rpmts ts, char ** loadBackends, int flags);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/keystore.hh
+++ b/lib/keystore.hh
@@ -10,6 +10,7 @@ namespace rpm {
 
 class keystore {
 public:
+    virtual std::string get_name() { return "None"; };
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring) = 0;
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0) = 0;
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key) = 0;
@@ -19,6 +20,7 @@ public:
 
 class keystore_fs : public keystore {
 public:
+    virtual std::string get_name() { return "fs"; };
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
@@ -29,6 +31,7 @@ private:
 
 class keystore_rpmdb : public keystore {
 public:
+    virtual std::string get_name() { return "rpmdb"; };
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
@@ -39,6 +42,7 @@ private:
 
 class keystore_openpgp_cert_d : public keystore {
 public:
+    virtual std::string get_name() { return "openpgp"; };
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);

--- a/lib/keystore.hh
+++ b/lib/keystore.hh
@@ -8,6 +8,8 @@
 
 namespace rpm {
 
+rpmRC check_backends(rpmtxn txn, rpmts ts);
+
 class keystore {
 public:
     virtual std::string get_name() { return "None"; };

--- a/lib/keystore.hh
+++ b/lib/keystore.hh
@@ -16,6 +16,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring) = 0;
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0) = 0;
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key) = 0;
+    virtual rpmRC rebuild(rpmtxn txn, rpmKeyring keys) = 0;
 
     virtual ~keystore() = default;
 };
@@ -26,6 +27,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
+    virtual rpmRC rebuild(rpmtxn txn, rpmKeyring keys);
 
 private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, const std::string & newname = "");
@@ -37,6 +39,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
+    virtual rpmRC rebuild(rpmtxn txn, rpmKeyring keys);
 
 private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, unsigned int newinstance = 0);
@@ -48,6 +51,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
+    virtual rpmRC rebuild(rpmtxn txn, rpmKeyring keys);
 };
 
 }; /* namespace */

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -299,6 +299,7 @@ static void loadKeyring(rpmts ts)
 	rpmtxn txn = rpmtxnBegin(ts, RPMTXN_READ);
 	if (txn) {
 	    ts->keystore->load_keys(txn, ts->keyring);
+	    check_backends(txn, ts);
 	    rpmtxnEnd(txn);
 	}
     }

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -321,7 +321,6 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
     rpmRC rc = RPMRC_FAIL;		/* assume failure */
     char *lints = NULL;
     rpmPubkey pubkey = NULL;
-    rpmPubkey oldkey = NULL;
     rpmKeyring keyring = NULL;
     int krc;
 
@@ -353,26 +352,13 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
     if ((pubkey = rpmPubkeyNew(pkt, pktlen)) == NULL)
 	goto exit;
 
-    oldkey = rpmKeyringLookupKey(keyring, pubkey);
-    if (oldkey) {
-	rpmPubkey mergedkey = NULL;
-	if (rpmPubkeyMerge(oldkey, pubkey, &mergedkey) != RPMRC_OK)
-	    goto exit;
-	if (!mergedkey) {
-	    rc = RPMRC_OK;		/* already have key */
-	    goto exit;
-	}
-	rpmPubkeyFree(pubkey);
-	pubkey = mergedkey;
-    }
-
-    krc = rpmKeyringModify(keyring, pubkey, oldkey ? RPMKEYRING_REPLACE : RPMKEYRING_ADD);
+    krc = rpmKeyringModify(keyring, pubkey, RPMKEYRING_MERGE);
     if (krc < 0)
 	goto exit;
 
     /* If we dont already have the key, make a persistent record of it */
     if (krc == 0) {
-	rc = ts->keystore->import_key(txn, pubkey, oldkey ? 1 : 0);
+	rc = ts->keystore->import_key(txn, pubkey, 1);
     } else {
 	rc = RPMRC_OK;		/* already have key */
     }
@@ -380,7 +366,6 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
 exit:
     /* Clean up. */
     rpmPubkeyFree(pubkey);
-    rpmPubkeyFree(oldkey);
 
     rpmKeyringFree(keyring);
     return rc;

--- a/rpmio/rpmkeyring.cc
+++ b/rpmio/rpmkeyring.cc
@@ -71,6 +71,14 @@ rpmKeyring rpmKeyringFree(rpmKeyring keyring)
     return NULL;
 }
 
+int rpmKeyringIsEmpty(rpmKeyring keyring)
+{
+    if (!keyring) return 1;
+    rdlock lock(keyring->mutex);
+    return keyring->keys.empty();
+}
+
+
 rpmKeyringIterator rpmKeyringInitIterator(rpmKeyring keyring, int unused)
 {
     if (!keyring || unused != 0)

--- a/rpmio/rpmkeyring.cc
+++ b/rpmio/rpmkeyring.cc
@@ -366,6 +366,17 @@ rpmPubkey rpmPubkeyLink(rpmPubkey key)
     return key;
 }
 
+void rpmPubkeyRawData(rpmPubkey key, unsigned const char ** pkt, size_t * pktlen)
+{
+    if (key) {
+	*pkt = key->pkt.data();
+	*pktlen = key->pkt.size();
+    } else {
+	*pkt = NULL;
+	*pktlen = 0;
+    }
+}
+
 char * rpmPubkeyBase64(rpmPubkey key)
 {
     char *enc = NULL;

--- a/rpmio/rpmkeyring.cc
+++ b/rpmio/rpmkeyring.cc
@@ -167,7 +167,8 @@ int rpmKeyringModify(rpmKeyring keyring, rpmPubkey key, rpmKeyringModifyMode mod
 	rpmPubkeyFree(item->second);
 	keyring->keys.erase(item);
 	rc = 0;
-    } else if ((item == range.second && mode == RPMKEYRING_ADD) || mode == RPMKEYRING_REPLACE) {
+    }
+    if ((item == range.second && mode == RPMKEYRING_ADD) || mode == RPMKEYRING_REPLACE) {
 	int subkeysCount = 0;
 	rpmPubkey *subkeys = rpmGetSubkeys(key, &subkeysCount);
 	keyring->keys.insert({key->keyid, rpmPubkeyLink(key)});

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1924,3 +1924,171 @@ hello-1.0.tar.gz:(none)
 ],
 [])
 RPMTEST_CLEANUP
+
+AT_SETUP([keyring rebuild rpmdb])
+AT_KEYWORDS([rpmkeys signature])
+RPMDB_INIT
+
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-ed25519-test.pub
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+        --define "_keyring openpgp" \
+        --import /data/keys/rpm.org-rsa-2048-add-subkey.asc
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/alice.asc
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring rpmdb" --rebuild
+]],
+[2],
+[],
+[error: public key backend fs is not empty
+])
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring rpmdb" --rebuild --include_backend fs --include_backend openpgp
+runroot rpm -qa gpg-pubkey
+runroot rpmkeys --define "_keyring rpmdb" --list
+echo "==============================================="
+runroot rpmkeys --define "_keyring fs" --list
+runroot rpmkeys --define "_keyring openpgp" --list
+runroot rpmkeys --define "_keyring rpmdb" -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm | grep "Header OpenPGP"
+]],
+[0],
+[gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc-58e63918
+gpg-pubkey-152bb32fd9ca982797e835cfb0645aec757bf69e-661d22a8
+gpg-pubkey-b6542f92f30650c36b6f41bcb3a771bfeb04e625-62521e00
+771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
+===============================================
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+],
+[ignore])
+RPMTEST_CLEANUP
+
+AT_SETUP([keyring rebuild rpmdb 2])
+AT_KEYWORDS([rpmkeys signature])
+RPMDB_INIT
+
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-ed25519-test.pub
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+        --define "_keyring openpgp" \
+        --import /data/keys/rpm.org-rsa-2048-add-subkey.asc
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/alice.asc
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring rpmdb" --rebuild --include_backend openpgp --drop_backends
+runroot rpm -qa gpg-pubkey
+runroot rpmkeys --define "_keyring rpmdb" --list
+echo "==============================================="
+runroot rpmkeys --define "_keyring fs" --list
+runroot rpmkeys --define "_keyring openpgp" --list
+runroot rpmkeys --define "_keyring rpmdb" -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm | grep "Header OpenPGP"
+]],
+[0],
+[gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc-58e63918
+gpg-pubkey-152bb32fd9ca982797e835cfb0645aec757bf69e-661d22a8
+771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+===============================================
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+],
+[ignore])
+RPMTEST_CLEANUP
+
+AT_SETUP([keyring rebuild fs])
+AT_KEYWORDS([rpmkeys signature])
+RPMDB_INIT
+
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-ed25519-test.pub
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+        --define "_keyring openpgp" \
+        --import /data/keys/rpm.org-rsa-2048-add-subkey.asc
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/alice.asc
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring fs" --rebuild --include_backend rpmdb --include_backend openpgp
+runroot rpmkeys --define "_keyring fs" --list
+echo "==============================================="
+runroot rpmkeys --define "_keyring rpmdb" --list
+runroot rpmkeys --define "_keyring openpgp" --list
+runroot rpmkeys --define "_keyring fs" -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm | grep "Header OpenPGP"
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
+===============================================
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+],
+[ignore])
+
+RPMTEST_CLEANUP
+
+AT_SETUP([keyring rebuild openpgp])
+AT_KEYWORDS([rpmkeys signature])
+RPMDB_INIT
+
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-ed25519-test.pub
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys \
+        --define "_keyring openpgp" \
+        --import /data/keys/rpm.org-rsa-2048-add-subkey.asc
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/alice.asc
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring openpgp" --rebuild --include_backend fs --include_backend rpmdb
+runroot rpmkeys --define "_keyring openpgp" --list
+echo "==============================================="
+runroot rpmkeys --define "_keyring fs" --list
+runroot rpmkeys --define "_keyring rpmdb" --list
+runroot rpmkeys --define "_keyring openpgp" -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm | grep "Header OpenPGP"
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
+===============================================
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+],
+[ignore])
+
+RPMTEST_CLEANUP


### PR DESCRIPTION
This rebuild the public key storage. If _keyring is set to a new value
keys from old storage are moved there and the old stores are deleted.
Keys are stored in the latest format. Keys no longer accepted are
dropped.

Resolves: #3347