### PR TITLE
Fix various issues with the man pages

### DIFF
--- a/docs/man/rpm-misc.8.md
+++ b/docs/man/rpm-misc.8.md
@@ -11,7 +11,7 @@ OPTIONS
 
 **\--predefine=\'***MACRO EXPR***\'**
 
-:   Defines *MACRO* with value *EXPR*. before loading macro files.
+:   Defines *MACRO* with value *EXPR* before loading macro files.
 
 Switching off features
 ======================
@@ -72,7 +72,7 @@ Obsolete Options
 
 **-K, \--checksig**
 
-:   See and use rpmkeys(8).
+:   See and use **rpmkeys**(8).
 
 **\--nodocs**
 

--- a/docs/man/rpm-plugin-audit.8.md
+++ b/docs/man/rpm-plugin-audit.8.md
@@ -48,7 +48,7 @@ The entries in the audit log have the following fields:
 
 **gpg\_res**
 
-:   0/1 result of signature check (0 == fail / 1 ==success)
+:   0/1 result of signature check (0 == fail / 1 == success)
 
 **root\_dir**
 

--- a/docs/man/rpm-plugin-prioreset.8.md
+++ b/docs/man/rpm-plugin-prioreset.8.md
@@ -13,12 +13,12 @@ with priorities of deamons on SysV init
 Description
 ===========
 
-In general scriptlets run with the same priority as rpm itself. However
+In general scriptlets run with the same priority as **rpm**(8) itself. However
 on legacy SysV init systems, properties of the parent process can be
 inherited by the actual daemons on restart. As a result daemons may end
 up with unwanted nice or ionice values. This plugin resets the scriptlet
 process priorities after forking, and can be used to counter that
-effect. Should not be used with systemd because it\'s not needed there,
+effect. Should not be used with **systemd**(1) because it\'s not needed there,
 and the effect is counter-productive.
 
 Configuration

--- a/docs/man/rpm-plugin-selinux.8.md
+++ b/docs/man/rpm-plugin-selinux.8.md
@@ -20,7 +20,7 @@ Configuration
 =============
 
 The plugin can be disabled temporarily by passing **\--nocontexts** at
-the RPM command line or setting the transaction flag
+the **rpm**(8) command line or setting the transaction flag
 **RPMTRANS\_FLAG\_NOCONTEXTS** in the API.
 
 See **rpm-plugins**(8) on how to control plugins in general.

--- a/docs/man/rpm-plugin-syslog.8.md
+++ b/docs/man/rpm-plugin-syslog.8.md
@@ -12,7 +12,7 @@ rpm-plugin-syslog - Syslog plugin for the RPM Package Manager
 Description
 ===========
 
-The plugin writes basic information about rpm transactions to the syslog
+The plugin writes basic information about **rpm**(8) transactions to the syslog
 - like transactions run and packages installed or removed.
 
 Configuration

--- a/docs/man/rpm-plugin-systemd-inhibit.8.md
+++ b/docs/man/rpm-plugin-systemd-inhibit.8.md
@@ -16,7 +16,7 @@ This plugin for RPM prevents the system to enter shutdown, sleep or idle
 mode while there is a rpm transaction running to prevent system
 corruption that can occur if the transaction is interrupted by a reboot.
 
-This is achieved by using the inhibit DBUS interface of systemd. The
+This is achieved by using the inhibit DBUS interface of **systemd**(1). The
 call is roughly equivalent to executing
 
 **systemd-inhibit \--mode=block \--what=idle:sleep:shutdown \--who=RPM
@@ -30,7 +30,7 @@ systems.
 Prerequisites
 =============
 
-For the plugin to work systemd has to be used as init system and though
+For the plugin to work systemd has to be used as init system and
 the DBUS system bus must be available. If the plugin cannot access the
 interface it gives a warning but does not stop the transaction.
 

--- a/docs/man/rpm-plugins.8.md
+++ b/docs/man/rpm-plugins.8.md
@@ -44,7 +44,7 @@ Another option is to remove the plugin from the system if it is packaged
 in its own sub package.
 
 For some operations it may be desirable to disable all plugins at once.
