### PR TITLE
Make the signing macros parametric

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -619,27 +619,26 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #==============================================================================
 # ---- OpenPGP signature macros.
 #	Macro(s) to hold the arguments passed to the cmd implementing package
-#	signing.  Expansion result is parsed by popt, so be sure to use
+#	signing. Input path passed as the first argument, output as second.
+#	Expansion result is parsed by popt, so be sure to use
 #	%{shescape} where needed.
 #
 %__gpg			@__GPG@
-%__gpg_sign_cmd			%{shescape:%{__gpg}} \
+%__gpg_sign_cmd()	%{shescape:%{__gpg}} \
 	--no-verbose --no-armor --no-secmem-warning \
 	%{?_gpg_path:--homedir %{shescape:%{_gpg_path}}} \
 	%{?_gpg_digest_algo:--digest-algo=%{_gpg_digest_algo}} \
 	%{?_gpg_sign_cmd_extra_args} \
 	%{?_openpgp_sign_id:-u %{shescape:%{_openpgp_sign_id}}} \
-	-sbo %{shescape:%{?__signature_filename}} \
-	%{?__plaintext_filename:-- %{shescape:%{__plaintext_filename}}}
+	-sbo %{shescape:%{2}} -- %{shescape:%{1}}
 
 %__sq @__SQ@
-%__sq_sign_cmd		%{shescape:%{__sq}} \
+%__sq_sign_cmd()	%{shescape:%{__sq}} \
 	sign \
 	%{?_sq_path:--homedir %{shescape:%{_sq_path}}} \
         %{?_openpgp_sign_id:--signer-key %{_openpgp_sign_id}} \
 	%{?_sq_sign_cmd_extra_args} \
-        --binary --detached --output %{shescape:%{?__signature_filename}} \
-        %{?__plaintext_filename:-- %{shescape:%{__plaintext_filename}}}
+        --binary --detached --output %{shescape:%{2}} -- %{shescape:%{1}}
 
 %__openpgp_sign_cmd %{expand:%{__%{_openpgp_sign}_sign_cmd}}
 

--- a/macros.in
+++ b/macros.in
@@ -624,7 +624,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #
 %__gpg			@__GPG@
 %__gpg_sign_cmd			%{shescape:%{__gpg}} \
-	gpg --no-verbose --no-armor --no-secmem-warning \
+	--no-verbose --no-armor --no-secmem-warning \
 	%{?_gpg_path:--homedir %{shescape:%{_gpg_path}}} \
 	%{?_gpg_digest_algo:--digest-algo=%{_gpg_digest_algo}} \
 	%{?_gpg_sign_cmd_extra_args} \
@@ -634,7 +634,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 
 %__sq @__SQ@
 %__sq_sign_cmd		%{shescape:%{__sq}} \
-	%{__sq} sign \
+	sign \
 	%{?_sq_path:--homedir %{shescape:%{_sq_path}}} \
         %{?_openpgp_sign_id:--signer-key %{_openpgp_sign_id}} \
 	%{?_sq_sign_cmd_extra_args} \

--- a/sign/rpmgensig.cc
+++ b/sign/rpmgensig.cc
@@ -246,7 +246,7 @@ static int runGPG(sigTarget sigt, const char *sigfile)
 	dup2(pipefd[0], STDIN_FILENO);
 	close(pipefd[1]);
 
-	rc = execve(argv[0], argv+1, environ);
+	rc = execve(argv[0], argv, environ);
 
 	rpmlog(RPMLOG_ERR, _("Could not exec %s: %s\n"), argv[0],
 		strerror(errno));


### PR DESCRIPTION
It's not any less code, but gives us much better control over how they're called, eliminating the need for global temporary macros for passing what really are command arguments.

No functional change, but paves way for future programmatic switches such as perhaps binary/ascii signatures.

This is of course incompatible with folks who have their own custom %__gpg_sign_cmd from the past, recipes for these have unfortunately commonly floated around the internet as "necessary" for signing. These are double-underscore macros, people messing with those had better know what they're doing.

