### PR TITLE
Fix race condition in rpmioMkpath

### DIFF
--- a/rpmio/rpmfileutil.cc
+++ b/rpmio/rpmfileutil.cc
@@ -122,22 +122,24 @@ int rpmioMkpath(const char * path, mode_t mode, uid_t uid, gid_t gid)
     for (;(de=strchr(de+1,'/'));) {
 	struct stat st;
 	*de = '\0';
-	rc = stat(d, &st);
-	if (rc) {
-	    if (errno != ENOENT)
-		goto exit;
-	    rc = mkdir(d, mode);
+	rc = mkdir(d, mode);
+	if (rc && errno == EEXIST) {
+	    rc = stat(d, &st);
 	    if (rc)
 		goto exit;
+	    if (!S_ISDIR(st.st_mode)) {
+		rc = ENOTDIR;
+		goto exit;
+	    }
+	} else if (rc) {
+	    goto exit;
+	} else {
 	    rpmlog(RPMLOG_DEBUG, "created directory(s) %s mode 0%o\n", path, mode);
 	    if (!(uid == (uid_t) -1 && gid == (gid_t) -1)) {
 		rc = chown(d, uid, gid);
 		if (rc)
 		    goto exit;
 	    }
-	} else if (!S_ISDIR(st.st_mode)) {
-	    rc = ENOTDIR;
-	    goto exit;
 	}
 	*de = '/';
     }

--- a/rpmio/rpmio.cc
+++ b/rpmio/rpmio.cc
@@ -462,6 +462,7 @@ static FD_t urlOpen(const char * url, int flags, mode_t mode)
 	unlink(dest);
     } else {
 	fd = NULL;
+	errno = ENOENT;
     }
     dest = _free(dest);
 


### PR DESCRIPTION
Fix race condition in rpmioMkpath
The previous implementation did stat the directory and created it if not
there. This allowed for a race condition where other rpm instances could
create the directory inbetween. This was observed in the wild for
%{_tmppath}.

Do create the directory unconditionally and if that fails see if the
directory is there already.

Not adding a test case as rpmioMkpath is heavily used all over the the
code base and tests for race conditions don't really fit in the test suite.

Resolves: https://github.com/rpm-software-management/rpm/issues/3508