### PR TITLE
Revert "Fix thinko in sysusers macro enablement comment"

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -140,7 +140,7 @@
 # location of sysusers.d(5) directory
 %_sysusersdir		@sysusersdir@
 
-# sysusers helper binary (or a replacement script), comment out to disable
+# sysusers helper binary (or a replacement script), uncomment to disable
 #%__systemd_sysusers	@__SYSTEMD_SYSUSERS@
 %__systemd_sysusers	%{_rpmconfigdir}/sysusers.sh
 


### PR DESCRIPTION
This reverts commit 87e45cfa25c59cef7cf3caba50b297fa2c352fbc.

A comment change can't possibly break anything (right?), but CI is now failing...