### PR TITLE
Make test image caching saner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 /_build
 /docs/_site
+/tests/mktree.cache

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,7 @@ if (MKTREE_BACKEND STREQUAL oci)
 		add_custom_target(ci
 			COMMAND ./mktree.oci build
 			COMMAND ./mktree.oci check ${JOBS} $(TESTOPTS)
+			COMMAND ./mktree.oci clean
 			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		)
 	else()
@@ -135,6 +136,7 @@ endif()
 
 add_custom_target(atshell
 	COMMAND ./mktree atshell ||:
+	COMMAND ./mktree clean
 	DEPENDS tree
 )
 
@@ -143,16 +145,19 @@ add_custom_target(pinned
 	COMMAND cp pinned/*.txt ${PINNED_DIR}/
 	COMMAND git add ${PINNED_DIR}/*.txt
 	COMMAND git diff --staged ${PINNED_DIR}/*.txt
+	COMMAND ./mktree clean
 	DEPENDS tree
 )
 
 add_custom_target(shell
 	COMMAND ./mktree shell ||:
+	COMMAND ./mktree clean
 	DEPENDS tree
 )
 
 add_custom_target(check
 	COMMAND ./mktree check ${JOBS} $(TESTOPTS)
+	COMMAND ./mktree clean
 	DEPENDS tree
 )
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,10 +84,11 @@ To only build the OCI image, use:
 
     make tree
 
-You can also just use Podman or Docker directly to manage containers (the image
-is named `rpm` when built).  For example, to run a shell:
+You can now also tag the image and then use it with Podman or Docker as normal:
 
-    podman run -it rpm
+    cd tests/
+    ./mktree tag <image-name>
+    podman run -it <image-name> ...
 
 ## Understanding the tests
 

--- a/tests/mktree.oci
+++ b/tests/mktree.oci
@@ -64,6 +64,7 @@ clean()
 {
     rm -f "$IID_FILE"
     [ -z "$IMAGE_ID" ] || [ -z "$($PODMAN images -q $IMAGE_ID)" ] && return
+    [ "$($PODMAN inspect -f "{{ .RepoTags }}" $IMAGE_ID)" != "[]" ] && return
     $PODMAN rmi $IMAGE_ID >/dev/null
 }
 
@@ -105,6 +106,9 @@ case $CMD in
     ;;
     reset)
         rpmtests --reset
+    ;;
+    tag)
+        $PODMAN tag $IMAGE_ID $1
     ;;
     clean)
         clean

--- a/tests/mktree.oci
+++ b/tests/mktree.oci
@@ -25,13 +25,18 @@ else
     FROM=
 fi
 
-IMAGE=rpm
+CACHE_DIR="mktree.cache"
+IID_FILE="$CACHE_DIR/image-id"
+IMAGE_ID=$(cat $IID_FILE 2>/dev/null || echo "")
+BASE_TAG="rpm/base"
 ARGS="-f Dockerfile $FROM $CONTEXT"
 ROOTLESS=$([ $(id -u) == 0 ] && echo 0 || echo 1)
 CMD=$1; shift
 
 export ROOTLESS
 source mktree.common
+
+mkdir -p $CACHE_DIR
 
 rpmtests()
 {
@@ -51,7 +56,15 @@ rpmtests()
     fi
 
     $PODMAN run --privileged -it --rm --read-only --tmpfs /tmp -v $vol \
-                --workdir /srv -e ROOTLESS=$ROOTLESS $opts $IMAGE rpmtests "$@"
+                --workdir /srv -e ROOTLESS=$ROOTLESS $opts $IMAGE_ID \
+                rpmtests "$@"
+}
+
+clean()
+{
+    rm -f "$IID_FILE"
+    [ -z "$IMAGE_ID" ] || [ -z "$($PODMAN images -q $IMAGE_ID)" ] && return
+    $PODMAN rmi $IMAGE_ID >/dev/null
 }
 
 unshared()
@@ -64,21 +77,21 @@ unshared()
 case $CMD in
     build) unshared
         # Build base image
-        $PODMAN build --target base -t $IMAGE/base $ARGS
+        $PODMAN build --target base -t $BASE_TAG $ARGS
 
         # Add RPM install on top
-        [ -n "$($PODMAN images -q $IMAGE)" ] && $PODMAN rmi $IMAGE
+        clean
         if [ $NATIVE == yes ]; then
             # Native build
-            id=$($PODMAN create -t $IMAGE/base)
+            id=$($PODMAN create -t $BASE_TAG)
             trap "$PODMAN kill $id >/dev/null; $PODMAN rm $id > /dev/null" EXIT
             $PODMAN start $id
             make_install $($PODMAN mount $id)
             $PODMAN exec $id /usr/share/mktree/setup.sh
-            $PODMAN commit -q $id $IMAGE
+            $PODMAN commit -q $id --iidfile=$IID_FILE
         else
             # Standalone build
-            $PODMAN build --target full -t $IMAGE $ARGS
+            $PODMAN build --target full --iidfile=$IID_FILE $ARGS
         fi
     ;;
     check)
@@ -92,5 +105,8 @@ case $CMD in
     ;;
     reset)
         rpmtests --reset
+    ;;
+    clean)
+        clean
     ;;
 esac

--- a/tests/mktree.oci
+++ b/tests/mktree.oci
@@ -28,7 +28,7 @@ fi
 CACHE_DIR="mktree.cache"
 IID_FILE="$CACHE_DIR/image-id"
 IMAGE_ID=$(cat $IID_FILE 2>/dev/null || echo "")
-BASE_TAG="rpm/base"
+BASE_TAG="rpm/base:$(sha256sum Dockerfile | head -c8)"
 ARGS="-f Dockerfile $FROM $CONTEXT"
 ROOTLESS=$([ $(id -u) == 0 ] && echo 0 || echo 1)
 CMD=$1; shift


### PR DESCRIPTION
* Use build-local "tags" instead of tagging all images as "rpm".
* Fix constant base image rebuilds when switching back and forth between branches

Details in commit messages.