-This can be done by passing **\--noplugins** to **rpm** at the command
+This can be done by passing **\--noplugins** to **rpm**(8) at the command
 line.
 
 SEE ALSO

--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -12,8 +12,8 @@ rpm - RPM Package Manager
 SYNOPSIS
 ========
 
-QUERYING AND VERIFYING PACKAGES:
---------------------------------
+QUERYING AND VERIFYING PACKAGES
+-------------------------------
 
 **rpm** {**-q\|\--query**} \[**select-options**\] \[**query-options**\]
 
@@ -22,8 +22,8 @@ QUERYING AND VERIFYING PACKAGES:
 **rpm** {**-V\|\--verify**} \[**select-options**\]
 \[**verify-options**\]
 
-INSTALLING, UPGRADING, AND REMOVING PACKAGES:
----------------------------------------------
+INSTALLING, UPGRADING, AND REMOVING PACKAGES
+--------------------------------------------
 
 **rpm** {**-i\|\--install**} \[**install-options**\] *PACKAGE\_FILE
 \...*
@@ -40,8 +40,8 @@ INSTALLING, UPGRADING, AND REMOVING PACKAGES:
 \[**\--nodb**\] \[**\--nodeps**\] \[**\--noscripts**\] \[**\--notriggers**\]
 \[**\--test**\] *PACKAGE\_NAME \...*
 
-MISCELLANEOUS:
---------------
+MISCELLANEOUS
+-------------
 
 **rpm** **\--showrc**
 
@@ -169,7 +169,7 @@ These options can be used in all the different modes.
 **\--dbpath** *DIRECTORY*
 
 :   Use the database in *DIRECTORY* rather than the default path
-    */var/lib/rpm*
+    */var/lib/rpm*.
 
 **\--root** *DIRECTORY*
 
@@ -195,7 +195,7 @@ These options can be used in all the different modes.
 
 :   Prints macro expansion of *EXPR*.
 
-More - less often needed - options can be found on the **rpm-misc(8)**
+More - less often needed - options can be found on the **rpm-misc**(8)
 man page.
 
 INSTALL AND UPGRADE OPTIONS
@@ -207,14 +207,14 @@ specified as an **ftp** or **http** URL, in which case the package will
 be downloaded before being installed. See **FTP/HTTP OPTIONS** for
 information on **rpm**\'s **ftp** and **http** client support.
 
-The general form of an rpm install command is
+The general form of an **rpm** install command is
 
 **rpm** {**-i\|\--install**} \[**install-options**\] *PACKAGE\_FILE
 \...*
 
 This installs a new package.
 
-The general form of an rpm upgrade command is
+The general form of an **rpm** upgrade command is
 
 **rpm** {**-U\|\--upgrade**} \[**install-options**\] *PACKAGE\_FILE
 \...*
@@ -229,7 +229,7 @@ package are removed after the new package is installed.
 This will upgrade packages, but only ones for which an earlier version
 is installed.
 
-The general form of an rpm reinstall command is
+The general form of an **rpm** reinstall command is
 
 **rpm** {**\--reinstall**} \[**install-options**\] *PACKAGE\_FILE \...*
 
@@ -398,7 +398,7 @@ and turns off execution of the corresponding **%triggerprein**,
 ERASE OPTIONS
 -------------
 
-The general form of an rpm erase command is
+The general form of an **rpm** erase command is
 
 **rpm** {**-e\|\--erase**} \[**\--allmatches**\] \[**\--justdb\]
 \[\--nodeps**\] \[**\--noscripts**\] \[**\--notriggers**\]
@@ -448,7 +448,7 @@ and turns off execution of the corresponding **%triggerun**, and
 QUERY OPTIONS
 -------------
 
-The general form of an rpm query command is
+The general form of an **rpm** query command is
 
 **rpm** {**-q\|\--query**} \[**select-options**\] \[**query-options**\]
 
