### PR TITLE
Fix formatting in man pages

### DIFF
--- a/docs/man/rpm-misc.8.md
+++ b/docs/man/rpm-misc.8.md
@@ -9,7 +9,7 @@ NAME rpm - lesser need options for rpm(8)
 OPTIONS
 =======
 
-**\--predefine**=\'*MACRO EXPR***\'**
+**\--predefine=\'***MACRO EXPR***\'**
 
 :   Defines *MACRO* with value *EXPR*. before loading macro files.
 

--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -50,23 +50,23 @@ MISCELLANEOUS:
 select-options
 --------------
 
-\[*PACKAGE\_NAME*\] \[**-a,\--all \[***SELECTOR*\]\] \[**-f,\--file
-***FILE*\] \[**\--path ***PATH*\] \[**-g,\--group ***GROUP*\] \[**-p,\--package
-***PACKAGE\_FILE*\]
-\[**\--tid ***TID*\] \[**\--querybynumber ***HDRNUM*\]
-\[**\--triggeredby ***PACKAGE\_NAME*\] \[**\--whatprovides
-***CAPABILITY*\] \[**\--whatrequires ***CAPABILITY*\]
-\[**\--whatrecommends ***CAPABILITY*\] \[**\--whatsuggests
-***CAPABILITY*\] \[**\--whatsupplements ***CAPABILITY*\]
-\[**\--whatenhances ***CAPABILITY*\] \[**\--whatobsoletes
-***CAPABILITY*\] \[**\--whatconflicts ***CAPABILITY*\]
+\[*PACKAGE\_NAME*\] \[**-a,\--all \[***SELECTOR*\]\] \[**-f,\--file**
+*FILE*\] \[**\--path** *PATH*\] \[**-g,\--group** *GROUP*\] \[**-p,\--package**
+*PACKAGE\_FILE*\]
+\[**\--tid** *TID*\] \[**\--querybynumber** *HDRNUM*\]
+\[**\--triggeredby** *PACKAGE\_NAME*\] \[**\--whatprovides**
+*CAPABILITY*\] \[**\--whatrequires** *CAPABILITY*\]
+\[**\--whatrecommends** *CAPABILITY*\] \[**\--whatsuggests**
+*CAPABILITY*\] \[**\--whatsupplements** *CAPABILITY*\]
+\[**\--whatenhances** *CAPABILITY*\] \[**\--whatobsoletes**
+*CAPABILITY*\] \[**\--whatconflicts** *CAPABILITY*\]
 
 query-options
 -------------
 
 General: \[**\--changelog**\] \[**\--changes**\] \[**\--dupes**\]
-\[**-i,\--info**\] \[**\--last**\] \[**\--qf,\--queryformat
-***QUERYFMT*\] \[**\--xml**\] \[**\--json**\]
+\[**-i,\--info**\] \[**\--last**\] \[**\--qf,\--queryformat**
+*QUERYFMT*\] \[**\--xml**\] \[**\--json**\]
 
 Dependencies: \[**\--conflicts**\] \[**\--enhances**\]
 \[**\--obsoletes**\] \[**\--provides**\] \[**\--recommends**\]
@@ -93,15 +93,15 @@ verify-options
 install-options
 ---------------
 
-\[**\--allfiles**\] \[**\--badreloc**\] \[**\--excludepath ***OLDPATH*\]
+\[**\--allfiles**\] \[**\--badreloc**\] \[**\--excludepath** *OLDPATH*\]
 \[**\--excludedocs**\] \[**\--force**\] \[**-h,\--hash**\]
 \[**\--ignoresize**\] \[**\--ignorearch**\] \[**\--ignoreos**\]
 \[**\--includedocs**\] \[**\--justdb**\] \[**--nodb**\] \[**\--nodeps**\]
 \[**\--nodigest**\] \[**\--noplugins**\] \[**\--nocaps**\]
 \[**\--noorder**\] \[**\--noverify**\] \[**\--nosignature**\]
 \[**\--noscripts**\] \[**\--notriggers**\] \[**\--oldpackage**\]
-\[**\--percent**\] \[**\--prefix ***NEWPATH*\] \[**\--relocate
-***OLDPATH***=***NEWPATH*\] \[**\--replacefiles**\]
+\[**\--percent**\] \[**\--prefix** *NEWPATH*\] \[**\--relocate**
+*OLDPATH***=***NEWPATH*\] \[**\--replacefiles**\]
 \[**\--replacepkgs**\] \[**\--test**\]
 
 DESCRIPTION
