### PR TITLE
Run test-suite environment setup inside the image

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ message(STATUS "Using mktree backend: ${MKTREE_BACKEND} "
 	       "(native: ${MKTREE_NATIVE})")
 configure_file(mktree.common mktree.common @ONLY)
 configure_file(mktree.${MKTREE_BACKEND} mktree @ONLY)
+configure_file(setup.sh setup.sh @ONLY)
 
 if (MKTREE_NATIVE)
 	find_program(AUTOM4TE autom4te REQUIRED)

--- a/tests/mktree.common
+++ b/tests/mktree.common
@@ -18,25 +18,6 @@ make_install()
     ln -s $script_dir/rpmtests.sh $DESTDIR/usr/bin/rpmtests
 
     mkdir -p $DESTDIR/$script_dir
-    cp rpmtests atlocal mktree.common $DESTDIR/$script_dir/
+    cp rpmtests atlocal mktree.common setup.sh $DESTDIR/$script_dir/
     cp @CMAKE_CURRENT_SOURCE_DIR@/rpmtests.sh $DESTDIR/$script_dir/
-
-    mkdir -p $DESTDIR/build
-    ln -sf ../data/SOURCES $DESTDIR/build/
-
-    # setup an empty db that all tests are pointed to by default
-    dbpath="/var/lib/rpm-testsuite"
-    mkdir -p $DESTDIR/$dbpath
-    echo "%_dbpath $dbpath" > $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/macros.db
-    rpmdb --dbpath $DESTDIR/$dbpath --initdb
-
-    # system-wide config to match our test environment
-    cp @CMAKE_CURRENT_SOURCE_DIR@/data/macros.testenv $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/
-
-    # gpg-connect-agent is very, very unhappy if this doesn't exist
-    mkdir -p $DESTDIR/root/.gnupg
-    chmod 700 $DESTDIR/root/.gnupg
-
-    # set up new-style XDG config directory
-    mkdir -p $DESTDIR/root/.config/rpm
 }

--- a/tests/mktree.oci
+++ b/tests/mktree.oci
@@ -70,9 +70,11 @@ case $CMD in
         [ -n "$($PODMAN images -q $IMAGE)" ] && $PODMAN rmi $IMAGE
         if [ $NATIVE == yes ]; then
             # Native build
-            id=$($PODMAN create $IMAGE/base)
-            trap "$PODMAN rm $id >/dev/null" EXIT
+            id=$($PODMAN create -t $IMAGE/base)
+            trap "$PODMAN kill $id >/dev/null; $PODMAN rm $id > /dev/null" EXIT
+            $PODMAN start $id
             make_install $($PODMAN mount $id)
+            $PODMAN exec $id /usr/share/mktree/setup.sh
             $PODMAN commit -q $id $IMAGE
         else
             # Standalone build

--- a/tests/mktree.rootfs
+++ b/tests/mktree.rootfs
@@ -14,6 +14,7 @@ case $CMD in
     build)
         source ./mktree.common
         make_install /
+        ./setup.sh /
     ;;
     check)
         ./rpmtests "$@"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Setup the environment inside the test-image
+# DESTDIR is only for testing purposes, inside the image it's always /
+export DESTDIR=${1:-/}
+
+mkdir -p $DESTDIR/build
+ln -sf ../data/SOURCES $DESTDIR/build/
+
+# setup an empty db that all tests are pointed to by default
+dbpath="/var/lib/rpm-testsuite"
+mkdir -p $DESTDIR/$dbpath
+echo "%_dbpath $dbpath" > $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/macros.db
+rpmdb --dbpath $DESTDIR/$dbpath --initdb
+
+# system-wide config to match our test environment
+cp /data/macros.testenv $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/
+
+# gpg-connect-agent is very, very unhappy if this doesn't exist
+mkdir -p $DESTDIR/root/.gnupg
+chmod 700 $DESTDIR/root/.gnupg
+
+# set up new-style XDG config directory
+mkdir -p $DESTDIR/root/.config/rpm
+


### PR DESCRIPTION
Commit c17cc691569040fdfd741c2a423e9efecde181b0 introduced an `rpmdb --initdb` call into test-suite make_install() but at that point, it's actually the rpm from the host, which is NOT what we want.

Split the image preparation to two stages: install, which runs from the outside and basically just copies data into the image, and setup which runs from inside the image. For this we need some extra container gymnastics.

Fixes: #3530