@@ -458,10 +458,10 @@ in. To do this, you use the
 **\--qf\|\--queryformat** *QUERYFMT*
 
 option, followed by the *QUERYFMT* format string. Query formats are
-modified versions of the standard **printf(3)** formatting. The format
+modified versions of the standard **printf**(3) formatting. The format
 is made up of static strings (which may include standard C character
 escapes for newlines, tabs, and other special characters (not including \0))
-and **printf(3)** type formatters. As **rpm** already knows the type to
+and **printf**(3) type formatters. As **rpm** already knows the type to
 print, the type specifier must be omitted however, and replaced by the
 name of the header tag to be printed, enclosed by **{}** characters. Tag
 names are case insensitive, and the leading **RPMTAG\_** portion of the
@@ -484,11 +484,11 @@ Alternate output formats may be requested by following the tag with
 
 **:date**
 
-:   Use strftime(3) \"%c\" format.
+:   Use **strftime**(3) \"%c\" format.
 
 **:day**
 
-:   Use strftime(3) \"%a %b %d %Y\" format.
+:   Use **strftime**(3) \"%a %b %d %Y\" format.
 
 **:depflags**
 
@@ -582,8 +582,8 @@ argument.
 There are three subsets of options for querying: package selection, file
 selection and information selection.
 
-PACKAGE SELECTION OPTIONS:
---------------------------
+PACKAGE SELECTION OPTIONS
+-------------------------
 
 *PACKAGE\_NAME*
 
@@ -647,7 +647,7 @@ name starts with \"b\".
     support. The *PACKAGE\_FILE* argument(s), if not a binary package,
     will be interpreted as an ASCII package manifest unless
     **\--nomanifest** option is used. In manifests, comments are
-    permitted, starting with a \'\#\', and each line of a package
+    permitted, starting with a \'*\#*\', and each line of a package
     manifest file may include white space separated glob expressions,
     including URL\'s, that will be expanded to paths that are
     substituted in place of the package manifest as additional
@@ -668,13 +668,13 @@ name starts with \"b\".
 
 :   Parse and query *SPECFILE* as if it were a package. Although not all
     the information (e.g. file lists) is available, this type of query
-    permits rpm to be used to extract information from spec files
+    permits **rpm** to be used to extract information from spec files
     without having to write a specfile parser.
 
 **\--tid** *TID*
 
 :   Query package(s) that have a given *TID* transaction identifier. A
-    unix time stamp is currently used as a transaction identifier. All
+    UNIX time stamp is currently used as a transaction identifier. All
     package(s) installed or erased within a single transaction have a
     common identifier.
 
@@ -715,8 +715,8 @@ name starts with \"b\".
 
 :   Query all packages that enhance *CAPABILITY*.
 
-PACKAGE QUERY OPTIONS:
-----------------------
+PACKAGE QUERY OPTIONS
+---------------------
 
 **\--changelog**
 
@@ -739,7 +739,7 @@ PACKAGE QUERY OPTIONS:
 
 **\--enhances**
 
-:   List capabilities enhanced by package(s)
+:   List capabilities enhanced by package(s).
 
 **\--filesbypkg**
 
@@ -773,7 +773,7 @@ PACKAGE QUERY OPTIONS:
 
 **\--recommends**
 
-:   List capabilities recommended by package(s)
+:   List capabilities recommended by package(s).
 
 **-R, \--requires**
 
@@ -781,11 +781,11 @@ PACKAGE QUERY OPTIONS:
 
 **\--suggests**
 
-:   List capabilities suggested by package(s)
+:   List capabilities suggested by package(s).
 
 **\--supplements**
 
-:   List capabilities supplemented by package(s)
+:   List capabilities supplemented by package(s).
 
 **\--scripts**
 
@@ -801,10 +801,14 @@ PACKAGE QUERY OPTIONS:
 **\--triggers, \--triggerscripts**
 
 :   Display the trigger scripts, if any, which are contained in the
-    package. **\--xml** Format package headers as XML.
+    package.
 
