### PR TITLE
Fix sq signing using invalid cli switch if %_sq_path is defined

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -638,7 +638,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %__sq @__SQ@
 %__sq_sign_cmd()	%{shescape:%{__sq}} \
 	sign \
-	%{?_sq_path:--homedir %{shescape:%{_sq_path}}} \
+	%{?_sq_path:--home %{shescape:%{_sq_path}}} \
         %{?_openpgp_sign_id:--signer %{_openpgp_sign_id}} \
 	%{?_sq_sign_cmd_extra_args} \
         --binary --signature-file %{shescape:%{2}} -- %{shescape:%{1}}

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1410,9 +1410,10 @@ RPMTEST_CHECK([
 cat << EOF >> ${HOME}/.config/rpm/macros
 %_openpgp_sign sq
 %_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
+%_sq_path ${HOME}/.config/rpm/sq
 EOF
 
-runroot_other sq key import /data/keys/*.secret
+runroot_other sq --home ${HOME}/.config/rpm/sq key import /data/keys/*.secret
 ],
 [0],
 [ignore],


### PR DESCRIPTION
--homedir is a gnupg thing, sq uses --home. Change one of the tests to utilize %_sq_path to make sure it works and stays that way.