@@ -148,30 +148,30 @@ These options can be used in all the different modes.
 
 :   Print lots of ugly debugging information.
 
-**\--rcfile ***FILELIST*
+**\--rcfile** *FILELIST*
 
 :   Replace the default list of configuration files to be read with *FILELIST*.
     See **rpmrc Configuration** for details.
 
-**\--load ***FILE*
+**\--load** *FILE*
 
 :   Load an individual macro file.
 
-**\--macros ***FILELIST*
+**\--macros** *FILELIST*
 
 :   Replace the list of macro files to be loaded with *FILELIST*.
     See **Macro Configuration** for details.
 
-**\--pipe ***CMD*
+**\--pipe** *CMD*
 
 :   Pipes the output of **rpm** to the command *CMD*.
 
-**\--dbpath ***DIRECTORY*
+**\--dbpath** *DIRECTORY*
 
 :   Use the database in *DIRECTORY* rather than the default path
     */var/lib/rpm*
 
-**\--root ***DIRECTORY*
+**\--root** *DIRECTORY*
 
 :   Use the file system tree rooted at *DIRECTORY* for all operations.
     Note that this means the database within *DIRECTORY* will be used
@@ -246,7 +246,7 @@ This reinstalls a previously installed package.
     just those *OLDPATH*\'s included in the binary package relocation
     hint(s).
 
-**\--excludepath ***OLDPATH*
+**\--excludepath** *OLDPATH*
 
 :   Don\'t install files whose name begins with *OLDPATH*.
 
@@ -367,13 +367,13 @@ and turns off execution of the corresponding **%triggerprein**,
 :   Print percentages as files are unpacked from the package archive.
     This is intended to make **rpm** easy to run from other tools.
 
-**\--prefix ***NEWPATH*
+**\--prefix** *NEWPATH*
 
 :   For relocatable binary packages, translate all file paths that start
     with the installation prefix in the package relocation hint(s) to
     *NEWPATH*.
 
-**\--relocate ***OLDPATH***=***NEWPATH*
+**\--relocate** *OLDPATH***=***NEWPATH*
 
 :   For relocatable binary packages, translate all file paths that start
     with *OLDPATH* in the package relocation hint(s) to *NEWPATH*. This
@@ -591,7 +591,7 @@ PACKAGE SELECTION OPTIONS:
     package more precisely the package name may be followed by the
     version or version and release both separated by a dash or an
     architecture name separated by a dot. See the output of **rpm -qa**