-FILE SELECTION OPTIONS:
------------------------
+**\--xml**
+
+:   Format package headers as XML.
+
+FILE SELECTION OPTIONS
+----------------------
 
 **-A, \--artifactfiles**
 
@@ -837,7 +841,7 @@ FILE SELECTION OPTIONS:
 VERIFY OPTIONS
 --------------
 
-The general form of an rpm verify command is
+The general form of an **rpm** verify command is
 
 **rpm** {**-V\|\--verify**} \[**select-options**\]
 \[**verify-options**\]
@@ -906,7 +910,7 @@ unique to verify mode are:
 **\--nogroup**
 
 :  Don\'t verify file user/group ownership. Note that only local
-   passwd(5) and group(5) databases are consulted.
+   **passwd**(5) and **group**(5) databases are consulted.
 
 **\--nocaps**
 
@@ -915,15 +919,15 @@ unique to verify mode are:
 The format of the output is a string of 9 characters, a possible
 attribute marker:
 
-    a %artifact a build side-effect file (such as buildid links).
-    c %config configuration file.
-    d %doc documentation file.
-    g %ghost file (i.e. the file contents are not included in the package payload).
-    l %license license file.
-    m %missingok file missing is not a verify failure.
-    n %%config(noreplace) (do not replace file).
-    r %readme readme file.
-    s specfile in source package.
+    **a** %**a**rtifact a build side-effect file (such as buildid links).
+    **c** %**c**onfig configuration file.
+    **d** %**d**oc documentation file.
+    **g** %**g**host file (i.e. the file contents are not included in the package payload).
+    **l** %**l**icense license file.
+    **m** %**m**issingok file missing is not a verify failure.
+    **n** %%config(**n**oreplace) (do not replace file).
+    **r** %**r**eadme readme file.
+    **s** **s**pecfile in source package.
 
 from the package header, followed by the file name. Each of the 9
 characters denotes the result of a comparison of attribute(s) of the
@@ -934,22 +938,22 @@ single \"**.**\" (period) means the test passed, while a single
 em**B**oldened) character denotes failure of the corresponding
 **\--verify** test:
 
-    S file Size differs
-    M Mode differs (includes permissions and file type)
-    5 digest (formerly MD5 sum) differs
-    D Device major/minor number mismatch
-    L readLink(2) path mismatch
-    U User ownership differs
-    G Group ownership differs
-    T mTime differs
-    P caPabilities differ
+    **S** file **S**ize differs
+    **M** **M**ode differs (includes permissions and file type)
+    **5** digest (formerly MD**5** sum) differs
+    **D** **D**evice major/minor number mismatch
+    **L** read**L**ink(2) path mismatch
+    **U** **U**ser ownership differs
+    **G** **G**roup ownership differs
+    **T** m**T**ime differs
+    **P** ca**P**abilities differ
 
 MISCELLANEOUS COMMANDS
 ----------------------
 
 **rpm** **\--showrc**
 
-:   shows the values **rpm** will use for all of the options are
+:   shows the values **rpm** will use for all of the options which are
     currently set in *rpmrc* and *macros* configuration file(s).
 
 **rpm** **\--setperms** | **\--setugids** | **\--setcaps** *PACKAGE\_NAME*
@@ -977,9 +981,7 @@ If both the user and password are omitted, anonymous **ftp** is used.
 
 **rpm** allows the following options to be used with ftp URLs:
 
-**rpm** allows the following options to be used with
-
-:   **http** and **ftp** URLs:
+**rpm** allows the following options to be used with **http** and **ftp** URLs:
 
 **\--httpproxy** *HOST*
 
@@ -1030,7 +1032,7 @@ does not exist.
 Macro Configuration
 -------------------
 
-Each file or **glob(7)** pattern in the colon-separated macro path is
+Each file or **glob**(7) pattern in the colon-separated macro path is
 read sequentially by **rpm** for macro definitions. Tildes will be expanded
 to the value of the environment variable *HOME*. The default macro path
 is as follows:
