### PR TITLE
Move test-suite configuration out of root's ~/.rpmmacros

### DIFF
--- a/tests/data/macros.testenv
+++ b/tests/data/macros.testenv
@@ -1,4 +1,4 @@
-# root's macro config in the test-environment
+# common macro config in the test-environment
 %_buildhost testhost
 %_topdir %{getenv:RPMTEST}/build
 %_tmppath %{getenv:RPMTEST}/tmp

--- a/tests/mktree.common
+++ b/tests/mktree.common
@@ -30,8 +30,9 @@ make_install()
     echo "%_dbpath $dbpath" > $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/macros.db
     rpmdb --dbpath $DESTDIR/$dbpath --initdb
 
-    # append in case Dockerfile put something in there already
-    cat @CMAKE_CURRENT_SOURCE_DIR@/data/macros.testenv >> $DESTDIR/root/.rpmmacros
+    # system-wide config to match our test environment
+    cp @CMAKE_CURRENT_SOURCE_DIR@/data/macros.testenv $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/
+
     # gpg-connect-agent is very, very unhappy if this doesn't exist
     mkdir -p $DESTDIR/root/.gnupg
     chmod 700 $DESTDIR/root/.gnupg

--- a/tests/mktree.common
+++ b/tests/mktree.common
@@ -36,4 +36,7 @@ make_install()
     # gpg-connect-agent is very, very unhappy if this doesn't exist
     mkdir -p $DESTDIR/root/.gnupg
     chmod 700 $DESTDIR/root/.gnupg
+
+    # set up new-style XDG config directory
+    mkdir -p $DESTDIR/root/.config/rpm
 }

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -133,8 +133,7 @@ AT_KEYWORDS([rpmdb query])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
 
-# root's .rpmmacros used to keep this build prefix independent
-echo "%_keyring rpmdb" >> "${RPMTEST}"/root/.rpmmacros
+echo "%_keyring rpmdb" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 
 RPMTEST_CHECK([
 runroot rpm -U --nodeps --ignorearch --ignoreos --nosignature \

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -904,7 +904,7 @@ for e in 1 2; do
     runroot_other cp /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm /tmp/epoch${e}.rpm
 done
 # for testing sanity
-echo '%_query_all_fmt %%{nevra}' >> ${HOME}/.rpmmacros
+echo '%_query_all_fmt %%{nevra}' >> ${HOME}/.config/rpm/macros
 
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -8,7 +8,7 @@ RPMDB_INIT
 
 # .rpmmacros exists, new directory not
 RPMTEST_CHECK([[
-rm -f ~/.config/rpm
+rm -rf ~/.config/rpm ~/.rpmmacros
 touch ~/.rpmmacros
 rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
 ]],
@@ -19,6 +19,7 @@ rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
 
 # prefer new style if it exists
 RPMTEST_CHECK([[
+rm -rf ~/.config/rpm ~/.rpmmacros
 mkdir -p ~/.config/rpm
 rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
 ]],

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -63,8 +63,7 @@ AT_SETUP([rpmkeys key update and delete (rpmdb)])
 AT_KEYWORDS([rpmkeys signature])
 RPMDB_INIT
 # currently the default but make it explicit
-# root's .rpmmacros used to keep this build prefix independent
-echo "%_keyring rpmdb" >> "${RPMTEST}"/root/.rpmmacros
+echo "%_keyring rpmdb" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
@@ -164,8 +163,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmkeys migrate from keyid to fingerprint (fs)])
 AT_KEYWORDS([rpmkeys rpmdb])
 RPMDB_INIT
-# root's .rpmmacros used to keep this build prefix independent
-echo "%_keyring fs" >> "${RPMTEST}"/root/.rpmmacros
+echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 krpath="$(rpm --eval %{_keyringpath})"
 
 RPMTEST_CHECK([
@@ -199,8 +197,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmkeys key update (fs)])
 AT_KEYWORDS([rpmkeys signature])
 RPMDB_INIT
-# root's .rpmmacros used to keep this build prefix independent
-echo "%_keyring fs" >> "${RPMTEST}"/root/.rpmmacros
+echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
@@ -278,8 +275,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmkeys key update (openpgp)])
 AT_KEYWORDS([rpmkeys signature])
 RPMDB_INIT
-# root's .rpmmacros used to keep this build prefix independent
-echo "%_keyring openpgp" >> "${RPMTEST}"/root/.rpmmacros
+echo "%_keyring openpgp" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 krpath=$(rpm --eval "%{_keyringpath}")
 
 RPMTEST_CHECK([

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1407,7 +1407,7 @@ AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
 
 RPMTEST_CHECK([
-cat << EOF >> ${HOME}/.rpmmacros
+cat << EOF >> ${HOME}/.config/rpm/macros
 %_openpgp_sign sq
 %_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
 EOF
@@ -1467,7 +1467,7 @@ AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
 
 RPMTEST_CHECK([
-cat << EOF >> ${HOME}/.rpmmacros
+cat << EOF >> ${HOME}/.config/rpm/macros
 %_openpgp_sign sq
 %_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
 EOF
@@ -1577,7 +1577,7 @@ AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
 
 RPMTEST_CHECK([
-cat << EOF >> ${HOME}/.rpmmacros
+cat << EOF >> ${HOME}/.config/rpm/macros
 %_openpgp_sign sq
 %_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
 EOF


### PR DESCRIPTION
This is the second half of #3524 rebased on top of #3525. It's all pretty straightforward now, the tricky part turned out to be #3525.

Fixes: #3521