### PR TITLE
Update sequoia-sq to 1.0 for CLI switch stability

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -639,9 +639,9 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %__sq_sign_cmd()	%{shescape:%{__sq}} \
 	sign \
 	%{?_sq_path:--homedir %{shescape:%{_sq_path}}} \
-        %{?_openpgp_sign_id:--signer-key %{_openpgp_sign_id}} \
+        %{?_openpgp_sign_id:--signer %{_openpgp_sign_id}} \
 	%{?_sq_sign_cmd_extra_args} \
-        --binary --detached --output %{shescape:%{2}} -- %{shescape:%{1}}
+        --binary --signature-file %{shescape:%{2}} -- %{shescape:%{1}}
 
 %__openpgp_sign_cmd %{expand:%{__%{_openpgp_sign}_sign_cmd}}
 

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -55,8 +55,10 @@ RUN dnf -y install \
   sequoia-sq \
   libasan \
   libubsan
+# Incapacitate IMA, needed until #3234 lands in fedora
+RUN rm -f /usr/lib/rpm/macros.d/macros.transaction_ima
 # If updates to specific packages are needed, do it here
-# RUN dnf --enablerepo=updates update ...
+RUN dnf -y --enablerepo=updates install "sequoia-sq >= 1.0"
 RUN dnf clean all
 
 RUN echo "%_dbpath $(rpm --eval '%_dbpath')" > /root/.rpmmacros

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -292,7 +292,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [])
 
 RPMTEST_CHECK([[
-runroot_other sq --cert-store=/usr/lib/sysimage/rpm/pubkeys pki list --gossip 2>&1 | grep -e "^[[:xdigit:]]\{40\}"
+runroot_other sq --cert-store=/usr/lib/sysimage/rpm/pubkeys cert list --gossip 2>&1 | grep -e "^ - [[:xdigit:]]\{40\}" | cut -c4-
 ]],
 [0],
 [771B18D3D7BAA28734333C424344591E1964C5FC


### PR DESCRIPTION
There are quite a few changes in the CLI of sq 1.0 (this was expected) that we'll just need to adapt to now.

The cli update itself is straightforward enough, the tricky part is getting the update pulled in because we need to do it in a separate transaction and at that point, rpm-plugin-ima has been pulled in and breaks installs in a rootless container. Thankfully since ce7210d5841389f866f66ae700817bee7fb10e9d we can just blast the IMA plugin config file away for now.

Fixes: #3506 