@@ -1068,7 +1070,7 @@ SEE ALSO
 **rpm-misc**(8), **popt**(3), **rpm2cpio**(8), **rpmbuild**(8), **rpmdb**(8),
 **rpmkeys**(8), **rpmsign**(8), **rpmspec**(8)
 
-**rpm \--help** - as rpm supports customizing the options via popt
+**rpm \--help** - as **rpm** supports customizing the options via popt
 aliases it\'s impossible to guarantee that what\'s described in the
 manual matches what\'s available.
 

--- a/docs/man/rpm2archive.8.md
+++ b/docs/man/rpm2archive.8.md
@@ -23,10 +23,10 @@ on standard out.
 If a \'-\' argument is given, an rpm stream is read from standard in.
 
 If standard out is connected to a terminal, the output is written to tar files
-with a \".tgz\" suffix, gzip compressed by default.
+with a \".tgz\" suffix, **gzip**(1) compressed by default.
 
 In opposite to **rpm2cpio** **rpm2archive** also works with RPM packages
-containing files greater than 4GB which are not supported by cpio.
+containing files greater than 4GB which are not supported by **cpio**.
 
 OPTIONS
 =======

--- a/docs/man/rpmbuild.8.md
+++ b/docs/man/rpmbuild.8.md
@@ -12,8 +12,8 @@ rpmbuild - Build RPM Package(s)
 SYNOPSIS
 ========
 
-BUILDING PACKAGES:
-------------------
+BUILDING PACKAGES
+-----------------
 
 **rpmbuild** {**-ba\|-bb\|-bp\|-bf|\-bc\|-bi\|-bl\|-bs\|-br\|-bd**}
 \[**rpmbuild-options**\] *SPECFILE \...*
@@ -26,8 +26,8 @@ BUILDING PACKAGES:
 
 **rpmbuild** {**\--rebuild\|\--recompile**} *SOURCEPKG \...*
 
-MISCELLANEOUS:
---------------
+MISCELLANEOUS
+-------------
 
 **rpmbuild** **\--showrc**
 
@@ -51,9 +51,9 @@ scripts, file attributes, and descriptive information about the package.
 software to be installed, and source packages, containing the source
 code and recipe necessary to produce binary packages.
 
-One of the following basic modes must be selected: **Build Package**,
-**Build Package from Tarball**, **Recompile Package**, **Show
-Configuration**.
+One of the following basic modes must be selected: *Build Package*,
+*Build Package from Tarball*, *Recompile Package*, *Show
+Configuration*.
 
 GENERAL OPTIONS
 ---------------
@@ -108,7 +108,7 @@ These options can be used in all the different modes.
 **\--dbpath** *DIRECTORY*
 
 :   Use the database in *DIRECTORY* rather than the default path
-    */var/lib/rpm*
+    */var/lib/rpm*.
 
 **\--root** *DIRECTORY*
 
@@ -124,7 +124,7 @@ These options can be used in all the different modes.
 
 **\--scm=***SCM*
 
-:   Select the *SCM* to use with %autosetup, if one is not set in the
+:   Select the *SCM* to use with **%autosetup**, if one is not set in the
     spec file. Note that not all values for *SCM*, e.g., **patch** (the
     default) and **gendiff**, **git**, or **quilt** work interchangeably
     with all other patches and options stated in the %autosetup line,
@@ -133,7 +133,7 @@ These options can be used in all the different modes.
 BUILD OPTIONS
 -------------
 
-The general form of an rpm build command is
+The general form of an **rpm**(8) build command is
 
 **rpmbuild** {**-b***STAGE***\|-r***STAGE***\|-t***STAGE*}
 \[**rpmbuild-options**\] *FILE \...*
@@ -165,28 +165,28 @@ all the stages preceding it), and is one of:
 
 **-bp**
 
-:   Unpack the sources and apply any patches - executes the %prep stage
+:   Unpack the sources and apply any patches - executes the **%prep** stage
     only.
 
 **-bf**
 
 :   Configure the sources - executes up to and including the %conf stage.
-    This generally involves the equivalent of a \"./configure\".
+    This generally involves the equivalent of a \"**./configure**\".
 
 **-bc**
 
