### PR TITLE
Fix regression causing a build directory left behind on rpmbuild -bs

### DIFF
--- a/build/build.cc
+++ b/build/build.cc
@@ -143,6 +143,7 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 	mTemplate = "%{__spec_builddir_template}";
 	mPost = "%{__spec_builddir_post}";
 	mCmd = "%{__spec_builddir_cmd}";
+	break;
     case RPMBUILD_PREP:
 	mTemplate = "%{__spec_prep_template}";
 	mPost = "%{__spec_prep_post}";

--- a/macros.in
+++ b/macros.in
@@ -833,11 +833,11 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 # ---- Scriptlet templates.
 #	Macro(s) that expand to a command and script that is executed.
 #
-%__spec_builddir_shell	%{nil}
-%__spec_builddir_args	%{nil}
-%__spec_builddir_cmd	%{nil}
+%__spec_builddir_shell	%{___build_shell}
+%__spec_builddir_args	%{___build_args}
+%__spec_builddir_cmd	%{___build_cmd}
 %__spec_builddir_pre	%{nil}
-%__spec_builddir_body   %{%nil}
+%__spec_builddir_body   %{nil}
 %__spec_builddir_post	%{nil}
 %__spec_builddir_template %{nil}
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -76,6 +76,14 @@ runroot rpmbuild -bs \
 [ignore],
 [ignore])
 
+# -bs must not leave junk behind
+RPMTEST_CHECK([
+ls ${RPMTEST}/build/BUILD
+],
+[0],
+[],
+[])
+
 RPMTEST_CHECK([
 runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-1.0-1.src.rpm
 ],

--- a/tools/rpmbuild.cc
+++ b/tools/rpmbuild.cc
@@ -525,7 +525,7 @@ static int buildForTarget(rpmts ts, const char * arg, BTA_t ba,
     }
 
     /* Create build tree if necessary */
-    if (rpmMkdirs(root, "%{_topdir}:%{_builddir}:%{_rpmdir}:%{_srcrpmdir}"))
+    if (rpmMkdirs(root, "%{_topdir}:%{_top_builddir}:%{_rpmdir}:%{_srcrpmdir}"))
 	goto exit;
 
     if ((rc = rpmSpecBuild(ts, spec, ba))) {


### PR DESCRIPTION
There are a bunch of flaws here, kinda separate items but as they were all introduced in a single commit it probably makes sense to address the mess as one too:

There was a missing 'break' causing %mkbuilddir to use the templates of %prep, which masks the fact that the %__spec_builddir_* stuff all set to %{nil} doesn't work, which causes us to try to 'cd' to the build directory that we're about to create in that %mkbuilddir. It only happens to work because I forgot to update the rpmMkdirs() call in rpmbuild to create %_top_builddir instead of %_builddir. Oof.

The only obvious evidence of all that fubar was that rpmbuild -bs started leaving an empty build directory behind.

Reported-by: Fabio Valentini <decathorpe@gmail.com>

Fixes: #3382