### PR TITLE
Fix brp-strip when using regex-unsafe build root

### DIFF
--- a/scripts/brp-strip
+++ b/scripts/brp-strip
@@ -32,8 +32,9 @@ strip_elf_binaries()
   local nlinks="${1}"
   local nprocs="${2}"
 
-  find "$RPM_BUILD_ROOT" -type f \
-    ! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" \
+  cd "$RPM_BUILD_ROOT" || return 0
+  find . -type f \
+    ! -regex '\./usr/lib/debug.*' \
     ! -name "*.py" ! -name "*.js" ! -name "*.rb" \
     ! -name "*.go" -links "${nlinks}" -print0 | \
     xargs -0 -r -P${nprocs} -n${MAX_ARGS} sh -c "file \"\$@\" | \

--- a/scripts/brp-strip-static-archive
+++ b/scripts/brp-strip-static-archive
@@ -13,5 +13,6 @@ Darwin*) exit 0 ;;
 esac
 
 # Strip static libraries.
-find "$RPM_BUILD_ROOT" -type f \! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" -print0 | \
+cd "$RPM_BUILD_ROOT" || exit 0
+find . -type f \! -regex '\./usr/lib/debug.*' -print0 | \
     xargs -0 -r -P$NCPUS -n32 sh -c "file \"\$@\" | sed 's/:  */: /' | grep 'current ar archive' | sed -n -e 's/^\(.*\):[  ]*current ar archive/\1/p' | xargs -d '\n' -I\{\} $STRIP -g \{\}" ARG0


### PR DESCRIPTION
By default, the build root contains NAME-VERSION-RELEASE.ARCH. Some of these may contain characters that are not taken as plain characters when interpreting a regex, such as "." or "+".
    
This may lead to a situation where files in /usr/lib/debug are stripped, making them useless for debugging. This is because the command to strip debug information interpreted part of the $RPM_BUILD_ROOT as part of a regex.
    
To fix this, first change to the build root directory, and run the find command relative to that directory, ensuring we don't have to make the build root part of the regex.