-:   Compile the sources - executes up to and including the %build stage.
-    This generally involves the equivalent of a \"make\".
+:   Compile the sources - executes up to and including the **%build** stage.
+    This generally involves the equivalent of \"**make**\".
 
 **-bi**
 
 :   Install the binaries into the build root - executes up to and
-    including the %check stage. This generally involves the equivalent
-    of a \"make install\" and \"make check\".
+    including the **%check** stage. This generally involves the equivalent
+    of a \"**make install**\" and \"**make check**\".
 
 **-bl**
 
-:   Do a \"list check\" - the %files section from the spec file is macro
+:   Do a \"list check\" - the **%files** section from the spec file is macro
     expanded, and checks are made to verify that each file exists.
 
 **-bs**
@@ -199,10 +199,10 @@ all the stages preceding it), and is one of:
 
 :   Build just the source package, but also parse and include dynamic
     build dependencies - executes up to and including the
-    %generate\_buildrequires stage and then skips straight to the
+    **%generate\_buildrequires** stage and then skips straight to the
     assembly stage, without creating binary packages. This command can
-    be used to fully resolve dynamic build dependencies. See the DYNAMIC
-    BUILD DEPENDENCIES section for details.
+    be used to fully resolve dynamic build dependencies. See the
+    **DYNAMIC BUILD DEPENDENCIES** section for details.
 
 **-bd**
 
@@ -213,9 +213,9 @@ The following options may also be used:
 
 **\--buildroot** *DIRECTORY* (DEPRECATED)
 
-:   When building a package, override rpm's buildroot to *DIRECTORY*.
-    This option is deprecated and will be removed in the future, do
-    not introduce new usages.
+:   When building a package, override the buildroot of **rpmbuild**(8) to
+    *DIRECTORY*. This option is deprecated and will be removed in the
+    future, do not introduce new usages.
 
 **\--clean**
 
@@ -227,15 +227,15 @@ The following options may also be used:
 
 **\--noprep**
 
-:   Do not execute %prep build stage even if present in spec.
+:   Do not execute **%prep** build stage even if present in spec.
 
 **\--noclean**
 
-:   Do not execute %clean build stage even if present in spec.
+:   Do not execute **%clean** build stage even if present in spec.
 
 **\--nocheck**
 
-:   Do not execute %check build stage even if present in spec.
+:   Do not execute **%check** build stage even if present in spec.
 
 **\--nodebuginfo**
 
