### PR TITLE
Support alternative config home with Sequoia signing too

### DIFF
--- a/docs/man/rpmsign.8.md
+++ b/docs/man/rpmsign.8.md
@@ -153,6 +153,10 @@ Implementation specific macros:
 :   Legacy macro for configuring user id with GnuPG. Use the implementation
     independent and non-ambiguous **%\_openpgp_sign_id** instead.
 
+**%\_sq\_path**
+
+:   The location of your Sequoia configuration if not the default.
+
 For example, to configure rpm to sign with Sequoia PGP using a key with
 fingerprint of 7B36C3EE0CCE86EDBC3EFF2685B274E29F798E08 you would include
 

--- a/macros.in
+++ b/macros.in
@@ -620,6 +620,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %__gpg			@__GPG@
 %__gpg_sign_cmd			%{shescape:%{__gpg}} \
 	gpg --no-verbose --no-armor --no-secmem-warning \
+	%{?_gpg_path:--homedir %{shescape:%{_gpg_path}}} \
 	%{?_gpg_digest_algo:--digest-algo=%{_gpg_digest_algo}} \
 	%{?_gpg_sign_cmd_extra_args} \
 	%{?_openpgp_sign_id:-u %{shescape:%{_openpgp_sign_id}}} \

--- a/macros.in
+++ b/macros.in
@@ -337,6 +337,11 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #
 #%_gpg_path /some/path
 
+#	Optional alternative path for Sequoia-sq configuration, same as
+#	passing --home to sq.
+#
+#%_sq_path /some/path
+
 #	The port and machine name of an HTTP proxy host (used for FTP/HTTP).
 #
 #%_httpport
@@ -630,6 +635,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %__sq @__SQ@
 %__sq_sign_cmd		%{shescape:%{__sq}} \
 	%{__sq} sign \
+	%{?_sq_path:--homedir %{shescape:%{_sq_path}}} \
         %{?_openpgp_sign_id:--signer-key %{_openpgp_sign_id}} \
 	%{?_sq_sign_cmd_extra_args} \
         --detached --output %{shescape:%{?__signature_filename}} \

--- a/macros.in
+++ b/macros.in
@@ -332,10 +332,10 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	Default to %_gpg_name for backwards compatibility
 %_openpgp_sign_id %{?_gpg_name}
 
-#	GnuPG signing additionally supports specifying the location of
-#	its configuration files (GNUPGHOME) via %_gpg_path if needed
+#	Optional alternative path for GnuPG configuration, same as setting
+#	GNUPGHOME environment variable or passing --homedir to gpg.
 #
-#%_gpg_path
+#%_gpg_path /some/path
 
 #	The port and machine name of an HTTP proxy host (used for FTP/HTTP).
 #

--- a/macros.in
+++ b/macros.in
@@ -635,7 +635,6 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
         --detached --output %{shescape:%{?__signature_filename}} \
         %{?__plaintext_filename:-- %{shescape:%{__plaintext_filename}}}
 
-%__openpgp_sign_path %{expand:%{__%{_openpgp_sign}}}
 %__openpgp_sign_cmd %{expand:%{__%{_openpgp_sign}_sign_cmd}}
 
 #==============================================================================

--- a/sign/rpmgensig.cc
+++ b/sign/rpmgensig.cc
@@ -237,14 +237,9 @@ static int runGPG(sigTarget sigt, const char *sigfile)
 	int using_gpg = (strstr(out, "GnuPG") != NULL);
 	if (using_gpg) {
 	    const char *tty = ttyname(STDIN_FILENO);
-	    const char *gpg_path = NULL;
 
 	    if (!getenv("GPG_TTY") && (!tty || setenv("GPG_TTY", tty, 0)))
 		rpmlog(RPMLOG_WARNING, _("Could not set GPG_TTY to stdin: %m\n"));
-
-	    gpg_path = rpmExpand("%{?_gpg_path}", NULL);
-	    if (gpg_path && *gpg_path != '\0')
-		(void) setenv("GNUPGHOME", gpg_path, 1);
 	}
 	free(out);
 


### PR DESCRIPTION
Some related cleanups + doc improvements, but main point is supporting the equivalent of %_gpg_path with Sequoia too.