### PR TITLE
Don't allow installing packages without ARCH or OS

### DIFF
--- a/lib/rpmte.cc
+++ b/lib/rpmte.cc
@@ -167,6 +167,11 @@ static int addTE(rpmte p, Header h, fnpyKey key, rpmRelocation * relocs)
 	}
     }
 
+    if (p->type != TR_REMOVED && rstreq(p->name, "gpg-pubkey")) {
+	rpmlog(RPMLOG_ERR, _("public keys can not be installed as gpg-pubkey packages; use rpmkeys --import <keyfile> for that\n"));
+	goto exit;
+    }
+
     p->isSource = headerIsSource(h);
     
     p->NEVR = headerGetAsString(h, RPMTAG_NEVR);

--- a/lib/rpmte.cc
+++ b/lib/rpmte.cc
@@ -159,9 +159,13 @@ static int addTE(rpmte p, Header h, fnpyKey key, rpmRelocation * relocs)
     p->arch = headerGetAsString(h, RPMTAG_ARCH);
     p->os = headerGetAsString(h, RPMTAG_OS);
 
-    /* gpg-pubkey's dont have os or arch (sigh), for others they are required */
-    if (!rstreq(p->name, "gpg-pubkey") && (p->arch == NULL || p->os == NULL))
-	goto exit;
+    if (p->arch == NULL || p->os == NULL) {
+	if (p->type == TR_REMOVED && rstreq(p->name, "gpg-pubkey")) {
+	    rpmlog(RPMLOG_WARNING, _("erasing gpg-pubkey packages is deprecated; use rpmkeys --delete %s\n"), p->version);
+	} else {
+	    goto exit;
+	}
+    }
 
     p->isSource = headerIsSource(h);
     

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -360,6 +360,23 @@ adding upgrade to transaction failed
 ],
 [])
 
+RPMPY_TEST([add bogus package to transaction 4],[
+
+h = ts.hdrFromFdno('${RPMDATA}/RPMS/hello-1.0-1.ppc64.rpm')
+del h["name"]
+h["name"] = "gpg-pubkey"
+try:
+    ts.addInstall(h, 'foo', 'u')
+except rpm.error as err:
+    myprint(err)
+for e in ts:
+    myprint(e.NEVRA())
+],
+[adding upgrade to transaction failed
+],
+[error: public keys can not be installed as gpg-pubkey packages; use rpmkeys --import <keyfile> for that
+])
+
 RPMPY_TEST([transaction element userdata],[
 mydata = { 'foo': 'bar', 'capstest': 'lock' }
 ts.addInstall('${RPMDATA}/RPMS/foo-1.0-1.noarch.rpm', 'u')

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -340,6 +340,26 @@ for e in ts:
 [adding upgrade to transaction failed]
 )
 
+RPMPY_TEST([add bogus package to transaction 3],[
+
+for tag in ["os", "arch", "name", "version", "release"]:
+    h = ts.hdrFromFdno('${RPMDATA}/RPMS/hello-1.0-1.ppc64.rpm')
+    del h[tag]
+    try:
+        ts.addInstall(h, 'foo', 'u')
+    except rpm.error as err:
+        myprint(err)
+for e in ts:
+    myprint(e.NEVRA())
+],
+[adding upgrade to transaction failed
+adding upgrade to transaction failed
+adding upgrade to transaction failed
+adding upgrade to transaction failed
+adding upgrade to transaction failed
+],
+[])
+
 RPMPY_TEST([transaction element userdata],[
 mydata = { 'foo': 'bar', 'capstest': 'lock' }
 ts.addInstall('${RPMDATA}/RPMS/foo-1.0-1.noarch.rpm', 'u')

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -130,7 +130,8 @@ runroot rpm -qa gpg-pubkey
 ],
 [0],
 [],
-[])
+[warning: erasing gpg-pubkey packages is deprecated; use rpmkeys --delete 771b18d3d7baa28734333c424344591e1964c5fc
+])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmkeys migrate from keyid to fingerprint (rpmdb)])

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -122,6 +122,15 @@ runroot rpmkeys --list
 [0],
 [],
 [])
+
+runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+RPMTEST_CHECK([
+runroot rpm -e gpg-pubkey-771b18d3d7baa28734333c424344591e1964c5fc
+runroot rpm -qa gpg-pubkey
+],
+[0],
+[],
+[])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmkeys migrate from keyid to fingerprint (rpmdb)])


### PR DESCRIPTION
We had an exception for public key packages in rpmte. With those now being handled in the keystore without going through the transaction machinery this is no longer needed. This also prevents people from just contrsucting their own pubkey packages and install them.

Resolves: #3344