-    or **rpm -qp ***PACKAGE\_FILE* as an example.
+    or **rpm -qp** *PACKAGE\_FILE* as an example.
 
 ```{=html}
 <!-- -->
@@ -609,7 +609,7 @@ name starts with \"b\".
 
 :   List duplicated packages.
 
-**-f, \--file ***FILE*
+**-f, \--file** *FILE*
 
 :   Query package owning installed *FILE*.
 
@@ -634,11 +634,11 @@ name starts with \"b\".
 
 :   List file names with their requires.
 
-**-g, \--group ***GROUP*
+**-g, \--group** *GROUP*
 
 :   Query packages with the group of *GROUP*.
 
-**-p, \--package ***PACKAGE\_FILE*
+**-p, \--package** *PACKAGE\_FILE*
 
 :   Query an (uninstalled) package *PACKAGE\_FILE*. The *PACKAGE\_FILE*
     may be specified as an **ftp** or **http** style URL, in which case
@@ -653,65 +653,65 @@ name starts with \"b\".
     substituted in place of the package manifest as additional
     *PACKAGE\_FILE* arguments to the query.
 
-**\--path ***PATH*
+**\--path** *PATH*
 
 :   Query package(s) owning *PATH*, whether the file is installed or not.
     Multiple packages may own a *PATH*, but the file is only owned by the
     package installed last.
 
-**\--querybynumber ***HDRNUM*
+**\--querybynumber** *HDRNUM*
 
 :   Query the *HDRNUM*th database entry directly; this is useful only
     for debugging.
 
-**\--specfile ***SPECFILE*
+**\--specfile** *SPECFILE*
 
 :   Parse and query *SPECFILE* as if it were a package. Although not all
     the information (e.g. file lists) is available, this type of query
     permits rpm to be used to extract information from spec files
     without having to write a specfile parser.
 
-**\--tid ***TID*
+**\--tid** *TID*
 
 :   Query package(s) that have a given *TID* transaction identifier. A
     unix time stamp is currently used as a transaction identifier. All
     package(s) installed or erased within a single transaction have a
     common identifier.
 
-**\--triggeredby ***PACKAGE\_NAME*
+**\--triggeredby** *PACKAGE\_NAME*
 
 :   Query packages that are triggered by package(s) *PACKAGE\_NAME*.
 
-**\--whatobsoletes ***CAPABILITY*
+**\--whatobsoletes** *CAPABILITY*
 
 :   Query all packages that obsolete *CAPABILITY* for proper
     functioning.
 
-**\--whatprovides ***CAPABILITY*
+**\--whatprovides** *CAPABILITY*
 
 :   Query all packages that provide the *CAPABILITY* capability.
 
-**\--whatrequires ***CAPABILITY*
+**\--whatrequires** *CAPABILITY*
 
 :   Query all packages that require *CAPABILITY* for proper functioning.
 
-**\--whatconflicts ***CAPABILITY*
+**\--whatconflicts** *CAPABILITY*
 
 :   Query all packages that conflict with *CAPABILITY*.
 
-**\--whatrecommends ***CAPABILITY*
+**\--whatrecommends** *CAPABILITY*
 
 :   Query all packages that recommend *CAPABILITY*.
 
-**\--whatsuggests ***CAPABILITY*
+**\--whatsuggests** *CAPABILITY*
 
 :   Query all packages that suggest *CAPABILITY*.
 
-**\--whatsupplements ***CAPABILITY*
+**\--whatsupplements** *CAPABILITY*
 
 :   Query all packages that supplement *CAPABILITY*.
 
-**\--whatenhances ***CAPABILITY*
+**\--whatenhances** *CAPABILITY*
 
 :   Query all packages that enhance *CAPABILITY*.
 
@@ -979,13 +979,13 @@ If both the user and password are omitted, anonymous **ftp** is used.
 
 :   **http** and **ftp** URLs:
 
-**\--httpproxy ***HOST*
+**\--httpproxy** *HOST*
 
 :   The host *HOST* will be used as a proxy server for all **http** and
     **ftp** transfers. This option may also be specified by configuring
     the macro **%\_httpproxy**.
 
-**\--httpport ***PORT*
+**\--httpport** *PORT*
 
 :   The TCP *PORT* number to use for the **http** connection on the
     proxy http server instead of the default port. This option may also

--- a/docs/man/rpmbuild.8.md
+++ b/docs/man/rpmbuild.8.md
@@ -34,11 +34,11 @@ MISCELLANEOUS:
 rpmbuild-options
 ----------------
 
-\[**\--buildroot ***DIRECTORY*\] \[**\--clean**\] \[**\--nobuild**\]
+\[**\--buildroot** *DIRECTORY*\] \[**\--clean**\] \[**\--nobuild**\]
 \[**\--rmsource**\] \[**\--rmspec**\] \[**\--short-circuit**\]
 \[**\--build-in-place**\] \[**\--noprep**\] \[**\--noclean**\]
-\[**\--nocheck**\] \[**\--rpmfcdebug**\] \[**\--target ***PLATFORM*\]
-\[**\--with ***OPTION*\] \[**\--without ***OPTION*\]
+\[**\--nocheck**\] \[**\--rpmfcdebug**\] \[**\--target** *PLATFORM*\]
+\[**\--with** *OPTION*\] \[**\--without** *OPTION*\]
 
 DESCRIPTION
 ===========
@@ -87,30 +87,30 @@ These options can be used in all the different modes.
 
 :   Enables to debug dependencies generation.
 
-**\--rcfile ***FILELIST*
+**\--rcfile** *FILELIST*
 
 :   Replace default list of configuration files to be read with *FILELIST*.
     See **rpmrc Configuration** in **rpm**(8) for details.
 
-**\--load ***FILE*
+**\--load** *FILE*
 
 :   Load an individual macro file.
 
-**\--macros ***FILELIST*
+**\--macros** *FILELIST*
 
 :   Replace the list of macro files to be loaded with *FILELIST*.
     See **Macro Configuration** in **rpm**(8) for details.
 
-**\--pipe ***CMD*
+**\--pipe** *CMD*
 
 :   Pipes the output of **rpm** to the command *CMD*.
 
-**\--dbpath ***DIRECTORY*
+**\--dbpath** *DIRECTORY*
 
 :   Use the database in *DIRECTORY* rather than the default path
     */var/lib/rpm*
 
-**\--root ***DIRECTORY*
+**\--root** *DIRECTORY*
 
 :   Use the file system tree rooted at *DIRECTORY* for all operations.
     Note that this means the database within *DIRECTORY* will be used
@@ -211,7 +211,7 @@ all the stages preceding it), and is one of:
 
 The following options may also be used:
 
-**\--buildroot ***DIRECTORY* (DEPRECATED)
+**\--buildroot** *DIRECTORY* (DEPRECATED)
 
 :   When building a package, override rpm's buildroot to *DIRECTORY*.
     This option is deprecated and will be removed in the future, do
@@ -270,17 +270,17 @@ The following options may also be used:
     but %builddir/%buildsubdir points back to the current working
     directory. %prep is skipped entirely.
 
-**\--target ***PLATFORM*
+**\--target** *PLATFORM*
 
 :   When building the package, interpret *PLATFORM* as
     **arch-vendor-os** and set the macros **%\_target**,
     **%\_target\_cpu**, and **%\_target\_os** accordingly.
 
-**\--with ***OPTION*
+**\--with** *OPTION*
 
 :   Enable configure *OPTION* for build.
 
-**\--without ***OPTION*
+**\--without** *OPTION*
 
 :   Disable configure *OPTION* for build.
 

--- a/docs/man/rpmdb.8.md
+++ b/docs/man/rpmdb.8.md
@@ -23,8 +23,8 @@ DESCRIPTION
 
 The general form of an rpmdb command is
 
-**rpm** {**\--initdb\|\--rebuilddb**} \[**-v**\] \[**\--dbpath
-***DIRECTORY*\] \[**\--root ***DIRECTORY*\]
+**rpm** {**\--initdb\|\--rebuilddb**} \[**-v**\] \[**\--dbpath**
+*DIRECTORY*\] \[**\--root** *DIRECTORY*\]
 
 Use **\--initdb** to create a new database if one doesn\'t already exist
 (existing database is not overwritten), use **\--rebuilddb** to rebuild

--- a/docs/man/rpmsign.8.md
+++ b/docs/man/rpmsign.8.md
@@ -25,7 +25,7 @@ SIGNING PACKAGES:
 rpmsign-options
 ---------------
 
-\[**\--rpmv3**\] \[**\--rpmv4**\] \[**\--fskpath ***KEY*\] \[**\--signfiles**\]
+\[**\--rpmv3**\] \[**\--rpmv4**\] \[**\--fskpath** *KEY*\] \[**\--signfiles**\]
 
 DESCRIPTION
 ===========
@@ -89,15 +89,15 @@ SIGN OPTIONS
 
     Has no effect when signing V6 packages.
 
-**\--fskpath ***KEY*
+**\--fskpath** *KEY*
 
 :   Used with **\--signfiles**, use file signing key *Key*.
 
-**\--certpath ***CERT*
+**\--certpath** *CERT*
 
 :   Used with **\--signverity**, use file signing certificate *Cert*.
 
-**\--verityalgo ***ALG*
+**\--verityalgo** *ALG*
 
 :   Used with **\--signverity**, to specify the signing algorithm.
     sha256 and sha512 are supported, with sha256 being the default if

--- a/docs/man/rpmspec.8.md
+++ b/docs/man/rpmspec.8.md
@@ -48,8 +48,8 @@ select-options
 query-options
 -------------
 
-\[**\--qf,\--queryformat ***QUERYFMT*\] \[**\--target
-***TARGET\_PLATFORM*\]
+\[**\--qf,\--queryformat** *QUERYFMT*\] \[**\--target**
+*TARGET\_PLATFORM*\]
 
 QUERY OPTIONS
 -------------


### PR DESCRIPTION
The renderer of GitHub pages - that we use for the in-tree documentation
- gets confused if tripple asterix are used near white space or line breaks.

Fix the formatting by moving the spaces or line breaks inbetween.

Resolves: #3502