### PR TITLE
Stringify the rest of the internal c++ macro API

### DIFF
--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -126,7 +126,8 @@ static int print_expand_trace = _PRINT_EXPAND_TRACE;
 static int expandMacro(rpmMacroBuf mb, const char *src, size_t slen);
 static int expandQuotedMacro(rpmMacroBuf mb, const char *src);
 static void pushMacro(rpmMacroContext mc,
-	const char * n, const char * o, const char * b, int level, int flags);
+	const std::string & n, const char * o, const std::string & b,
+	int level, int flags);
 static void popMacro(rpmMacroContext mc, const std::string & n);
 static int loadMacroFile(rpmMacroContext mc, const char * fn);
 /* =============================================================== */
@@ -1749,7 +1750,7 @@ static int doExpandMacros(rpmMacroContext mc, const string & src, int flags,
 }
 
 static void pushMacroAny(rpmMacroContext mc,
-	const char * n, const char * o, const char * b,
+	const string & n, const char * o, const string & b,
 	macroFunc f, void *priv, int nargs, int level, int flags)
 {
     auto res = mc->tab.insert({n, {}});
@@ -1780,7 +1781,8 @@ static void pushMacroAny(rpmMacroContext mc,
 }
 
 static void pushMacro(rpmMacroContext mc,
-	const char * n, const char * o, const char * b, int level, int flags)
+		const string & n, const char * o, const string & b,
+		int level, int flags)
 {
     return pushMacroAny(mc, n, o, b, NULL, NULL, 0, level, flags);
 }
@@ -2165,14 +2167,14 @@ int macros::pop(const std::string & n)
     return 0;
 }
 
