### PR TITLE
Ignore EPERM when setting IMA signature xattr

### DIFF
--- a/plugins/ima.c
+++ b/plugins/ima.c
@@ -71,7 +71,9 @@ static rpmRC ima_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 	    else
 		xx = lsetxattr(path, XATTR_NAME_IMA, fsig, len, 0);
 	    if (xx < 0) {
-		int is_err = errno != EOPNOTSUPP;
+		/* unsupported fs or root inside rootless container? */
+		int is_err = !(errno == EOPNOTSUPP ||
+			      (errno == EPERM && getuid() == 0));
 
 	        rpmlog(is_err?RPMLOG_ERR:RPMLOG_DEBUG,
 			"ima: could not apply signature on '%s': %s\n",

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1829,8 +1829,8 @@ POST-IMPORT
 gpgconf --kill gpg-agent
 RPMTEST_CLEANUP
 
-AT_SETUP([ima])
-AT_KEYWORDS([rpmsign file signature])
+AT_SETUP([ima file signatures])
+AT_KEYWORDS([rpmsign ima signature])
 AT_SKIP_IF([$IMA_DISABLED])
 
 RPMTEST_SETUP
@@ -1893,7 +1893,7 @@ RPMTEST_CLEANUP
 
 
 AT_SETUP([--delsign with misplaced ima signature])
-AT_KEYWORDS([rpmsign file signature])
+AT_KEYWORDS([rpmsign ima signature])
 RPMTEST_CHECK([
 cp /data/RPMS/hello-2.0-1.x86_64-badima.rpm .
 rpmsign --delsign hello-2.0-1.x86_64-badima.rpm

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1874,6 +1874,21 @@ rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" imatest-1.0-1.fc34.noarch.rpm
 /usr/share/example2:(none)
 ],
 [])
+
+RPMTEST_CHECK([
+cp /data/SRPMS/hello-1.0-1.src.rpm /tmp/
+rpmsign --debug --key-id 4344591E1964C5FC \
+	--addsign --signfiles --fskpath=/data/keys/privkey.pem \
+	/tmp/hello-1.0-1.src.rpm 2>&1 | grep "File signatures not applicable"
+# Avoid spurious NOKEY warning
+rpmsign --delsign /tmp/hello-1.0-1.src.rpm
+rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" /tmp/hello-1.0-1.src.rpm
+],
+[0],
+[D: File signatures not applicable to src.rpm: /tmp/hello-1.0-1.src.rpm
+hello-1.0.tar.gz:(none)
+],
+[])
 RPMTEST_CLEANUP
 
 
@@ -1906,21 +1921,6 @@ rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" hello-2.0-1.x86_64-badima.rpm
 /usr/share/doc/hello-2.0/COPYING:(none)
 /usr/share/doc/hello-2.0/FAQ:(none)
 /usr/share/doc/hello-2.0/README:(none)
-],
-[])
-
-RPMTEST_CHECK([
-cp /data/SRPMS/hello-1.0-1.src.rpm /tmp/
-rpmsign --debug --key-id 4344591E1964C5FC \
-	--addsign --signfiles --fskpath=/data/keys/privkey.pem \
-	/tmp/hello-1.0-1.src.rpm 2>&1 | grep "File signatures not applicable"
-# Avoid spurious NOKEY warning
-rpmsign --delsign /tmp/hello-1.0-1.src.rpm
-rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" /tmp/hello-1.0-1.src.rpm
-],
-[0],
-[D: File signatures not applicable to src.rpm: /tmp/hello-1.0-1.src.rpm
-hello-1.0.tar.gz:(none)
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1891,6 +1891,36 @@ hello-1.0.tar.gz:(none)
 [])
 RPMTEST_CLEANUP
 
+# Test that installing an ima signed package works.
+# The installation should succeed in all cases, but whether setting the
+# IMA signature succeeds depends on container privileges - in rootless
+# we can't do this.
+AT_SETUP([install ima file signatures])
+AT_KEYWORDS([install ima signature])
+AT_SKIP_IF([$IMA_DISABLED])
+
+RPMTEST_SETUP
+
+cat << EOF > expout
+# file: /usr/share/example1
+security.ima=0sAwIEpZglVABIMEYCIQDlEXva+nO6rrHx3EbsqkaYGmLUF3RaM1MlcrY9xtldFgIhAMeJEHrFuR4tkV4d88e3hBT2s/UImdRMHeOB0Ok438gr
+
+EOF
+
+touch canary
+# different expectations in a rootless container
+if ! setfattr -n security.ima -v 0sAwIEpZglVABIMEYCIQDlEXva+nO6rrHx3EbsqkaYGmLUF3RaM1MlcrY9xtldFgIhAMeJEHrFuR4tkV4d88e3hBT2s/UImdRMHeOB0Ok438gr canary 2> /dev/null; then
+    echo -n "" > expout
+fi
+
+RPMTEST_CHECK([
+runroot rpm -U /data/RPMS/imatest-1.0-1.fc34.noarch.rpm
+runroot_other getfattr --absolute-names -d -m security.ima /usr/share/example1
+],
+[0],
+[expout],
+[])
+RPMTEST_CLEANUP
 
 AT_SETUP([--delsign with misplaced ima signature])
 AT_KEYWORDS([rpmsign ima signature])


### PR DESCRIPTION
This lets installations succeed even if the ima plugin happens to be installed in a container, where IMA isn't supported. We don't know it failure was because of a container so this is far from ideal, but failing an install just because some package dragged in the ima plugin as a dependency is worse.

Counter-intuitively, the test verifies that the IMA xattr didn't get installed because that's the expected result, when inside a container.
 
Fixes: #3234

The first commits are tweaks to a couple of small issues I ran into when looking at this.