@@ -253,7 +253,7 @@ The following options may also be used:
 **\--rmspec**
 
 :   Remove the spec file after the build (may also be used standalone,
-    eg. \"**rpmbuild** **\--rmspec foo.spec**\").
+    e.g. \"**rpmbuild** **\--rmspec foo.spec**\").
 
 **\--short-circuit**
 
@@ -266,9 +266,9 @@ The following options may also be used:
 **\--build-in-place**
 
 :   Build from locally checked out sources in the current working
-    directory. The build tree is set up as if %setup was used,
-    but %builddir/%buildsubdir points back to the current working
-    directory. %prep is skipped entirely.
+    directory. The build tree is set up as if **%setup** was used,
+    but *%builddir*/*%buildsubdir* points back to the current working
+    directory. **%prep** is skipped entirely.
 
 **\--target** *PLATFORM*
 
@@ -287,7 +287,7 @@ The following options may also be used:
 REBUILD AND RECOMPILE OPTIONS
 -----------------------------
 
-There are two other ways to invoke building with rpm:
+There are two other ways to invoke building with **rpm**(8):
 
 **rpmbuild** **\--rebuild\|\--recompile** *SOURCEPKG \...*
 
@@ -303,19 +303,19 @@ much more fine control over what stages of the build to run.
 DYNAMIC BUILD DEPENDENCIES
 --------------------------
 
-When the %generate\_buildrequires stage runs and some of the newly
+When the **%generate\_buildrequires** stage runs and some of the newly
 generated BuildRequires are not satisfied, **rpmbuild** creates an
 intermediate source package ending in *buildreqs.nosrc.rpm*, which has
 the new BuildRequires, and exits with code 11. This package can then be
 used in place of the original source package to resolve and install the
 missing build dependencies in the usual way, such as with
-**dnf-builddep(8)**.
+**dnf-builddep**(8).
 
 Multiple layers of dynamic build dependencies may exist in a spec file;
 the presence of specific BuildRequires on the system may yield new
 BuildRequires next time a build is performed with the same source
 package. The easiest way to ensure that all dynamic build dependencies
-are satisfied is to run the **-br** command, install the new
+are satisfied is to run the **-br** option, install the new
 dependencies of the *buildreqs.nosrc.rpm* package and repeat the whole
 procedure until **rpmbuild** no longer exits with code 11.
 

--- a/docs/man/rpmdb.8.md
+++ b/docs/man/rpmdb.8.md
@@ -23,7 +23,7 @@ DESCRIPTION
 
 The general form of an rpmdb command is
 
-**rpm** {**\--initdb\|\--rebuilddb**} \[**-v**\] \[**\--dbpath**
+**rpmdb** {**\--initdb\|\--rebuilddb**} \[**-v**\] \[**\--dbpath**
 *DIRECTORY*\] \[**\--root** *DIRECTORY*\]
 
 Use **\--initdb** to create a new database if one doesn\'t already exist
@@ -44,7 +44,7 @@ SEE ALSO
 **popt**(3), **rpm**(8), **rpmkeys**(8), **rpmsign**(8), **rpm2cpio**(8),
 **rpmbuild**(8), **rpmspec**(8)
 
-**rpm \--help** - as rpm supports customizing the options via popt
+**rpmdb \--help** - as **rpm**(8) supports customizing the options via popt
 aliases it\'s impossible to guarantee that what\'s described in the
 manual matches what\'s available.
 

--- a/docs/man/rpmdb.8.md
+++ b/docs/man/rpmdb.8.md
@@ -33,7 +33,7 @@ the database indices from the installed package headers.
 **\--verifydb** performs a low-level integrity check on the database.
 
 **\--exportdb** exports the database in header-list format, suitable
-for transfporting to another host or database type.
+for transporting to another host or database type.
 
 **\--importdb** imports a database from a header-list format as created
 by **\--exportdb**.

--- a/docs/man/rpmgraph.8.md
+++ b/docs/man/rpmgraph.8.md
@@ -19,7 +19,7 @@ DESCRIPTION
 
 **rpmgraph** uses *PACKAGE\_FILE* arguments to generate a package
 dependency graph. Each *PACKAGE\_FILE* argument is read and added to an
-rpm transaction set. The elements of the transaction set are partially
+**rpm**(8) transaction set. The elements of the transaction set are partially
 ordered using a topological sort. The partially ordered elements are
 then printed to standard output.
 

--- a/docs/man/rpmkeys.8.md
+++ b/docs/man/rpmkeys.8.md
@@ -17,7 +17,7 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-The general forms of rpm digital signature commands are
+The general forms of **rpm**(8) digital signature commands are
 
 **rpmkeys** {**-l\|\--list**} \[*FINGERPRINT \...*\]
 

--- a/docs/man/rpmlua.8.md
+++ b/docs/man/rpmlua.8.md
@@ -28,7 +28,7 @@ of the more customary index zero.
 
 **--opts=OPTSTRING**
 
-: Perform getopt(3) option processing on the passed arguments according
+: Perform **getopt**(3) option processing on the passed arguments according
   to OPTSTRING.
 
 **-e\|\--execute**

--- a/docs/man/rpmsign.8.md
+++ b/docs/man/rpmsign.8.md
@@ -91,18 +91,18 @@ SIGN OPTIONS
 
 **\--fskpath** *KEY*
 
-:   Used with **\--signfiles**, use file signing key *Key*.
+:   Used with **\--signfiles**, use file signing key *KEY*.
 
 **\--certpath** *CERT*
 
-:   Used with **\--signverity**, use file signing certificate *Cert*.
+:   Used with **\--signverity**, use file signing certificate *CERT*.
 
 **\--verityalgo** *ALG*
 
 :   Used with **\--signverity**, to specify the signing algorithm.
     sha256 and sha512 are supported, with sha256 being the default if
     this argument is not specified. This can also be specified with the
-    macro %\_verity\_algorithm
+    macro *%\_verity\_algorithm*.
 
 **\--signfiles**
 
@@ -128,7 +128,7 @@ CONFIGURING SIGNING KEYS
 ------------------------
 
 In order to sign packages, you need to create your own OpenPGP key pair
-(aka certificate) and configure **rpm** to use it. The following macros are
+(aka certificate) and configure **rpm**(8) to use it. The following macros are
 available:
 
 **%\_openpgp_sign_id**

--- a/docs/man/rpmsort.8.md
+++ b/docs/man/rpmsort.8.md
@@ -7,7 +7,7 @@ title: RPMSORT
 NAME
 ====
 
-rpmsort - Sort input by RPM Package Manager (RPM) versioning.
+rpmsort - Sort input by RPM Package Manager (RPM) versioning
 
 SYNOPSIS
 ========
@@ -17,11 +17,11 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-**rpmsort** sorts the input files, and writes a sorted list to standard out -
-like sort(1), but aware of RPM versioning.
+**rpmsort**(8) sorts the input files, and writes a sorted list to standard
+out - like **sort**(1), but aware of RPM versioning.
 
 If \'-\' is given as an argument, or no arguments are given, versions are read
-from stdandard in and writen to standard out.
+from standard in and written to standard out.
 
 EXAMPLES
 ========

--- a/docs/man/rpmspec.8.md
+++ b/docs/man/rpmspec.8.md
@@ -12,19 +12,19 @@ rpmspec - RPM Spec Tool
 SYNOPSIS
 ========
 
-QUERYING SPEC FILES:
---------------------
+QUERYING SPEC FILES
+-------------------
 
 **rpmspec** {**-q\|\--query**} \[**select-options**\]
 \[**query-options**\] *SPEC\_FILE \...*
 
-PARSING SPEC FILES TO STDOUT:
------------------------------
+PARSING SPEC FILES TO STDOUT
+----------------------------
 
 **rpmspec** {**-P\|\--parse**} *SPEC\_FILE \...*
 
-INVOKING MACRO SHELL:
----------------------
+INVOKING MACRO SHELL
+--------------------
 
 **rpmspec** {**--shell**} \[*SPEC_FILE \...*\]
 
@@ -63,18 +63,26 @@ do this, you use the
 
 **\--qf\|\--queryformat** *QUERYFMT*
 
-option, followed by the *QUERYFMT* format string. See **rpm(8)** for
+option, followed by the *QUERYFMT* format string. See **rpm**(8) for
 details.
 
 SELECT OPTIONS
 --------------
 
-**\--rpms** Operate on the all binary package headers generated from
-spec. **\--builtrpms** Operate only on the binary package headers of
-packages which would be built from spec. That means ignoring package
-headers of packages that won\'t be built from spec i. e. ignoring
-package headers of packages without file section. **\--srpm** Operate on
-the source package header(s) generated from spec.
+**\--rpms**
+
+:   Operate on the all binary package headers generated from spec.
+
+**\--builtrpms**
+
+:   Operate only on the binary package headers of packages which would be
+    built from spec. That means ignoring package headers of packages that
+    won\'t be built from spec i. e. ignoring package headers of packages
+    without file section.
+
+**\--srpm**
+
+:   Operate on the source package header(s) generated from spec.
 
 EXAMPLES
 ========


### PR DESCRIPTION
This is based on a list provided by the manpage-l10n project
(https://manpages-l10n-team.pages.debian.net/manpages-l10n/) in https://github.com/rpm-software-management/rpm/issues/3511.

This is mainly formatting and punctuation issues, referencing the proper
man pages and a few typos and minor re-wordings.

Resolves: https://github.com/rpm-software-management/rpm/issues/3511