-int macros::push(const char *n, const char *o, const char *b,
+int macros::push(const std::string & n, const char *o, const std::string & b,
 		int level, int flags)
 {
     pushMacro(mc, n, o, b, level, flags & RPMMACRO_LITERAL ? ME_LITERAL : ME_NONE);
     return 0;
 }
 
-int macros::push_aux(const char *n, const char *o,
+int macros::push_aux(const std::string & n, const char *o,
 		    macroFunc f, void *priv, int nargs,
 		    int level, int flags)
 {

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -595,7 +595,7 @@ exit:
  * @return		number of consumed characters
  */
 static void
-doDefine(rpmMacroBuf mb, const char * se, int level, int expandbody, size_t *parsed)
+doDefine(rpmMacroBuf mb, const char *se, int level, int expandbody, size_t *parsed)
 {
     const char *start = se;
     const char *s = se;
@@ -1799,7 +1799,7 @@ static void popMacro(rpmMacroContext mc, const std::string & n)
 	mc->tab.erase(entry);
 }
 
-static int defineMacro(rpmMacroContext mc, const char * macro, int level)
+static int defineMacro(rpmMacroContext mc, const std::string macro, int level)
 {
     rpmMacroBuf mb = new rpmMacroBuf_s {};
     int rc;
@@ -1807,7 +1807,7 @@ static int defineMacro(rpmMacroContext mc, const char * macro, int level)
 
     /* XXX just enough to get by */
     mb->mc = mc;
-    doDefine(mb, macro, level, 0, &parsed);
+    doDefine(mb, macro.c_str(), level, 0, &parsed);
     rc = mb->error;
     delete mb;
     return rc;
@@ -2023,7 +2023,7 @@ void macros::copy(rpm::macros & dest, int level)
     copyMacros(mc, dest.mc, level);
 }
 
-int macros::define(const char *macro, int level)
+int macros::define(const std::string & macro, int level)
 {
     return defineMacro(mc, macro, level);
 }

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -131,6 +131,15 @@ static void popMacro(rpmMacroContext mc, const char * n);
 static int loadMacroFile(rpmMacroContext mc, const char * fn);
 /* =============================================================== */
 
+static rpmMacroEntry
+findEntry(rpmMacroContext mc, const string & n, size_t *pos)
+{
+    auto const & entry = mc->tab.find(n);
+    if (entry == mc->tab.end())
+	return NULL;
+    return &entry->second.top();
+}
+
 /**
  * Find entry in macro table.
  * @param mc		macro context
@@ -145,10 +154,7 @@ findEntry(rpmMacroContext mc, const char *name, size_t namelen, size_t *pos)
     if (namelen == 0)
 	namelen = strlen(name);
     string n(name, namelen);
-    auto const & entry = mc->tab.find(n);
-    if (entry == mc->tab.end())
-	return NULL;
-    return &entry->second.top();
+    return findEntry(mc, n, pos);
 }
 
 /* =============================================================== */

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -2144,14 +2144,14 @@ void macros::init(const std::string & macrofiles)
     copyMacros(cli.mc, mc, RMIL_CMDLINE);
 }
 
-bool macros::is_defined(const char *n)
+bool macros::is_defined(const std::string & n)
 {
-    return (findEntry(mc, n, 0, NULL) != NULL);
+    return (findEntry(mc, n, NULL) != NULL);
 }
 
-bool macros::is_parametric(const char *n)
+bool macros::is_parametric(const std::string & n)
 {
-    rpmMacroEntry mep = findEntry(mc, n, 0, NULL);
+    rpmMacroEntry mep = findEntry(mc, n, NULL);
     return (mep && mep->opts);
 }
 int macros::load(const char *fn)

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -2061,12 +2061,12 @@ macros::expand(const std::initializer_list<std::string> src, int flags)
 }
 
 std::pair<int,std::string>
-macros::expand_this(const char *n, ARGV_const_t args, int flags)
+macros::expand_this(const std::string & n, ARGV_const_t args, int flags)
 {
     string target;
     int rc = 1; /* assume failure */
 
-    rpmMacroEntry mep = findEntry(mc, n, 0, NULL);
+    rpmMacroEntry mep = findEntry(mc, n, NULL);
     if (mep) {
 	rpmMacroBuf mb = mbCreate(mc, flags);
 	rc = expandThisMacro(mb, mep, args, flags);

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -2106,7 +2106,7 @@ macros::expand_numeric(const std::initializer_list<std::string> & src, int flags
     return expand_numeric(buf, flags);
 }
 
-void macros::init(const char *macrofiles)
+void macros::init(const std::string & macrofiles)
 {
     /* Define built-in macros */
     for (const struct builtins_s *b = builtinmacros; b->name; b++) {
@@ -2115,7 +2115,7 @@ void macros::init(const char *macrofiles)
     }
 
     ARGV_t pattern, globs = NULL;
-    argvSplit(&globs, macrofiles, ":");
+    argvSplit(&globs, macrofiles.c_str(), ":");
     for (pattern = globs; pattern && *pattern; pattern++) {
 	ARGV_t path, files = NULL;
 

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -129,7 +129,7 @@ static void pushMacro(rpmMacroContext mc,
 	const std::string & n, const char * o, const std::string & b,
 	int level, int flags);
 static void popMacro(rpmMacroContext mc, const std::string & n);
-static int loadMacroFile(rpmMacroContext mc, const char * fn);
+static int loadMacroFile(rpmMacroContext mc, const std::string fn);
 /* =============================================================== */
 
 static rpmMacroEntry
@@ -1824,9 +1824,9 @@ static void linenoMacro(rpmMacroBuf mb,
     }
 }
 
-static int loadMacroFile(rpmMacroContext mc, const char * fn)
+static int loadMacroFile(rpmMacroContext mc, const std::string fn)
 {
-    FILE *fd = fopen(fn, "r");
+    FILE *fd = fopen(fn.c_str(), "r");
     size_t blen = MACROBUFSIZ;
     std::vector<char> buf(blen);
     int rc = -1;
@@ -2156,7 +2156,7 @@ bool macros::is_parametric(const std::string & n)
     rpmMacroEntry mep = findEntry(mc, n, NULL);
     return (mep && mep->opts);
 }
-int macros::load(const char *fn)
+int macros::load(const string & fn)
 {
     return loadMacroFile(mc, fn);
 }

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -127,7 +127,7 @@ static int expandMacro(rpmMacroBuf mb, const char *src, size_t slen);
 static int expandQuotedMacro(rpmMacroBuf mb, const char *src);
 static void pushMacro(rpmMacroContext mc,
 	const char * n, const char * o, const char * b, int level, int flags);
-static void popMacro(rpmMacroContext mc, const char * n);
+static void popMacro(rpmMacroContext mc, const std::string & n);
 static int loadMacroFile(rpmMacroContext mc, const char * fn);
 /* =============================================================== */
 
@@ -1786,7 +1786,7 @@ static void pushMacro(rpmMacroContext mc,
 }
 
 /* Return pointer to the _previous_ macro definition (or NULL) */
-static void popMacro(rpmMacroContext mc, const char * n)
+static void popMacro(rpmMacroContext mc, const std::string & n)
 {
     auto const & entry = mc->tab.find(n);
     if (entry == mc->tab.end())
@@ -2159,7 +2159,7 @@ int macros::load(const char *fn)
     return loadMacroFile(mc, fn);
 }
 
-int macros::pop(const char *n)
+int macros::pop(const std::string & n)
 {
     popMacro(mc, n);
     return 0;

--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -74,9 +74,9 @@ public:
     bool is_parametric(const std::string & n);
     int load(const char *fn);
     int pop(const std::string & n);
-    int push(const char *n, const char *o, const char *b,
+    int push(const std::string & n, const char *o, const std::string & b,
 		int level, int flags = RPMMACRO_DEFAULT);
-    int push_aux(const char *n, const char *o,
+    int push_aux(const std::string & n, const char *o,
 		macroFunc f, void *priv, int nargs,
 		int level, int flags = RPMMACRO_DEFAULT);
 

--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -69,7 +69,7 @@ public:
     std::pair<int,int64_t> expand_numeric(const std::string & src, int flags = 0);
     std::pair<int,int64_t> expand_numeric(const std::initializer_list<std::string> & src,
 					int flags = 0);
-    void init(const char *macrofiles);
+    void init(const std::string & macrofiles);
     bool is_defined(const char *n);
     bool is_parametric(const char *n);
     int load(const char *fn);

--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -73,7 +73,7 @@ public:
     bool is_defined(const std::string & n);
     bool is_parametric(const std::string & n);
     int load(const char *fn);
-    int pop(const char *n);
+    int pop(const std::string & n);
     int push(const char *n, const char *o, const char *b,
 		int level, int flags = RPMMACRO_DEFAULT);
     int push_aux(const char *n, const char *o,

--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -63,7 +63,7 @@ public:
     std::pair<int,std::string> expand(const std::string & src, int flags = 0);
     std::pair<int,std::string> expand(const std::initializer_list<std::string> src,
 					int flags = 0);
-    std::pair<int,std::string> expand_this(const char *n, ARGV_const_t args,
+    std::pair<int,std::string> expand_this(const std::string & n, ARGV_const_t args,
 					int flags = 0);
     /* Expand macros to numeric value, with a return code (rc, number) */
     std::pair<int,int64_t> expand_numeric(const std::string & src, int flags = 0);

--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -70,8 +70,8 @@ public:
     std::pair<int,int64_t> expand_numeric(const std::initializer_list<std::string> & src,
 					int flags = 0);
     void init(const std::string & macrofiles);
-    bool is_defined(const char *n);
-    bool is_parametric(const char *n);
+    bool is_defined(const std::string & n);
+    bool is_parametric(const std::string & n);
     int load(const char *fn);
     int pop(const char *n);
     int push(const char *n, const char *o, const char *b,

--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -72,7 +72,7 @@ public:
     void init(const std::string & macrofiles);
     bool is_defined(const std::string & n);
     bool is_parametric(const std::string & n);
-    int load(const char *fn);
+    int load(const std::string & fn);
     int pop(const std::string & n);
     int push(const std::string & n, const char *o, const std::string & b,
 		int level, int flags = RPMMACRO_DEFAULT);

--- a/rpmio/rpmmacro_internal.hh
+++ b/rpmio/rpmmacro_internal.hh
@@ -57,7 +57,7 @@ public:
     void clear();
     /* Copy all macros from this context to another one */
     void copy(rpm::macros & dest, int level);
-    int define(const char *macro, int level);
+    int define(const std::string & macro, int level);
     void dump(FILE *fp = stderr);
     /* Expand macros to a C++ string, with a return code (rc, string) */
     std::pair<int,std::string> expand(const std::string & src, int flags = 0);


### PR DESCRIPTION
The initial round left a lot of const char * arguments around, and trying to use this stuff, you bang your head into them sooner than later. 

These are rather small and straightforward patches and could be probaby squashed into larger commits, but should be at least easy to review in this format.

One noteworthy exception (noted also in the commit message) is the parametric macro options that can't be converted to a string just like that because NULL and "" are two entirely different meanings there (NULL option is a non-parametric macro and "" is a parametric macro that takes no options)