### PR TITLE
macros: Use /bin/bash instead of /bin/sh by default

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -118,7 +118,7 @@
 %_builddir		%{_topdir}/BUILD
 
 #	The interpreter used for build scriptlets.
-%_buildshell		/bin/sh
+%_buildshell		/bin/bash --posix
 
 #	The location of the rpm database file(s).
 %_dbpath		%{_var}/lib/rpm


### PR DESCRIPTION
RPM spec files (and %build/%install sections) assume certain bashisms, such as pushd, brace'd globs (i.e mkdir {bin, lib}), etc. Currently, rpm macros as packages enforce /bin/sh as the shebang for the rpmbuild generated .sh. This works okay as long as /bin/sh points to bash, however this is not necessarily the case, and plenty of distros have/are switching to other shells such as dash by default for /bin/sh scripts.

Since we aren't going to fix all spec files any time soon, use /bin/bash as the default %{_buildshell} value. This makes sure rpmbuild works without a hitch on such systems.

This PR is ready for inclusion if everyone agrees with it.