### PR TITLE
Add support for SHA3-256 and SHA3-512

### DIFF
--- a/include/rpm/rpmcrypto.h
+++ b/include/rpm/rpmcrypto.h
@@ -23,10 +23,13 @@ typedef enum rpmHashAlgo_e {
     RPM_HASH_MD2		=  5,	/*!< MD2 */
     RPM_HASH_TIGER192		=  6,	/*!< TIGER192 */
     RPM_HASH_HAVAL_5_160	=  7,	/*!< HAVAL-5-160 */
-    RPM_HASH_SHA256		=  8,	/*!< SHA256 */
-    RPM_HASH_SHA384		=  9,	/*!< SHA384 */
-    RPM_HASH_SHA512		= 10,	/*!< SHA512 */
-    RPM_HASH_SHA224		= 11,	/*!< SHA224 */
+    RPM_HASH_SHA256		=  8,	/*!< SHA2-256 */
+    RPM_HASH_SHA384		=  9,	/*!< SHA2-384 */
+    RPM_HASH_SHA512		= 10,	/*!< SHA2-512 */
+    RPM_HASH_SHA224		= 11,	/*!< SHA2-224 */
+    RPM_HASH_SHA3_256		= 12,	/*!< SHA3-256 */
+					/*!< reserved */
+    RPM_HASH_SHA3_512		= 14,	/*!< SHA3-512 */
 } rpmHashAlgo;
 
 /** \ingroup rpmcrypto

--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -143,10 +143,13 @@ typedef enum pgpHashAlgo_e {
     PGPHASHALGO_MD2		=  5,	/*!< MD2 */
     PGPHASHALGO_TIGER192	=  6,	/*!< TIGER192 */
     PGPHASHALGO_HAVAL_5_160	=  7,	/*!< HAVAL-5-160 */
-    PGPHASHALGO_SHA256		=  8,	/*!< SHA256 */
-    PGPHASHALGO_SHA384		=  9,	/*!< SHA384 */
-    PGPHASHALGO_SHA512		= 10,	/*!< SHA512 */
-    PGPHASHALGO_SHA224		= 11,	/*!< SHA224 */
+    PGPHASHALGO_SHA256		=  8,	/*!< SHA2-256 */
+    PGPHASHALGO_SHA384		=  9,	/*!< SHA2-384 */
+    PGPHASHALGO_SHA512		= 10,	/*!< SHA2-512 */
+    PGPHASHALGO_SHA224		= 11,	/*!< SHA2-224 */
+    PGPHASHALGO_SHA3_256	= 12,	/*!< SHA3-256 */
+					/*!< 13 reserved */
+    PGPHASHALGO_SHA3_512	= 14,	/*!< SHA3-256 */
 } pgpHashAlgo;
 
 /** \ingroup rpmpgp

--- a/macros.in
+++ b/macros.in
@@ -395,6 +395,8 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	8	SHA256 (default)
 #	9	SHA384
 #	10	SHA512
+#	12	SHA3-256
+#	14	SHA3-512
 #
 %_source_filedigest_algorithm	8
 %_binary_filedigest_algorithm	8

--- a/rpmio/digest_libgcrypt.cc
+++ b/rpmio/digest_libgcrypt.cc
@@ -46,6 +46,10 @@ size_t rpmDigestLength(int hashalgo)
 	return 48;
     case RPM_HASH_SHA512:
 	return 64;
+    case RPM_HASH_SHA3_256:
+	return 32;
+    case RPM_HASH_SHA3_512:
+	return 64;
     default:
 	return 0;
     }
@@ -66,6 +70,10 @@ static int hashalgo2gcryalgo(int hashalgo)
 	return GCRY_MD_SHA384;
     case RPM_HASH_SHA512:
 	return GCRY_MD_SHA512;
+    case RPM_HASH_SHA3_256:
+	return GCRY_MD_SHA3_256;
+    case RPM_HASH_SHA3_512:
+	return GCRY_MD_SHA3_512;
     default:
 	return 0;
     }

--- a/rpmio/digest_openssl.cc
+++ b/rpmio/digest_openssl.cc
@@ -66,6 +66,12 @@ static const EVP_MD *getEVPMD(int hashalgo)
     case RPM_HASH_SHA224:
         return EVP_sha224();
 
+    case RPM_HASH_SHA3_256:
+        return EVP_sha3_256();
+
+    case RPM_HASH_SHA3_512:
+        return EVP_sha3_512();
+
     default:
         return EVP_md_null();
     }

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3641,3 +3641,34 @@ b718a835936fd2f6c8855f210c4789a1 hello-1.0.tar.gz
 ],
 [])
 RPMTEST_CLEANUP
+
+AT_SETUP([file digests sha3])
+AT_KEYWORDS([build digest])
+AT_SKIP_IF([test x$PGP = xsequoia])
+RPMDB_INIT
+RPMTEST_CHECK([[
+runroot rpmbuild -bs --quiet \
+		--define "_source_filedigest_algorithm 12" \
+		 /data/SPECS/hello.spec
+runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.src.rpm
+]],
+[0],
+[f1a0a1e0e413d66a4bd948cb16bdd03600c7aea6dcd04522bcbc3041a29ee651 hello-1.0-modernize.patch
+a0da711d71069ab2735448140c5e0b51b4aeb3150a72877df54f372350e68644 hello-1.0.tar.gz
+bf352b9ec1645d799dde77fcde2249eb62a0a29a1c10fbbc3dce03d851132b3f hello.spec
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpmbuild -bs --quiet \
+		--define "_source_filedigest_algorithm 14" \
+		 /data/SPECS/hello.spec
+runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.src.rpm
+]],
+[0],
+[11ddad2c1e5ef58d94d008634d9ad3a95cb7b5fab51652e73bb999c8d12110c4cdf6c572187c1a880a3c171a1af739fb48f77e98f5e30cc3bc1ec91a16182915 hello-1.0-modernize.patch
+154b8717381c284af9b939cc28199347edc5cbcc3228bf0983d52323ca19ec73ad85a834ee9851d746561a0bdfc2dfa7278846b3b7b492d66451658275e0f1d5 hello-1.0.tar.gz
+7cbf4a017c065a583caecea1de6c7e48210c949e416db788118b81d8ccbc941d0890bc48b3c250208f80b7a059a3fe40fd27426f6b25920cd533bfe83c2676a2 hello.spec
+],
+[])
+RPMTEST_CLEANUP


### PR DESCRIPTION
Sequoia doesn't yet support SHA3 so we need to skip it in the default CI tests. Tests verified locally with libgrypt and openssl builds.
    
Fixes: #3436
