### PR TITLE
Set RPM_PLUGINDIR in top level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,9 @@ if (ENABLE_PYTHON)
 	add_subdirectory(python)
 endif()
 
+set(RPM_PLUGINDIR ${CMAKE_INSTALL_FULL_LIBDIR}/rpm-plugins
+       CACHE PATH "rpm plugin directory")
+
 if (ENABLE_PLUGINS)
 	add_subdirectory(plugins)
 endif()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -42,9 +42,6 @@ if (HAVE_UNSHARE)
 	add_library(unshare MODULE unshare.c)
 endif()
 
-set(RPM_PLUGINDIR ${CMAKE_INSTALL_FULL_LIBDIR}/rpm-plugins
-	CACHE PATH "rpm plugin directory")
-
 get_property(plugins DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(plugin ${plugins})
 	target_link_libraries(${plugin} PRIVATE librpmio librpm ${Intl_LIBRARIES})


### PR DESCRIPTION
We have in macros.in:
  %__plugindir          @RPM_PLUGINDIR@

This means, if RPM_PLUGINDIR is not set, %__plugindir will be empty. This in turn results in error message when running 'dnf'.

e.g.,
dnf --help >/dev/null
error: /usr/lib64/rpm/macros: line 1183: Macro %__plugindir has empty body error: /usr/lib64/rpm/macros: line 1183: Macro %__plugindir has empty body

So we should move this directory setting into the top level CMakeLists.txt.