### PR TITLE
Lock the GitHub CI runner to a specific Ubuntu version

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We need to have control over our CI environment - we lock Fedora to a certain version without updates, yet the underlying Ubuntu image has been floating and causing trouble every now and then. Like just now, with ubuntu-latest moving from 22.04 to 24.04 where sudo is somehow broken inside our test-suite and causing totally unrelated PR's to fail with

   sudo: PAM account management error: Authentication service cannot retrieve authentication info
   sudo: a password is required

Lock the version to Ubuntu 22.04 for now, we'll need to eventually figure what the issue is but these things need to happen on our terms.