### PR TITLE
Consistify and cleanup test-suite setup macros

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -137,7 +137,7 @@ as well as the existing tests.  Below are the specifics of RPM's test-suite:
 
 * Use `RPMTEST_CHECK` instead of `AT_CHECK`
 * Use `RPMTEST_CLEANUP` instead of `AT_CLEANUP`
-* Use `RPMTEST_SETUP` or `RPMDB_INIT` to create a mutable snapshot (optional)
+* Use `RPMTEST_INIT` or `RPMDB_INIT` to create a mutable snapshot (optional)
     * The absolute path to the snapshot's root is stored in the `$RPMTEST`
       environment variable, modify the directory tree as you wish
     * To run RPM inside the snapshot, use the `runroot` prefix, e.g. `runroot

--- a/tests/README.md
+++ b/tests/README.md
@@ -135,6 +135,7 @@ For the typical structure of a single test, consult GNU Autotest's
 [documentation](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/autoconf.html#Writing-Testsuites)
 as well as the existing tests.  Below are the specifics of RPM's test-suite:
 
+* Use `RPMTEST_SETUP` instead of `AT_SETUP`
 * Use `RPMTEST_CHECK` instead of `AT_CHECK`
 * Use `RPMTEST_CLEANUP` instead of `AT_CLEANUP`
 * Use `RPMTEST_INIT` or `RPMDB_INIT` to create a mutable snapshot (optional)

--- a/tests/README.md
+++ b/tests/README.md
@@ -138,7 +138,7 @@ as well as the existing tests.  Below are the specifics of RPM's test-suite:
 * Use `RPMTEST_SETUP` instead of `AT_SETUP`
 * Use `RPMTEST_CHECK` instead of `AT_CHECK`
 * Use `RPMTEST_CLEANUP` instead of `AT_CLEANUP`
-* Use `RPMTEST_INIT` or `RPMDB_INIT` to create a mutable snapshot (optional)
+* Use `RPMTEST_INIT` to create a mutable snapshot (optional)
     * The absolute path to the snapshot's root is stored in the `$RPMTEST`
       environment variable, modify the directory tree as you wish
     * To run RPM inside the snapshot, use the `runroot` prefix, e.g. `runroot
@@ -155,6 +155,7 @@ as well as the existing tests.  Below are the specifics of RPM's test-suite:
     * You can create a custom user (or users) by supplying a list of usernames
       to the macro, e.g. `RPMTEST_USER([user1, user2])`.  Then, use
       `runroot_user -n <name>` to run a binary as a specific user
+* Use `RPMDB_RESET` to reinitialize a snapshot to an empty rpmdb (avoid this)
 * If no snapshot was used, just call the RPM binaries normally
 * Store any working files in the current directory (it's always writable)
 

--- a/tests/local.at
+++ b/tests/local.at
@@ -1,5 +1,9 @@
 AT_TESTED([rpm rpmbuild rpmquery])
 
+m4_define([RPMTEST_SETUP],[
+AT_SETUP($1)
+])
+
 m4_define([RPMTEST_INIT],[[
 export RPMTEST="${PWD}/tree"
 export HOME="${RPMTEST}/root"
@@ -61,7 +65,7 @@ RPMTEST_CHECK([RPMPY_RUN([$1])], [], [$2], [$3])
 ])
 
 m4_define([RPMPY_TEST],[
-AT_SETUP([$1])
+RPMTEST_SETUP([$1])
 AT_KEYWORDS([python])
 setup_env
 RPMDB_INIT

--- a/tests/local.at
+++ b/tests/local.at
@@ -10,10 +10,14 @@ export HOME="${RPMTEST}/root"
 [ -d "$RPMTEST" ] || snapshot mount "${PWD}"
 ]])
 
-m4_define([RPMDB_INIT],[
-RPMTEST_INIT
+m4_define([RPMDB_RESET],[
 rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`
 runroot rpm --initdb
+])
+
+m4_define([RPMDB_INIT],[
+RPMTEST_INIT
+RPMDB_RESET
 ])
 
 m4_define([RPMPY_RUN],[[

--- a/tests/local.at
+++ b/tests/local.at
@@ -15,11 +15,6 @@ rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`
 runroot rpm --initdb
 ])
 
-m4_define([RPMDB_INIT],[
-RPMTEST_INIT
-RPMDB_RESET
-])
-
 m4_define([RPMPY_RUN],[[
 cat << EOF > test.py
 # coding=utf-8
@@ -72,7 +67,6 @@ m4_define([RPMPY_TEST],[
 RPMTEST_SETUP([$1])
 AT_KEYWORDS([python])
 setup_env
-RPMDB_INIT
 RPMPY_CHECK([$2], [$3], [$4])
 RPMTEST_CLEANUP
 ])

--- a/tests/local.at
+++ b/tests/local.at
@@ -1,13 +1,13 @@
 AT_TESTED([rpm rpmbuild rpmquery])
 
-m4_define([RPMTEST_SETUP],[[
+m4_define([RPMTEST_INIT],[[
 export RPMTEST="${PWD}/tree"
 export HOME="${RPMTEST}/root"
 [ -d "$RPMTEST" ] || snapshot mount "${PWD}"
 ]])
 
 m4_define([RPMDB_INIT],[
-RPMTEST_SETUP
+RPMTEST_INIT
 rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`
 runroot rpm --initdb
 ])
@@ -70,7 +70,7 @@ RPMTEST_CLEANUP
 ])
 
 m4_define([RPMTEST_USER],[
-RPMTEST_SETUP
+RPMTEST_INIT
 [[ $# != 0 ]] && export RPMUSER=$1
 useradd -m -R $RPMTEST $RPMUSER
 ])

--- a/tests/rpmbrp.at
+++ b/tests/rpmbrp.at
@@ -4,7 +4,7 @@ AT_BANNER([RPM build root policy scripts])
 
 # ------------------------------
 # Check brp-remove-la-files
-AT_SETUP([brp-remove-la-files])
+RPMTEST_SETUP([brp-remove-la-files])
 AT_KEYWORDS([build brp])
 RPMTEST_CHECK([
 TD=/tmp/brp-remove-la-files

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -20,7 +20,7 @@ AT_BANNER([RPM build])
 
 # ------------------------------
 # Check if rpmbuild -ba *.spec works
-AT_SETUP([rpmbuild -ba *.spec])
+RPMTEST_SETUP([rpmbuild -ba *.spec])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -63,7 +63,7 @@ Iam
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -bs spec])
+RPMTEST_SETUP([rpmbuild -bs spec])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -94,7 +94,7 @@ runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-1.0-1.src.rpm
 
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -b buildsystem])
+RPMTEST_SETUP([rpmbuild -b buildsystem])
 AT_KEYWORDS([build buildsystem])
 RPMDB_INIT
 
@@ -211,7 +211,7 @@ runroot rpmspec -q --qf "%{nvr}\n" /data/SPECS/amhello.spec
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -b steps])
+RPMTEST_SETUP([rpmbuild -b steps])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -325,7 +325,7 @@ runroot rpmbuild -bs /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild script prepend/append])
+RPMTEST_SETUP([rpmbuild script prepend/append])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -343,7 +343,7 @@ DDD
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild dir layout])
+RPMTEST_SETUP([rpmbuild dir layout])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -389,7 +389,7 @@ runroot_other find /build/BUILD|sort
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -ba autosetup])
+RPMTEST_SETUP([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -402,7 +402,7 @@ rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -bp autosetup without patches])
+RPMTEST_SETUP([rpmbuild -bp autosetup without patches])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -422,7 +422,7 @@ grep warning: stderr
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild --build-in-place 1])
+RPMTEST_SETUP([rpmbuild --build-in-place 1])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -485,7 +485,7 @@ hello-2.0/hello.c
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild --build-in-place --noprep])
+RPMTEST_SETUP([rpmbuild --build-in-place --noprep])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -506,7 +506,7 @@ runroot --chdir hello-2.0 rpmbuild -bb --quiet \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild --build-in-place --short-circuit])
+RPMTEST_SETUP([rpmbuild --build-in-place --short-circuit])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -529,7 +529,7 @@ hello-debuginfo-2.0-1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild with %autosetup -C])
+RPMTEST_SETUP([rpmbuild with %autosetup -C])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -567,7 +567,7 @@ rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -ba autopatch])
+RPMTEST_SETUP([rpmbuild -ba autopatch])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -588,7 +588,7 @@ grep warning: stderr
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -ba find-lang])
+RPMTEST_SETUP([rpmbuild -ba find-lang])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -612,7 +612,7 @@ pl /usr/share/man/pl/man1/find-lang-test.1.gz
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -ba find-lang --generate-subpackages])
+RPMTEST_SETUP([rpmbuild -ba find-lang --generate-subpackages])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -642,7 +642,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpmbuild --rebuild *.src.rpm works
-AT_SETUP([rpmbuild --rebuild])
+RPMTEST_SETUP([rpmbuild --rebuild])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -664,7 +664,7 @@ runroot rpm -qp --qf "%{packager}\n" /build/RPMS/*/hello-1.0-1.*.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild --short-circuit -bl])
+RPMTEST_SETUP([rpmbuild --short-circuit -bl])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -679,7 +679,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if tar unpacking works
-AT_SETUP([rpmbuild -tb <tar with bad spec>])
+RPMTEST_SETUP([rpmbuild -tb <tar with bad spec>])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -693,7 +693,7 @@ runroot rpmbuild \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -ts <spec>])
+RPMTEST_SETUP([rpmbuild -ts <spec>])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -719,7 +719,7 @@ runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-2.0-1.src.rpm
 RPMTEST_CLEANUP
 
 # weird filename survival test
-AT_SETUP([rpmbuild package with weird filenames])
+RPMTEST_SETUP([rpmbuild package with weird filenames])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -751,7 +751,7 @@ runroot rpm -qpl /build/RPMS/noarch/weirdnames-1.0-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild package with illegal filenames])
+RPMTEST_SETUP([rpmbuild package with illegal filenames])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -766,7 +766,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if tar build works
 # TODO: test that the rpms are actually created...
-AT_SETUP([rpmbuild -tb])
+RPMTEST_SETUP([rpmbuild -tb])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -779,7 +779,7 @@ rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild with deprecated patch])
+RPMTEST_SETUP([rpmbuild with deprecated patch])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -792,7 +792,7 @@ runroot rpmbuild -bp --quiet /data/SPECS/hello-patch.spec
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild scriptlet -f])
+RPMTEST_SETUP([rpmbuild scriptlet -f])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -860,7 +860,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # %attr/%defattr tests
-AT_SETUP([rpmbuild %attr and %defattr])
+RPMTEST_SETUP([rpmbuild %attr and %defattr])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -930,7 +930,7 @@ drwxrwxrwx   1 root     root            0 Feb 20  2020 ./j/dir
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild SOURCE_DATE_EPOCH])
+RPMTEST_SETUP([rpmbuild SOURCE_DATE_EPOCH])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -951,7 +951,7 @@ runroot rpm -q --dump /build/RPMS/noarch/test-1-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild SOURCE_DATE_EPOCH=0])
+RPMTEST_SETUP([rpmbuild SOURCE_DATE_EPOCH=0])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -972,7 +972,7 @@ runroot rpm -q --dump /build/RPMS/noarch/test-1-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild _buildtime macro])
+RPMTEST_SETUP([rpmbuild _buildtime macro])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -994,7 +994,7 @@ runroot rpm -q --qf '%{BUILDTIME}\n' /build/RPMS/noarch/test-1-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild unpackaged files])
+RPMTEST_SETUP([rpmbuild unpackaged files])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -1011,7 +1011,7 @@ runroot rpmbuild \
 RPMTEST_CLEANUP
 
 # rpm doesn't detect unpackaged directories but should, really
-AT_SETUP([rpmbuild unpackaged directories])
+RPMTEST_SETUP([rpmbuild unpackaged directories])
 AT_KEYWORDS([build])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMDB_INIT
@@ -1030,7 +1030,7 @@ runroot rpmbuild \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild glob])
+RPMTEST_SETUP([rpmbuild glob])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -1066,7 +1066,7 @@ warning: absolute symlink: /opt/globtest/linkgood -> /opt/globtest/zab
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild glob escape])
+RPMTEST_SETUP([rpmbuild glob escape])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1132,7 +1132,7 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild bad escape])
+RPMTEST_SETUP([rpmbuild bad escape])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1147,7 +1147,7 @@ runroot rpmbuild -bb --quiet /data/SPECS/badescape.spec
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild bad quote])
+RPMTEST_SETUP([rpmbuild bad quote])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1162,7 +1162,7 @@ runroot rpmbuild -bb --quiet /data/SPECS/badquote.spec
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild prefixpostfix])
+RPMTEST_SETUP([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1197,7 +1197,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if weak and reverse requires can be built
-AT_SETUP([Weak and reverse requires])
+RPMTEST_SETUP([Weak and reverse requires])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1228,7 +1228,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test BuildRequire functionality
-AT_SETUP([Build requires])
+RPMTEST_SETUP([Build requires])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1245,7 +1245,7 @@ runroot rpmbuild -bb --quiet \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([Dependency generation 1])
+RPMTEST_SETUP([Dependency generation 1])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -1298,7 +1298,7 @@ runroot rpm -qp --qf '[["%{FILENAMES}\t%{FILEPROVIDE}"\n]]' /build/RPMS/noarch/f
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([Dependency generation 2])
+RPMTEST_SETUP([Dependency generation 2])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1313,7 +1313,7 @@ runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([Dependency generation 3])
+RPMTEST_SETUP([Dependency generation 3])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1334,7 +1334,7 @@ runroot rpmbuild -bb --quiet \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([Dependency generation 4])
+RPMTEST_SETUP([Dependency generation 4])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1363,7 +1363,7 @@ one(shebang) = 77
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([Dependency generation 5])
+RPMTEST_SETUP([Dependency generation 5])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1381,7 +1381,7 @@ runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([Local dependency generator])
+RPMTEST_SETUP([Local dependency generator])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1433,7 +1433,7 @@ shebang = 0.1-1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([elf dependencies])
+RPMTEST_SETUP([elf dependencies])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -1496,7 +1496,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test spec query functionality
-AT_SETUP([rpmspec query 1])
+RPMTEST_SETUP([rpmspec query 1])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 
@@ -1516,7 +1516,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # archive sanity check
-AT_SETUP([rpmbuild archive sanity])
+RPMTEST_SETUP([rpmbuild archive sanity])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1534,7 +1534,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpmbuild creates the minisymtab section in the main hello binary
-AT_SETUP([rpmbuild debuginfo minisymtab])
+RPMTEST_SETUP([rpmbuild debuginfo minisymtab])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1572,7 +1572,7 @@ RPMTEST_CLEANUP
 # Check if rpmbuild doesn't create the minisymtab section if we keep symtab
 # Some package might want to use strip -g to keep the symbol table and only
 # but the debug symbols/info in the debuginfo package.
-AT_SETUP([rpmbuild debuginfo minisymtab strip -g])
+RPMTEST_SETUP([rpmbuild debuginfo minisymtab strip -g])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1612,7 +1612,7 @@ RPMTEST_CLEANUP
 # debuginfo. This is simply the hello example with one binary build twice
 # so dwz has enough slightly similar debug data.
 # Test the case without unique debug file names.
-AT_SETUP([rpmbuild debuginfo dwz])
+RPMTEST_SETUP([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1699,7 +1699,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that rpmbuild creates no debuginfo when --nodebuginfo is passed
-AT_SETUP([rpmbuild no debuginfo])
+RPMTEST_SETUP([rpmbuild no debuginfo])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1733,7 +1733,7 @@ RPMTEST_CLEANUP
 # debuginfo. This is simply the hello example with one binary build twice
 # so dwz has enough slightly similar debug data.
 # Test with unique debug file names.
-AT_SETUP([rpmbuild debuginfo dwz unique debug names])
+RPMTEST_SETUP([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1820,7 +1820,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that an implicit suid binary get included with the suid bit set.
 # We explicitly build with all debug.macros to test those helpers.
-AT_SETUP([rpmbuild implicit suid binary])
+RPMTEST_SETUP([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1852,7 +1852,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that a GDB index is included when requested.
-AT_SETUP([rpmbuild debuginfo gdb index included])
+RPMTEST_SETUP([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1879,7 +1879,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that a GDB index is NOT included when not requested.
-AT_SETUP([rpmbuild debuginfo no gdb index included])
+RPMTEST_SETUP([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1905,7 +1905,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that a -g3 (macros) build creates a valid .debug file.
-AT_SETUP([rpmbuild debuginfo -g3 .debug_macro])
+RPMTEST_SETUP([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1937,7 +1937,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # ------------------------------
 # Check that a debug source is in a "unique" directory when requested.
-AT_SETUP([rpmbuild debuginfo unique debug src dir])
+RPMTEST_SETUP([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1974,7 +1974,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that a debug source is NOT in a "unique" directory when not requested.
 # It will be in the "build directory" name under /usr/src/debug.
-AT_SETUP([rpmbuild debuginfo no unique debug src dir])
+RPMTEST_SETUP([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2008,7 +2008,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that defining _debugsource_packages creates -debugsource package
-AT_SETUP([rpmbuild debugsource])
+RPMTEST_SETUP([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2040,7 +2040,7 @@ RPMTEST_CLEANUP
 # Check that defining _debugsource_packages creates -debugsource package
 # even if %install changes the working directory (debugsourcefiles.list
 # should be in expected build dir).
-AT_SETUP([rpmbuild debugsource debugsourcefiles.list path])
+RPMTEST_SETUP([rpmbuild debugsource debugsourcefiles.list path])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2065,7 +2065,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that undefining _debuginfo_subpackages creates one single -debuginfo.
-AT_SETUP([rpmbuild debuginfo subpackages single])
+RPMTEST_SETUP([rpmbuild debuginfo subpackages single])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2104,7 +2104,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
-AT_SETUP([rpmbuild debuginfo subpackages multiple])
+RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2185,7 +2185,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
 # With unique debug and source names
-AT_SETUP([rpmbuild debuginfo subpackages multiple unique])
+RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple unique])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2266,7 +2266,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
 # Unique with debugsources.
-AT_SETUP([rpmbuild debuginfo subpackages multiple unique debugsource])
+RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple unique debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2350,7 +2350,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that defining _debuginfo_subpackages works with excluded files.
-AT_SETUP([rpmbuild debuginfo subpackages multiple excluded])
+RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2411,7 +2411,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that defining _debuginfo_subpackages works with RemovePathPostfixes.
-AT_SETUP([rpmbuild debuginfo subpackages multiple excluded])
+RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -2475,7 +2475,7 @@ No hello.debug
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([manual debuginfo package])
+RPMTEST_SETUP([manual debuginfo package])
 AT_KEYWORDS([build debuginfo])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2523,7 +2523,7 @@ runroot rpmbuild --quiet -bb \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([manual %debug_package use])
+RPMTEST_SETUP([manual %debug_package use])
 AT_KEYWORDS([build debuginfo])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -2535,7 +2535,7 @@ runroot rpmbuild -bb \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([explicit %_enable_debug_package on noarch])
+RPMTEST_SETUP([explicit %_enable_debug_package on noarch])
 AT_KEYWORDS([build debuginfo])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2563,7 +2563,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
-AT_SETUP([dynamic build requires rpmbuild -bs])
+RPMTEST_SETUP([dynamic build requires rpmbuild -bs])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2584,7 +2584,7 @@ RPMTEST_CLEANUP
 # Check dynamic build requires
 # Mimick what mock does: repeat build with --noprep --noclean
 # until -br succeeds, and finally build the package.
-AT_SETUP([rpmbuild -br])
+RPMTEST_SETUP([rpmbuild -br])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2619,7 +2619,7 @@ runroot rpmbuild \
 RPMTEST_CLEANUP
 
 # Test that -br creates an src.rpm on success
-AT_SETUP([rpmbuild -br success])
+RPMTEST_SETUP([rpmbuild -br success])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2636,7 +2636,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
-AT_SETUP([rpmbuild -bd with errors])
+RPMTEST_SETUP([rpmbuild -bd with errors])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2656,7 +2656,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpmbuild -bd *.spec doesn't build anything
-AT_SETUP([rpmbuild -bd *.spec])
+RPMTEST_SETUP([rpmbuild -bd *.spec])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -2673,7 +2673,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
-AT_SETUP([rpmbuild -ba])
+RPMTEST_SETUP([rpmbuild -ba])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2694,7 +2694,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
-AT_SETUP([rpmbuild -br --nodeps])
+RPMTEST_SETUP([rpmbuild -br --nodeps])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2717,7 +2717,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that rpmbuild aborts with missing Source
-AT_SETUP([rpmbuild -ba missing source])
+RPMTEST_SETUP([rpmbuild -ba missing source])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -2746,7 +2746,7 @@ error: Bad file: /notthere/hello-1.0.tar.gz: No such file or directory
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild minimal spec])
+RPMTEST_SETUP([rpmbuild minimal spec])
 AT_KEYWORDS([build])
 RPMTEST_CHECK_UNQUOTED([
 RPMDB_INIT
@@ -2759,7 +2759,7 @@ runroot rpmbuild \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild missing files])
+RPMTEST_SETUP([rpmbuild missing files])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -2783,7 +2783,7 @@ error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/share/l
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild missing doc])
+RPMTEST_SETUP([rpmbuild missing doc])
 AT_KEYWORDS([build])
 RPMTEST_CHECK_UNQUOTED([
 RPMDB_INIT
@@ -2803,7 +2803,7 @@ done
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([spec conditionals])
+RPMTEST_SETUP([spec conditionals])
 AT_KEYWORDS([if else elif build])
 RPMDB_INIT
 
@@ -2902,7 +2902,7 @@ runroot rpmbuild -ba --quiet      \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([bcond macro])
+RPMTEST_SETUP([bcond macro])
 AT_KEYWORDS([bcond build])
 RPMDB_INIT
 
@@ -2975,7 +2975,7 @@ has_bcond(normally_on)
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([bcond_override_default macros])
+RPMTEST_SETUP([bcond_override_default macros])
 AT_KEYWORDS([bcond build])
 RPMDB_INIT
 
@@ -3070,7 +3070,7 @@ has_bcond(normally_off)
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild spec tag])
+RPMTEST_SETUP([rpmbuild spec tag])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -3118,7 +3118,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check %sources and %patches with weird file names
-AT_SETUP([%sources and %patches])
+RPMTEST_SETUP([%sources and %patches])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3137,7 +3137,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if dynamic spec generation works
-AT_SETUP([rpmbuild with dynamic spec generation])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3164,7 +3164,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if dynamic spec generation works for main package, too
 # Fails now as feature is disbled
-AT_SETUP([rpmbuild with dynamic spec generation for main package])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMDB_INIT
@@ -3193,7 +3193,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if dynamic spec generation works for main package, too
 # Check for failure as feature is disabled. Remove tests when enabled
-AT_SETUP([rpmbuild with dynamic spec generation for main package])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3207,7 +3207,7 @@ error: License field must be present in package: dynamic
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild with dynamic spec generation for main package])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3223,7 +3223,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-AT_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3240,7 +3240,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-AT_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3256,7 +3256,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-AT_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3273,7 +3273,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-AT_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3290,7 +3290,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-AT_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3308,7 +3308,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check source name with space
-AT_SETUP([rpmbuild source name with space])
+RPMTEST_SETUP([rpmbuild source name with space])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3320,7 +3320,7 @@ runroot rpmbuild -bp --quiet /data/SPECS/source_space.spec
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild bad filetrigger condition])
+RPMTEST_SETUP([rpmbuild bad filetrigger condition])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -3348,7 +3348,7 @@ rpmspec --define "nosuchmacro /bbb" --parse /data/SPECS/badftrigger.spec
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild interactive])
+RPMTEST_SETUP([rpmbuild interactive])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -3367,7 +3367,7 @@ runroot rpmbuild --quiet -bp /data/SPECS/stdin.spec
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild bpf file])
+RPMTEST_SETUP([rpmbuild bpf file])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -3381,7 +3381,7 @@ RPMTEST_CLEANUP
 
 # XXX this always succeeds when rpmbuild is run as root so the test is
 # kinda meaningless until #3005 is done, but works as a manual reproducer.
-AT_SETUP([rpmbuild non-removable file in builddir])
+RPMTEST_SETUP([rpmbuild non-removable file in builddir])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -3395,7 +3395,7 @@ runroot rpmbuild --quiet -bb /data/SPECS/noperms.spec
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild %caps])
+RPMTEST_SETUP([rpmbuild %caps])
 AT_KEYWORDS([build])
 AT_SKIP_IF([$CAP_DISABLED])
 RPMDB_INIT
@@ -3448,7 +3448,7 @@ runroot_other /usr/sbin/getcap /usr/bin/test
 
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild -bs with source macro])
+RPMTEST_SETUP([rpmbuild -bs with source macro])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -3479,7 +3479,7 @@ hello-1.0-install.patch
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild target macro sanity])
+RPMTEST_SETUP([rpmbuild target macro sanity])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
@@ -3531,7 +3531,7 @@ BUILD_POST noarch noarch noarch
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmbuild install_pre override])
+RPMTEST_SETUP([rpmbuild install_pre override])
 AT_KEYWORDS([build])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -3544,7 +3544,7 @@ RPMTEST_CLEANUP
 
 # Mimick what cpack does. It's not how rpmbuild wants to be used, so
 # please don't copy this to any new usages.
-AT_SETUP([rpmbuild --buildroot])
+RPMTEST_SETUP([rpmbuild --buildroot])
 AT_KEYWORDS([build])
 
 RPMDB_INIT
@@ -3568,7 +3568,7 @@ runroot rpm -qpl /build/RPMS/noarch/brtest-1.0-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([builddir])
+RPMTEST_SETUP([builddir])
 AT_KEYWORDS([build builddir])
 
 RPMDB_INIT
@@ -3594,7 +3594,7 @@ mydir2=/build/BUILD/mydir-1.0-build/mydir-1.0
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([file digests])
+RPMTEST_SETUP([file digests])
 AT_KEYWORDS([build digest])
 RPMDB_INIT
 RPMTEST_CHECK([[
@@ -3650,7 +3650,7 @@ b718a835936fd2f6c8855f210c4789a1 hello-1.0.tar.gz
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([file digests sha3])
+RPMTEST_SETUP([file digests sha3])
 AT_KEYWORDS([build digest])
 AT_SKIP_IF([test x$PGP = xsequoia])
 RPMDB_INIT

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -22,7 +22,7 @@ AT_BANNER([RPM build])
 # Check if rpmbuild -ba *.spec works
 RPMTEST_SETUP([rpmbuild -ba *.spec])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -65,7 +65,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -bs spec])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild -bs \
@@ -96,7 +96,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -b buildsystem])
 AT_KEYWORDS([build buildsystem])
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}/data/macros.buildsystem" "${RPMTEST}/${RPM_CONFIGDIR_PATH}/macros.d/"
 
@@ -213,7 +213,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -b steps])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bp /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
@@ -327,7 +327,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild script prepend/append])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bb --quiet ${RPMDATA}/SPECS/append.spec
 runroot_other rpm2cpio /build/RPMS/noarch/append-1.0-1.noarch.rpm | cpio -id 2> /dev/null
@@ -345,7 +345,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild dir layout])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 rpmbuild \
 	-bi --target noarch --quiet \
@@ -391,7 +391,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -404,7 +404,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -bp autosetup without patches])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild -D="nopatches 1" \
@@ -424,7 +424,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild --build-in-place 1])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
@@ -487,7 +487,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild --build-in-place --noprep])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
@@ -508,7 +508,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild --build-in-place --short-circuit])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
@@ -531,7 +531,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild with %autosetup -C])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -569,7 +569,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -ba autopatch])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -590,7 +590,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -ba find-lang])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild \
   -ba /data/SPECS/find-lang-test.spec
@@ -614,7 +614,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -ba find-lang --generate-subpackages])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -D "langpacks 1"\
   -ba /data/SPECS/find-lang-test.spec
@@ -644,7 +644,7 @@ RPMTEST_CLEANUP
 # Check if rpmbuild --rebuild *.src.rpm works
 RPMTEST_SETUP([rpmbuild --rebuild])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -666,7 +666,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild --short-circuit -bl])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild -bi ${RPMDATA}/SPECS/hello.spec &> /dev/null
@@ -681,7 +681,7 @@ RPMTEST_CLEANUP
 # Check if tar unpacking works
 RPMTEST_SETUP([rpmbuild -tb <tar with bad spec>])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild \
@@ -695,7 +695,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -ts <spec>])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet \
@@ -721,7 +721,7 @@ RPMTEST_CLEANUP
 # weird filename survival test
 RPMTEST_SETUP([rpmbuild package with weird filenames])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild -bb --quiet /data/SPECS/weirdnames.spec
@@ -753,7 +753,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild package with illegal filenames])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 # XXX current output is not well suited for grab + compare, just ignore
 runroot rpmbuild -bb --quiet --with illegal /data/SPECS/weirdnames.spec
@@ -768,7 +768,7 @@ RPMTEST_CLEANUP
 # TODO: test that the rpms are actually created...
 RPMTEST_SETUP([rpmbuild -tb])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -781,7 +781,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild with deprecated patch])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bp --quiet /data/SPECS/hello-patch.spec
 ],
@@ -794,7 +794,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild scriptlet -f])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild \
@@ -862,7 +862,7 @@ RPMTEST_CLEANUP
 # %attr/%defattr tests
 RPMTEST_SETUP([rpmbuild %attr and %defattr])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot \
   --setenv SOURCE_DATE_EPOCH 1582222800 \
@@ -933,7 +933,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild SOURCE_DATE_EPOCH])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot \
   --setenv SOURCE_DATE_EPOCH 1699460418 \
@@ -954,7 +954,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild SOURCE_DATE_EPOCH=0])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot \
   --setenv SOURCE_DATE_EPOCH 0 \
@@ -975,7 +975,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild _buildtime macro])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot \
   rpmbuild \
@@ -996,9 +996,9 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild unpackaged files])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -bb --quiet --with unpackaged_files /data/SPECS/hlinktest.spec
@@ -1014,9 +1014,9 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild unpackaged directories])
 AT_KEYWORDS([build])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -bb --quiet --with unpackaged_dirs /data/SPECS/hlinktest.spec
@@ -1032,9 +1032,9 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild glob])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/globtest.spec
 runroot rpm -qp \
@@ -1069,7 +1069,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild glob escape])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
 runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
@@ -1135,7 +1135,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild bad escape])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/badescape.spec
 ],
@@ -1150,7 +1150,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild bad quote])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/badquote.spec
 ],
@@ -1165,7 +1165,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 	/data/SPECS/prefixtest.spec
@@ -1200,7 +1200,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([Weak and reverse requires])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 	--define "pkg weakdeps" \
@@ -1231,7 +1231,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([Build requires])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define "pkg buildreq" \
@@ -1247,7 +1247,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([Dependency generation 1])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define "_binary_payload w9.gzdio" \
@@ -1301,7 +1301,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([Dependency generation 2])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		/data/SPECS/shebang.spec
@@ -1316,7 +1316,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([Dependency generation 3])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cat << EOF > "${RPMTEST}"/tmp/bad.req
 #!/bin/sh
@@ -1337,7 +1337,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([Dependency generation 4])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '__script_requires() \
@@ -1366,7 +1366,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([Dependency generation 5])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '__script_mime text/plain' \
@@ -1384,7 +1384,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([Local dependency generator])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '_local_file_attrs my_test_attr' \
@@ -1400,7 +1400,7 @@ shebang = 0.1-1
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '_local_file_attrs script' \
@@ -1415,7 +1415,7 @@ shebang = 0.1-1
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '_local_file_attrs my_test_attr:script' \
@@ -1435,7 +1435,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([elf dependencies])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other chmod a-x /data/misc/libhello.so
@@ -1519,7 +1519,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild archive sanity])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -bb --quiet /data/SPECS/attrtest.spec
@@ -1538,7 +1538,7 @@ RPMTEST_SETUP([rpmbuild debuginfo minisymtab])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Use macros.debug to generate a debuginfo package.
 export CFLAGS="-g"
@@ -1576,7 +1576,7 @@ RPMTEST_SETUP([rpmbuild debuginfo minisymtab strip -g])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Use macros.debug to generate a debuginfo package.
 export CFLAGS="-g"
@@ -1616,7 +1616,7 @@ RPMTEST_SETUP([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -1703,7 +1703,7 @@ RPMTEST_SETUP([rpmbuild no debuginfo])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Use macros.debug to generate a debuginfo package,
 # but pass --nodebuginfo to skip it.
@@ -1737,7 +1737,7 @@ RPMTEST_SETUP([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -1824,7 +1824,7 @@ RPMTEST_SETUP([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build a package that has some debuginfo
 rundebug rpmbuild --quiet \
@@ -1856,7 +1856,7 @@ RPMTEST_SETUP([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build a package that has some debuginfo
 rundebug rpmbuild --quiet \
@@ -1883,7 +1883,7 @@ RPMTEST_SETUP([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build a package that has some debuginfo
 rundebug rpmbuild --quiet \
@@ -1909,7 +1909,7 @@ RPMTEST_SETUP([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build a package that has some debuginfo generated with -g3.
 # Specifically it uses -DDEBUG_DEFINE=1, which we want to see back
@@ -1941,7 +1941,7 @@ RPMTEST_SETUP([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build a package that has some debuginfo
 # Note that the spec defines hello2 as name, but the source is hello-1.0.
@@ -1978,7 +1978,7 @@ RPMTEST_SETUP([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build a package that has some debuginfo
 # Note that the spec defines hello2 as name, but the source is hello-1.0.
@@ -2012,7 +2012,7 @@ RPMTEST_SETUP([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_debugsource_packages 1" \
@@ -2044,7 +2044,7 @@ RPMTEST_SETUP([rpmbuild debugsource debugsourcefiles.list path])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_debugsource_packages 1" \
@@ -2069,7 +2069,7 @@ RPMTEST_SETUP([rpmbuild debuginfo subpackages single])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -2108,7 +2108,7 @@ RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -2189,7 +2189,7 @@ RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple unique])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -2270,7 +2270,7 @@ RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple unique debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -2354,7 +2354,7 @@ RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -2415,7 +2415,7 @@ RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -2478,7 +2478,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([manual debuginfo package])
 AT_KEYWORDS([build debuginfo])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 		--define "_prefix /usr/local" \
@@ -2525,7 +2525,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([manual %debug_package use])
 AT_KEYWORDS([build debuginfo])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bb \
 		/data/SPECS/manualdebug.spec
@@ -2538,7 +2538,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([explicit %_enable_debug_package on noarch])
 AT_KEYWORDS([build debuginfo])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 		--define "%_enable_debug_packages 1" \
@@ -2566,7 +2566,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([dynamic build requires rpmbuild -bs])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   --quiet -bs /data/SPECS/buildrequires.spec
@@ -2587,7 +2587,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild -br])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -br  --quiet /data/SPECS/buildrequires.spec
@@ -2622,7 +2622,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild -br success])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -br  /data/SPECS/mini.spec
@@ -2639,7 +2639,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild -bd with errors])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -bd  --quiet /data/SPECS/buildrequires.spec
@@ -2658,7 +2658,7 @@ RPMTEST_CLEANUP
 # Check if rpmbuild -bd *.spec doesn't build anything
 RPMTEST_SETUP([rpmbuild -bd *.spec])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -2676,7 +2676,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild -ba])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -ba  --quiet /data/SPECS/buildrequires.spec
@@ -2697,7 +2697,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild -br --nodeps])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -br  --quiet --nodeps /data/SPECS/buildrequires.spec
@@ -2719,7 +2719,7 @@ RPMTEST_CLEANUP
 # Check that rpmbuild aborts with missing Source
 RPMTEST_SETUP([rpmbuild -ba missing source])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK_UNQUOTED([
 runroot rpmbuild \
@@ -2749,7 +2749,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild minimal spec])
 AT_KEYWORDS([build])
 RPMTEST_CHECK_UNQUOTED([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild \
   -bb --quiet /data/SPECS/mini.spec
@@ -2762,7 +2762,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild missing files])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/filemiss.spec
 ],
@@ -2786,7 +2786,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild missing doc])
 AT_KEYWORDS([build])
 RPMTEST_CHECK_UNQUOTED([
-RPMDB_INIT
+RPMTEST_INIT
 
 for val in 1 0; do
     runroot rpmbuild \
@@ -2805,7 +2805,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([spec conditionals])
 AT_KEYWORDS([if else elif build])
-RPMDB_INIT
+RPMTEST_INIT
 
 # %if, %else, %elif test basic
 RPMTEST_CHECK([
@@ -2904,7 +2904,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([bcond macro])
 AT_KEYWORDS([bcond build])
-RPMDB_INIT
+RPMTEST_INIT
 
 # basic bcond behavior with --eval
 RPMTEST_CHECK([
@@ -2977,7 +2977,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([bcond_override_default macros])
 AT_KEYWORDS([bcond build])
-RPMDB_INIT
+RPMTEST_INIT
 
 # check bcond_override_default by defining
 RPMTEST_CHECK([
@@ -3073,7 +3073,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild spec tag])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_INIT
 runroot rpmbuild -bs --quiet /data/SPECS/foo.spec
 runroot rpm -qp --qf "%{spec}" /build/SRPMS/foo-1.0-1.src.rpm
@@ -3120,7 +3120,7 @@ RPMTEST_CLEANUP
 # Check %sources and %patches with weird file names
 RPMTEST_SETUP([%sources and %patches])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild \
@@ -3139,7 +3139,7 @@ RPMTEST_CLEANUP
 # Check if dynamic spec generation works
 RPMTEST_SETUP([rpmbuild with dynamic spec generation])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --define "_prefix /usr/local" -ba /data/SPECS/dynamic.spec
@@ -3167,7 +3167,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -ba /data/SPECS/dynamic.spec
@@ -3195,7 +3195,7 @@ RPMTEST_CLEANUP
 # Check for failure as feature is disabled. Remove tests when enabled
 RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -ba /data/SPECS/dynamic.spec
@@ -3209,7 +3209,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -bs /data/SPECS/dynamic.spec
@@ -3225,7 +3225,7 @@ RPMTEST_CLEANUP
 # Check failing dynamic spec generation
 RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "FAIL 1" -ba /data/SPECS/dynamic.spec
@@ -3242,7 +3242,7 @@ RPMTEST_CLEANUP
 # Check failing dynamic spec generation
 RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "DOUBLESUMMARY 1" -ba /data/SPECS/dynamic.spec
@@ -3258,7 +3258,7 @@ RPMTEST_CLEANUP
 # Check failing dynamic spec generation
 RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "WRONGTAG 1" -ba /data/SPECS/dynamic.spec
@@ -3275,7 +3275,7 @@ RPMTEST_CLEANUP
 # Check failing dynamic spec generation
 RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "FORBIDDENSECTION 1" -ba /data/SPECS/dynamic.spec
@@ -3292,7 +3292,7 @@ RPMTEST_CLEANUP
 # Check failing dynamic spec generation
 RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "FORBIDDENTAG 1" -ba /data/SPECS/dynamic.spec
@@ -3310,7 +3310,7 @@ RPMTEST_CLEANUP
 # Check source name with space
 RPMTEST_SETUP([rpmbuild source name with space])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild -bp --quiet /data/SPECS/source_space.spec
@@ -3322,7 +3322,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild bad filetrigger condition])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 rpmspec --parse /data/SPECS/badftrigger.spec
@@ -3350,7 +3350,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild interactive])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild --quiet -bb /data/SPECS/interact.spec
@@ -3369,7 +3369,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild bpf file])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild --quiet -bb /data/SPECS/bpf.spec
@@ -3383,7 +3383,7 @@ RPMTEST_CLEANUP
 # kinda meaningless until #3005 is done, but works as a manual reproducer.
 RPMTEST_SETUP([rpmbuild non-removable file in builddir])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 # -bi doesn't run cleanup, test that we manage that situation too
 RPMTEST_CHECK([
@@ -3398,7 +3398,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild %caps])
 AT_KEYWORDS([build])
 AT_SKIP_IF([$CAP_DISABLED])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild --quiet -bb /data/SPECS/caps.spec
@@ -3450,7 +3450,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild -bs with source macro])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild --quiet -bs /data/SPECS/macrosource.spec
@@ -3481,7 +3481,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild target macro sanity])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 
 # This is surprisingly tricky - we need to place these macros in a place
 # that is after the platform stuff in macro path so we can't just drop
@@ -3533,7 +3533,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild install_pre override])
 AT_KEYWORDS([build])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bb /data/SPECS/install-hack.spec
 ],
@@ -3547,7 +3547,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmbuild --buildroot])
 AT_KEYWORDS([build])
 
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot_other mkdir -p /tmp/buildroot/out
 runroot_other touch /tmp/buildroot/out/sider
@@ -3571,7 +3571,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([builddir])
 AT_KEYWORDS([build builddir])
 
-RPMDB_INIT
+RPMTEST_INIT
 # Trick for compatibly getting the builddir out of old and new rpm
 RPMTEST_CHECK([
 runroot rpmbuild \
@@ -3596,7 +3596,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([file digests])
 AT_KEYWORDS([build digest])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([[
 runroot rpmbuild -bs --quiet /data/SPECS/hello.spec
 runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.src.rpm
@@ -3653,7 +3653,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([file digests sha3])
 AT_KEYWORDS([build digest])
 AT_SKIP_IF([test x$PGP = xsequoia])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([[
 runroot rpmbuild -bs --quiet \
 		--define "_source_filedigest_algorithm 12" \

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3074,7 +3074,7 @@ AT_SETUP([rpmbuild spec tag])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 RPMDB_INIT
-RPMTEST_SETUP
+RPMTEST_INIT
 runroot rpmbuild -bs --quiet /data/SPECS/foo.spec
 runroot rpm -qp --qf "%{spec}" /build/SRPMS/foo-1.0-1.src.rpm
 ],

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -24,7 +24,7 @@ RPMTEST_SETUP([rpmbuild buildid none])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -55,7 +55,7 @@ RPMTEST_SETUP([rpmbuild buildid alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -144,7 +144,7 @@ RPMTEST_SETUP([rpmbuild buildid alldebug unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -232,7 +232,7 @@ RPMTEST_SETUP([rpmbuild buildid separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -320,7 +320,7 @@ RPMTEST_SETUP([rpmbuild buildid separate unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -407,7 +407,7 @@ RPMTEST_SETUP([rpmbuild buildid compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -508,7 +508,7 @@ RPMTEST_SETUP([rpmbuild buildid compat unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -609,7 +609,7 @@ RPMTEST_SETUP([rpmbuild buildid duplicate alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links alldebug" \
@@ -674,7 +674,7 @@ RPMTEST_SETUP([rpmbuild buildid hardlink alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links alldebug" \
@@ -736,7 +736,7 @@ RPMTEST_SETUP([rpmbuild buildid duplicate separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links separate" \
@@ -798,7 +798,7 @@ RPMTEST_SETUP([rpmbuild buildid hardlink separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links separate" \
@@ -857,7 +857,7 @@ RPMTEST_SETUP([rpmbuild buildid duplicate compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links compat" \
@@ -931,7 +931,7 @@ RPMTEST_SETUP([rpmbuild buildid hardlink compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links compat" \
@@ -1001,7 +1001,7 @@ RPMTEST_SETUP([rpmbuild buildid recompute])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # Make sure we get debuginfo
 export CFLAGS="-g"
 
@@ -1112,7 +1112,7 @@ RPMTEST_SETUP([rpmbuild buildid unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_unique_build_ids 1" \
@@ -1157,7 +1157,7 @@ RPMTEST_SETUP([rpmbuild buildid non-unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --undefine="_unique_build_ids" \
@@ -1206,7 +1206,7 @@ RPMTEST_SETUP([rpmbuild buildid attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -1237,7 +1237,7 @@ RPMTEST_SETUP([rpmbuild buildid config attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -20,7 +20,7 @@ AT_BANNER([RPM buildid tests])
 
 # ------------------------------
 # Check if rpmbuild "none" doesn't generates buildid symlinks for hello program
-AT_SETUP([rpmbuild buildid none])
+RPMTEST_SETUP([rpmbuild buildid none])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -51,7 +51,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "alldebug" generates debuginfo buildid symlinks.
 # Without unique debug file names.
-AT_SETUP([rpmbuild buildid alldebug])
+RPMTEST_SETUP([rpmbuild buildid alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -140,7 +140,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "alldebug" generates debuginfo buildid symlinks.
 # With unique debug file names.
-AT_SETUP([rpmbuild buildid alldebug unique debug names])
+RPMTEST_SETUP([rpmbuild buildid alldebug unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -228,7 +228,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "separate" generates main and debuginfo buildid symlinks
 # Without unique debug file names
-AT_SETUP([rpmbuild buildid separate])
+RPMTEST_SETUP([rpmbuild buildid separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -316,7 +316,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "separate" generates main and debuginfo buildid symlinks
 # With unique debug file names
-AT_SETUP([rpmbuild buildid separate unique debug names])
+RPMTEST_SETUP([rpmbuild buildid separate unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -403,7 +403,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "compat" generates main and debuginfo buildid symlinks
 # Without unique debug file names
-AT_SETUP([rpmbuild buildid compat])
+RPMTEST_SETUP([rpmbuild buildid compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -504,7 +504,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "compat" generates main and debuginfo buildid symlinks
 # With unique debug file names
-AT_SETUP([rpmbuild buildid compat unique debug names])
+RPMTEST_SETUP([rpmbuild buildid compat unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -605,7 +605,7 @@ RPMTEST_CLEANUP
 # Check that (copied) files with duplicate build-ids are handled correctly.
 # This should create "numbered" build-id files.
 # This is simply the hello example with one binary copied.
-AT_SETUP([rpmbuild buildid duplicate alldebug])
+RPMTEST_SETUP([rpmbuild buildid duplicate alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -670,7 +670,7 @@ RPMTEST_CLEANUP
 # Since the hard linked files have duplicate build-ids,
 # it should create "numbered" build-id files.
 # This is simply the hello example with one binary hard linked.
-AT_SETUP([rpmbuild buildid hardlink alldebug])
+RPMTEST_SETUP([rpmbuild buildid hardlink alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -732,7 +732,7 @@ RPMTEST_CLEANUP
 # Check that (copied) files with duplicate build-ids are handled correctly.
 # This should create "numbered" build-id files.
 # This is simply the hello example with one binary copied.
-AT_SETUP([rpmbuild buildid duplicate separate])
+RPMTEST_SETUP([rpmbuild buildid duplicate separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -794,7 +794,7 @@ RPMTEST_CLEANUP
 # Since the hard linked files have duplicate build-ids,
 # it should create "numbered" build-id files.
 # This is simply the hello example with one binary hard linked.
-AT_SETUP([rpmbuild buildid hardlink separate])
+RPMTEST_SETUP([rpmbuild buildid hardlink separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -853,7 +853,7 @@ RPMTEST_CLEANUP
 # Check that (copied) files with duplicate build-ids are handled correctly.
 # This should create "numbered" build-id files.
 # This is simply the hello example with one binary copied.
-AT_SETUP([rpmbuild buildid duplicate compat])
+RPMTEST_SETUP([rpmbuild buildid duplicate compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -927,7 +927,7 @@ RPMTEST_CLEANUP
 # Since the hard linked files have duplicate build-ids,
 # it should create "numbered" build-id files.
 # This is simply the hello example with one binary hard linked.
-AT_SETUP([rpmbuild buildid hardlink compat])
+RPMTEST_SETUP([rpmbuild buildid hardlink compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -997,7 +997,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check build-ids are recomputed with unique_build_ids,
 # but not with _no_recompute_build_ids
-AT_SETUP([rpmbuild buildid recompute])
+RPMTEST_SETUP([rpmbuild buildid recompute])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1108,7 +1108,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check build-ids are unique between versions/releases
 # with _unique_build_ids defined.
-AT_SETUP([rpmbuild buildid unique r1 r2])
+RPMTEST_SETUP([rpmbuild buildid unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1153,7 +1153,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check build-ids are non-unique between versions/releases
 # with _unique_build_ids undefined (and exact same sources).
-AT_SETUP([rpmbuild buildid non-unique r1 r2])
+RPMTEST_SETUP([rpmbuild buildid non-unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1202,7 +1202,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that build-id directories are created with the right permissions
 # even if the spec file sets attrs explicitly.
-AT_SETUP([rpmbuild buildid attrs])
+RPMTEST_SETUP([rpmbuild buildid attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
@@ -1233,7 +1233,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that build-id directories are created with the right attributes
 # even if the spec file sets config explicitly.
-AT_SETUP([rpmbuild buildid config attrs])
+RPMTEST_SETUP([rpmbuild buildid config attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([

--- a/tests/rpmconfig.at
+++ b/tests/rpmconfig.at
@@ -4,7 +4,7 @@ AT_BANNER([RPM config file behavior])
 
 RPMTEST_SETUP([config file install/upgrade/erase])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -14,7 +14,7 @@ done
 
 # Install over existing config file
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -33,7 +33,7 @@ otherstuff
 
 # Install over existing identical config file, no backup needed
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -50,7 +50,7 @@ test ! -f "${cf}"
 
 # Erase unmodified config file, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -66,7 +66,7 @@ test ! -f "${cf}"
 
 # Erase modified config file
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -86,7 +86,7 @@ otherstuff
 
 # Upgrade package with config file, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -103,7 +103,7 @@ foo
 
 # Upgrade package with config file, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -118,7 +118,7 @@ grep -c  "touch" output.txt
 
 # Upgrade package with locally modified config file, unchanged in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -140,7 +140,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([config(noreplace) file install/upgrade/erase])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -150,7 +150,7 @@ runroot rpmbuild --quiet -bb \
 
 # Install over existing config file
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 echo "otherstuff" > "${cf}"
@@ -173,7 +173,7 @@ warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
 
 # Erase modified config(noreplace) file
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -195,7 +195,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade changing config])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -206,7 +206,7 @@ done
 
 # Upgrade package with unmodified config file, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -223,9 +223,8 @@ foo-2.0
 
 # ------------------------------
 # Upgrade package with locally modified config file, changed in pkg
-AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -249,7 +248,7 @@ otherstuff
 # ------------------------------
 # Modified config file matches the content from new package.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -272,7 +271,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -284,7 +283,7 @@ done
 #
 # Upgrade package with config file, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -301,7 +300,7 @@ foo
 
 # Upgrade package with locally modified config file, unchanged in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -324,7 +323,7 @@ RPMTEST_CLEANUP
 # noreplace variants of the same
 RPMTEST_SETUP([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -335,7 +334,7 @@ done
 
 # Upgrade package with unmodified config file, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -352,7 +351,7 @@ foo-2.0
 
 # Upgrade package with locally modified config file, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -375,7 +374,7 @@ foo-2.0
 
 # Modified config file matches the content from new package.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -398,7 +397,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade shared config])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
@@ -411,7 +410,7 @@ done
 
 # Upgrade package with config file, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -432,7 +431,7 @@ foo
 
 # Upgrade package with locally modified config file, unchanged in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -458,7 +457,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade changing shared config])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
@@ -471,7 +470,7 @@ done
 
 # Upgrade package with unmodified config file, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -492,7 +491,7 @@ foo-2.0
 
 # Upgrade package with locally modified config file, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -519,7 +518,7 @@ otherstuff
 
 # Modified config file matches the content from new package.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -547,7 +546,7 @@ RPMTEST_CLEANUP
 # Upgrade package with locally modified config file, changed in pkg.
 RPMTEST_SETUP([upgrade shared config(noreplace)])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -561,7 +560,7 @@ for s in "A" "B"; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -589,7 +588,7 @@ foo-2.0
 # ------------------------------
 # Modified config file matches the content from new package.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -617,7 +616,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([ghost config])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 

--- a/tests/rpmconfig.at
+++ b/tests/rpmconfig.at
@@ -2,7 +2,7 @@
 
 AT_BANNER([RPM config file behavior])
 
-AT_SETUP([config file install/upgrade/erase])
+RPMTEST_SETUP([config file install/upgrade/erase])
 AT_KEYWORDS([install])
 RPMDB_INIT
 for v in "1.0" "2.0"; do
@@ -138,7 +138,7 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([config(noreplace) file install/upgrade/erase])
+RPMTEST_SETUP([config(noreplace) file install/upgrade/erase])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -193,7 +193,7 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([upgrade changing config])
+RPMTEST_SETUP([upgrade changing config])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -270,7 +270,7 @@ RPMTEST_CLEANUP
 
 # config(noreplace) variants of the same cases.
 # ------------------------------
-AT_SETUP([upgrade changing config(noreplace)])
+RPMTEST_SETUP([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -322,7 +322,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # noreplace variants of the same
-AT_SETUP([upgrade changing config(noreplace)])
+RPMTEST_SETUP([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
 RPMDB_INIT
 for v in "1.0" "2.0"; do
@@ -396,7 +396,7 @@ RPMTEST_CLEANUP
 
 # Shared config file variants of the same cases
 # ------------------------------
-AT_SETUP([upgrade shared config])
+RPMTEST_SETUP([upgrade shared config])
 AT_KEYWORDS([install])
 RPMDB_INIT
 for s in "A" "B"; do
@@ -456,7 +456,7 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([upgrade changing shared config])
+RPMTEST_SETUP([upgrade changing shared config])
 AT_KEYWORDS([install])
 RPMDB_INIT
 for s in "A" "B"; do
@@ -545,7 +545,7 @@ RPMTEST_CLEANUP
 # Shared config(noreplace) variants of the more interesting cases
 # ------------------------------
 # Upgrade package with locally modified config file, changed in pkg.
-AT_SETUP([upgrade shared config(noreplace)])
+RPMTEST_SETUP([upgrade shared config(noreplace)])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -614,7 +614,7 @@ RPMTEST_CLEANUP
 
 ---------
 # Test pre-existing and post-install config ghost survival and erasure
-AT_SETUP([ghost config])
+RPMTEST_SETUP([ghost config])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmconfig2.at
+++ b/tests/rpmconfig2.at
@@ -4,7 +4,7 @@ AT_BANNER([RPM config symlink behavior])
 
 RPMTEST_SETUP([config symlinks])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -16,7 +16,7 @@ done
 
 # Install over existing config file
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -35,7 +35,7 @@ otherstuff
 
 # Install over existing identical config link, no backup needed
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -54,7 +54,7 @@ foo
 
 # Erase unmodified config link, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -70,7 +70,7 @@ test ! -L "${cf}"
 
 # Erase modified config link
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -89,7 +89,7 @@ otherstuff
 
 # Upgrade package with config link, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -107,7 +107,7 @@ foo
 #
 # Upgrade package with config link, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -122,7 +122,7 @@ grep -c  "touch" output.txt
 
 # Upgrade package with modified config link, unchanged in pkg. No backup.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -144,7 +144,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([changing config symlinks])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -155,7 +155,7 @@ done
 
 # Upgrade package with unmodified config link, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -172,7 +172,7 @@ foo-2.0
 
 # Upgrade package with locally modified config link, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -195,7 +195,7 @@ otherstuff
 
 # Modified config link matches the content from new package.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -219,7 +219,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade unchanged config(noreplace) links])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -231,7 +231,7 @@ done
 
 # Upgrade package with config file, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -248,7 +248,7 @@ foo
 
 # Upgrade package with locally modified config file, unchanged in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -270,7 +270,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade changing config(noreplace) links])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -282,7 +282,7 @@ for v in "1.0" "2.0"; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -300,7 +300,7 @@ foo-2.0
 
 # Upgrade package with locally modified config file, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -323,7 +323,7 @@ foo-2.0
 
 # Modified config link matches the content from new package.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -347,7 +347,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade unchanged shared config links])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -362,7 +362,7 @@ done
 
 # Upgrade package with config file, no backup here
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -383,7 +383,7 @@ foo
 
 # Upgrade package with locally modified config file, unchanged in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -409,7 +409,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade changing shared config links])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -424,7 +424,7 @@ done
 
 # Upgrade package with unmodified config file, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -445,7 +445,7 @@ foo-2.0
 
 # Upgrade package with locally modified config file, changed in pkg
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -472,7 +472,7 @@ otherstuff
 
 # Modified config link matches the content from new package.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -499,7 +499,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([upgrade changing shared config(noreplace) links])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -515,7 +515,7 @@ done
 
 # Upgrade package with locally modified config file, changed in pkg.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -542,7 +542,7 @@ foo-2.0
 
 # Modified config link matches the content from new package.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 

--- a/tests/rpmconfig2.at
+++ b/tests/rpmconfig2.at
@@ -2,7 +2,7 @@
 
 AT_BANNER([RPM config symlink behavior])
 
-AT_SETUP([config symlinks])
+RPMTEST_SETUP([config symlinks])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -142,7 +142,7 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([changing config symlinks])
+RPMTEST_SETUP([changing config symlinks])
 AT_KEYWORDS([install])
 RPMDB_INIT
 for v in "1.0" "2.0"; do
@@ -217,7 +217,7 @@ RPMTEST_CLEANUP
 # config(noreplace) variants of the same cases.
 #
 # ------------------------------
-AT_SETUP([upgrade unchanged config(noreplace) links])
+RPMTEST_SETUP([upgrade unchanged config(noreplace) links])
 AT_KEYWORDS([install])
 RPMDB_INIT
 for v in "1.0" "2.0"; do
@@ -268,7 +268,7 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([upgrade changing config(noreplace) links])
+RPMTEST_SETUP([upgrade changing config(noreplace) links])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -345,7 +345,7 @@ RPMTEST_CLEANUP
 
 # Shared config link variants of the same cases
 # ------------------------------
-AT_SETUP([upgrade unchanged shared config links])
+RPMTEST_SETUP([upgrade unchanged shared config links])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -407,7 +407,7 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([upgrade changing shared config links])
+RPMTEST_SETUP([upgrade changing shared config links])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -497,7 +497,7 @@ RPMTEST_CLEANUP
 
 # Shared config(noreplace) variants of the more interesting cases
 # ------------------------------
-AT_SETUP([upgrade changing shared config(noreplace) links])
+RPMTEST_SETUP([upgrade changing shared config(noreplace) links])
 AT_KEYWORDS([install])
 RPMDB_INIT
 

--- a/tests/rpmconfig3.at
+++ b/tests/rpmconfig3.at
@@ -2,7 +2,7 @@
 
 AT_BANNER([RPM config filetype changes])
 
-AT_SETUP([upgrade config to/from non-config])
+RPMTEST_SETUP([upgrade config to/from non-config])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -89,7 +89,7 @@ foo
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade config to/from config link])
+RPMTEST_SETUP([upgrade config to/from config link])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -150,7 +150,7 @@ otherstuff
 RPMTEST_CLEANUP
 
 # Modified config link changes to config file
-AT_SETUP([upgrade modified config link to config])
+RPMTEST_SETUP([upgrade modified config link to config])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -187,7 +187,7 @@ otherstuff
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade config to directory])
+RPMTEST_SETUP([upgrade config to directory])
 AT_KEYWORDS([install])
 RPMDB_INIT
 

--- a/tests/rpmconfig3.at
+++ b/tests/rpmconfig3.at
@@ -4,7 +4,7 @@ AT_BANNER([RPM config filetype changes])
 
 RPMTEST_SETUP([upgrade config to/from non-config])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -21,7 +21,7 @@ runroot rpmbuild --quiet -bb \
 
 # non-modified config changes to non-config and back, no backups
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
 
@@ -41,7 +41,7 @@ foo
 
 # modified config changes to non-config and back, back up on first upgrade
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -67,7 +67,7 @@ foo
 
 # modified config changes to identical non-config and back, no backups
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -91,7 +91,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([upgrade config to/from config link])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -107,7 +107,7 @@ runroot rpmbuild --quiet -bb \
 
 # non-modified config file changes to config symlink and back, no backups
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
 
@@ -127,7 +127,7 @@ foo
 
 # Modified config changes to config symlink
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
 
@@ -153,7 +153,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade modified config link to config])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
 
@@ -189,7 +189,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([upgrade config to directory])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -204,7 +204,7 @@ runroot rpmbuild --quiet -bb \
 
 # Non-modified config file changes to directory.
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 
@@ -220,7 +220,7 @@ test -d "${cf}"
 
 # Modified config changes to directory
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 

--- a/tests/rpmconflict.at
+++ b/tests/rpmconflict.at
@@ -3,7 +3,7 @@
 AT_BANNER([RPM implicit file conflicts])
 
 # ------------------------------
-AT_SETUP([packages with file conflicts])
+RPMTEST_SETUP([packages with file conflicts])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -38,7 +38,7 @@ runroot rpm -U \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([shareable files])
+RPMTEST_SETUP([shareable files])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -74,7 +74,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # (Build and) install package with identical basename in different directories
-AT_SETUP([non-conflicting identical basenames])
+RPMTEST_SETUP([non-conflicting identical basenames])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -90,7 +90,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # (Build and) install package with a self-conflict due to directory symlinks
-AT_SETUP([conflicting identical basenames])
+RPMTEST_SETUP([conflicting identical basenames])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -108,7 +108,7 @@ runroot rpm -U /build/RPMS/noarch/selfconflict-1.0-1.noarch.rpm
 RPMTEST_CLEANUP
 # ------------------------------
 # File conflict between colored files, prefer 64bit
-AT_SETUP([multilib elf conflict, prefer 64bit 1])
+RPMTEST_SETUP([multilib elf conflict, prefer 64bit 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -129,7 +129,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 64bit
-AT_SETUP([multilib elf conflict, prefer 64bit 2])
+RPMTEST_SETUP([multilib elf conflict, prefer 64bit 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -155,7 +155,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 64bit
-AT_SETUP([multilib elf conflict, prefer 64bit 3])
+RPMTEST_SETUP([multilib elf conflict, prefer 64bit 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -181,7 +181,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 32bit
-AT_SETUP([multilib elf conflict, prefer 32bit 1])
+RPMTEST_SETUP([multilib elf conflict, prefer 32bit 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -202,7 +202,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 32bit
-AT_SETUP([multilib elf conflict, prefer 32bit 2])
+RPMTEST_SETUP([multilib elf conflict, prefer 32bit 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -228,7 +228,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 32bit
-AT_SETUP([multilib elf conflict, prefer 32bit 3])
+RPMTEST_SETUP([multilib elf conflict, prefer 32bit 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -254,7 +254,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored and non-colored file 1
-AT_SETUP([multilib elf vs non-elf file conflict 1])
+RPMTEST_SETUP([multilib elf vs non-elf file conflict 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -274,7 +274,7 @@ runroot rpm -U --ignoreos --ignorearch --nodeps \
 RPMTEST_CLEANUP
 
 # File conflict between colored and non-colored file 2
-AT_SETUP([multilib elf vs non-elf file conflict 2])
+RPMTEST_SETUP([multilib elf vs non-elf file conflict 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -298,7 +298,7 @@ runroot rpm -U --ignoreos --ignorearch --nodeps \
 RPMTEST_CLEANUP
 
 # File conflict between colored and non-colored file 3
-AT_SETUP([multilib elf vs non-elf file conflict 3])
+RPMTEST_SETUP([multilib elf vs non-elf file conflict 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -323,7 +323,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Removal conflict on directory -> symlink change
-AT_SETUP([replacing directory with symlink])
+RPMTEST_SETUP([replacing directory with symlink])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -345,7 +345,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Replace symlink with a directory
-AT_SETUP([replacing symlink with directory])
+RPMTEST_SETUP([replacing symlink with directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -368,7 +368,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Regular file shared with a ghost, does not conflict
 # Regular file should be created and not removed when the ghost is removed
-AT_SETUP([real file with shared ghost])
+RPMTEST_SETUP([real file with shared ghost])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmconflict.at
+++ b/tests/rpmconflict.at
@@ -5,7 +5,7 @@ AT_BANNER([RPM implicit file conflicts])
 # ------------------------------
 RPMTEST_SETUP([packages with file conflicts])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for p in "one" "two"; do
     runroot rpmbuild --quiet -bb \
@@ -15,7 +15,7 @@ for p in "one" "two"; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 # (Build and) install conflicting package (should fail)
 runroot rpm -U /build/RPMS/noarch/conflictone-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/conflicttwo-1.0-1.noarch.rpm
@@ -26,7 +26,7 @@ runroot rpm -U /build/RPMS/noarch/conflicttwo-1.0-1.noarch.rpm
 
 # Install conflicting packages in same transaction (should fail)
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U \
   /build/RPMS/noarch/conflictone-1.0-1.noarch.rpm \
@@ -40,7 +40,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([shareable files])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for p in "one" "two"; do
     runroot rpmbuild --quiet -bb \
@@ -51,7 +51,7 @@ done
 
 # (Build and) install package with shareable file
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/conflictone-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/conflicttwo-1.0-1.noarch.rpm
 ],
@@ -61,7 +61,7 @@ runroot rpm -U /build/RPMS/noarch/conflicttwo-1.0-1.noarch.rpm
 
 # Install packages with shareable file in same transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U \
   /build/RPMS/noarch/conflictone-1.0-1.noarch.rpm \
@@ -77,7 +77,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([non-conflicting identical basenames])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/selfconflict.spec
 rm -rf "${RPMTEST}"/opt/mydir
@@ -93,7 +93,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([conflicting identical basenames])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/selfconflict.spec
 rm -rf "${RPMTEST}"/opt/mydir
@@ -111,7 +111,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf conflict, prefer 64bit 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -132,7 +132,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf conflict, prefer 64bit 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -158,7 +158,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf conflict, prefer 64bit 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -184,7 +184,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf conflict, prefer 32bit 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -205,7 +205,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf conflict, prefer 32bit 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -231,7 +231,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf conflict, prefer 32bit 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -257,7 +257,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf vs non-elf file conflict 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -277,7 +277,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf vs non-elf file conflict 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -301,7 +301,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([multilib elf vs non-elf file conflict 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -326,7 +326,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([replacing directory with symlink])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest*
 
 runroot rpmbuild --quiet -bb \
@@ -348,7 +348,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([replacing symlink with directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest*
 
 runroot rpmbuild --quiet -bb \
@@ -371,7 +371,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([real file with shared ghost])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 fn="${RPMTEST}"/usr/share/my.version
 
 runroot rpmbuild --quiet -bb \

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -20,7 +20,7 @@ AT_BANNER([RPM database access])
 
 # ------------------------------
 # Attempt to initialize a rpmdb
-AT_SETUP([rpm --initdb])
+RPMTEST_SETUP([rpm --initdb])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -32,7 +32,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Run rpm -qa on an empty rpmdb
-AT_SETUP([rpm -qa 1])
+RPMTEST_SETUP([rpm -qa 1])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -43,7 +43,7 @@ runroot rpm \
 RPMTEST_CLEANUP
 
 # Run rpm -qa on a non-existent rpmdb
-AT_SETUP([rpm -qa 2])
+RPMTEST_SETUP([rpm -qa 2])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
 RPMTEST_INIT
@@ -56,7 +56,7 @@ runroot rpm \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -qa 3])
+RPMTEST_SETUP([rpm -qa 3])
 AT_KEYWORDS([rpmdb query])
 RPMDB_INIT
 
@@ -79,7 +79,7 @@ hello-2.0-1.x86_64
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmdb --export and --import])
+RPMTEST_SETUP([rpmdb --export and --import])
 AT_KEYWORDS([rpmdb])
 
 # This needs to run *without* RPMDB_INIT to test behavior on read-only mount
@@ -128,7 +128,7 @@ runroot rpm -qa --dbpath ${PWD}
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -qa and rpmkeys])
+RPMTEST_SETUP([rpm -qa and rpmkeys])
 AT_KEYWORDS([rpmdb query])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -357,7 +357,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Run rpm -q <package> where <package> exists in the db.
-AT_SETUP([rpm -q foo])
+RPMTEST_SETUP([rpm -q foo])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -376,7 +376,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Run rpm -q <package>- where <package> exists in the db.
-AT_SETUP([rpm -q foo-])
+RPMTEST_SETUP([rpm -q foo-])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -393,7 +393,7 @@ runroot rpm -q foo-
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmdb header numbering])
+RPMTEST_SETUP([rpmdb header numbering])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -413,7 +413,7 @@ done
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -q --querybynumber])
+RPMTEST_SETUP([rpm -q --querybynumber])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -446,7 +446,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # install a noarch package into a local rpmdb without --relocate and --nodeps
 # * Should always succeed
-AT_SETUP([rpm -i *.noarch.rpm])
+RPMTEST_SETUP([rpm -i *.noarch.rpm])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
@@ -461,7 +461,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # reinstall a noarch package (with no files)
-AT_SETUP([rpm -U --replacepkgs 1])
+RPMTEST_SETUP([rpm -U --replacepkgs 1])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
@@ -482,7 +482,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # reinstall a package with different file policies
-AT_SETUP([rpm -U --replacepkgs 2])
+RPMTEST_SETUP([rpm -U --replacepkgs 2])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
@@ -502,7 +502,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # reinstall a package with different file policies
-AT_SETUP([rpm --reinstall 1])
+RPMTEST_SETUP([rpm --reinstall 1])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
@@ -524,7 +524,7 @@ RPMTEST_CLEANUP
 # install a package into a local rpmdb
 # * Shall only work with if one is relocated
 # * Use --ignorearch because we don't know the arch
-AT_SETUP([rpm -i --relocate=.. *.i386.rpm])
+RPMTEST_SETUP([rpm -i --relocate=.. *.i386.rpm])
 AT_KEYWORDS([rpmdb install])
 RPMDB_INIT
 
@@ -565,7 +565,7 @@ runroot rpm -ql hello.i386 hello.ppc64
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmdb --rebuilddb])
+RPMTEST_SETUP([rpmdb --rebuilddb])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -589,7 +589,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Attempt to initialize, rebuild and verify a db
-AT_SETUP([rpmdb --rebuilddb and verify empty database])
+RPMTEST_SETUP([rpmdb --rebuilddb and verify empty database])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -603,7 +603,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Install and verify status
-AT_SETUP([rpm -U and verify status])
+RPMTEST_SETUP([rpm -U and verify status])
 AT_KEYWORDS([install rpmdb query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -624,7 +624,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Install and verify status
-AT_SETUP([rpm -U with _install_lang and verify status])
+RPMTEST_SETUP([rpm -U with _install_lang and verify status])
 AT_KEYWORDS([install rpmdb query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -647,7 +647,7 @@ not installed /usr/share/flangtest/pl.txt
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpmdb query special chars])
+RPMTEST_SETUP([rpmdb query special chars])
 AT_KEYWORDS([install rpmdb query])
 RPMDB_INIT
 for v in "1.0+2" "1.0^2" "1.0~2"; do
@@ -689,7 +689,7 @@ runroot rpm -q 'versiontest-1.0~2-1'
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpmdb vacuum])
+RPMTEST_SETUP([rpmdb vacuum])
 AT_KEYWORDS([install rpmdb sqlite])
 RPMDB_INIT
 RPMTEST_CHECK([

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -46,7 +46,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpm -qa 2])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMTEST_SETUP
+RPMTEST_INIT
 rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`
 runroot rpm \
   -qa

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -23,7 +23,7 @@ AT_BANNER([RPM database access])
 RPMTEST_SETUP([rpm --initdb])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 ],
 [0],
 [ignore],
@@ -35,7 +35,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qa 1])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   -qa
 ],
@@ -58,7 +58,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -qa 3])
 AT_KEYWORDS([rpmdb query])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpm -U --nodeps --ignorearch --ignoreos --nosignature \
@@ -82,7 +82,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmdb --export and --import])
 AT_KEYWORDS([rpmdb])
 
-# This needs to run *without* RPMDB_INIT to test behavior on read-only mount
+# This needs to run *without* RPMTEST_INIT to test behavior on read-only mount
 RPMTEST_CHECK([
 # XXX FIXME: should not use system rpmdb for anything, but there's a
 # mystery failure here if pointed to /data/misc which should be equally
@@ -95,7 +95,7 @@ test -s rdonly.list
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -U /data/RPMS/hlinktest-1.0-1.noarch.rpm
 ],
 [0],
@@ -131,7 +131,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qa and rpmkeys])
 AT_KEYWORDS([rpmdb query])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 
 echo "%_keyring rpmdb" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 
@@ -360,7 +360,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -q foo])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -i \
   /data/RPMS/foo-1.0-1.noarch.rpm
@@ -379,7 +379,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -q foo-])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -i \
   /data/RPMS/foo-1.0-1.noarch.rpm
@@ -396,7 +396,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmdb header numbering])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 for i in 1 2 3; do
     runroot rpm -i /data/RPMS/foo-1.0-1.noarch.rpm
@@ -416,7 +416,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -q --querybynumber])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -i \
   /data/RPMS/foo-1.0-1.noarch.rpm
@@ -450,7 +450,7 @@ RPMTEST_SETUP([rpm -i *.noarch.rpm])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -i \
   /data/RPMS/foo-1.0-1.noarch.rpm
@@ -465,7 +465,7 @@ RPMTEST_SETUP([rpm -U --replacepkgs 1])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 tpkg="/data/RPMS/foo-1.0-1.noarch.rpm"
 
@@ -486,7 +486,7 @@ RPMTEST_SETUP([rpm -U --replacepkgs 2])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 tpkg="/data/RPMS/hello-2.0-1.i686.rpm"
 
@@ -506,7 +506,7 @@ RPMTEST_SETUP([rpm --reinstall 1])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 tpkg="/data/RPMS/hello-2.0-1.i686.rpm"
 
@@ -526,7 +526,7 @@ RPMTEST_CLEANUP
 # * Use --ignorearch because we don't know the arch
 RPMTEST_SETUP([rpm -i --relocate=.. *.i386.rpm])
 AT_KEYWORDS([rpmdb install])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpm -i \
@@ -568,7 +568,8 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmdb --rebuilddb])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
+RPMDB_RESET
 
 runroot rpm -U --noscripts --nodeps --ignorearch --noverify \
   /data/RPMS/hello-1.0-1.i386.rpm
@@ -592,7 +593,8 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmdb --rebuilddb and verify empty database])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
+RPMDB_RESET
 runroot rpmdb --rebuilddb
 runroot rpmdb --verifydb
 ],
@@ -606,7 +608,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U and verify status])
 AT_KEYWORDS([install rpmdb query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "pkg status" \
@@ -627,7 +629,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U with _install_lang and verify status])
 AT_KEYWORDS([install rpmdb query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
           /data/SPECS/flangtest.spec
@@ -649,7 +651,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([rpmdb query special chars])
 AT_KEYWORDS([install rpmdb query])
-RPMDB_INIT
+RPMTEST_INIT
 for v in "1.0+2" "1.0^2" "1.0~2"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -657,7 +659,7 @@ for v in "1.0+2" "1.0^2" "1.0~2"; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U '/build/RPMS/noarch/versiontest-1.0+2-1.noarch.rpm'
 runroot rpm -q 'versiontest-1.0+2-1'
 ],
@@ -667,7 +669,7 @@ runroot rpm -q 'versiontest-1.0+2-1'
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U '/build/RPMS/noarch/versiontest-1.0^2-1.noarch.rpm'
 runroot rpm -q 'versiontest-1.0^2-1'
 ],
@@ -677,7 +679,7 @@ runroot rpm -q 'versiontest-1.0^2-1'
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U '/build/RPMS/noarch/versiontest-1.0~2-1.noarch.rpm'
 runroot rpm -q 'versiontest-1.0~2-1'
 ],
@@ -691,7 +693,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([rpmdb vacuum])
 AT_KEYWORDS([install rpmdb sqlite])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -U --noscripts --nodeps --ignorearch --noverify \
   /data/RPMS/hello-1.0-1.i386.rpm

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -5,7 +5,7 @@ AT_BANNER([RPM dependencies])
 # ------------------------------
 RPMTEST_SETUP([unversioned requires])
 AT_KEYWORDS([install depends])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -19,7 +19,7 @@ runroot rpmbuild --quiet -bb \
 
 # missing dependency
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
@@ -31,7 +31,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 
 # cross-depending packages
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -45,7 +45,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([unsatisfied versioned require])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -79,7 +79,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([satisfied versioned require])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -102,7 +102,7 @@ RPMTEST_CLEANUP
 # 
 RPMTEST_SETUP([versioned conflicts])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -115,7 +115,7 @@ runroot rpmbuild --quiet -bb \
 
 # versioned conflict in transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -127,7 +127,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # versioned conflict in database
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
@@ -142,7 +142,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([install and verify self-conflicting package])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -162,7 +162,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([explicit file conflicts])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -199,7 +199,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([erase to break dependencies])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -225,7 +225,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([erase to break colored file dependency])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg hello" \
@@ -252,7 +252,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([erase on wrong-colored file dependency])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg hello" \
@@ -278,7 +278,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([unsatisfied WITH requires])
 AT_KEYWORDS([install, boolean])
 
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
 	--define "reqs (deptest-two with flavor = dekstop)" \
@@ -296,7 +296,7 @@ runroot rpmbuild --quiet -bb \
 
 # unsatisfied WITH require in transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -308,7 +308,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # unsatisfied WITH require in rpmdb
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 
@@ -323,7 +323,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([satisfied WITH requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -337,7 +337,7 @@ runroot rpmbuild --quiet -bb \
 
 # satisfied WITH require in transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
 [0],
@@ -346,7 +346,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied WITH require in rpmdb
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -371,7 +371,7 @@ RPMTEST_CLEANUP
 #
 RPMTEST_SETUP([unsatisfied WITHOUT requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -385,7 +385,7 @@ runroot rpmbuild --quiet -bb \
 
 # unsatisfied WITHOUT require in transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -397,7 +397,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # unsatisfied WITHOUT require in rpmdb
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 
@@ -412,7 +412,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([satisfied WITHOUT requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -425,7 +425,7 @@ runroot rpmbuild --quiet -bb \
 
 # satisfied WITHOUT require in transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -435,7 +435,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied WITHOUT require in rpmdb
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 
@@ -450,7 +450,7 @@ RPMTEST_CLEANUP
 #
 RPMTEST_SETUP([AND requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -464,7 +464,7 @@ for pkg in two three; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # unsatisfied AND require - all missing
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
@@ -476,7 +476,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 
 # unsatisfied AND require - first is missing
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -488,7 +488,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # unsatisfied AND require - second is missing
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -500,7 +500,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied AND require
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -513,7 +513,7 @@ RPMTEST_CLEANUP
 #
 RPMTEST_SETUP([OR requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -528,7 +528,7 @@ done
 
 # unsatisfied OR require - all missing
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
 [1],
@@ -539,7 +539,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 
 # satisfied OR require - first is missing
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -549,7 +549,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied OR require - second is missing
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -559,7 +559,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied OR require - both present
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -572,7 +572,7 @@ RPMTEST_CLEANUP
 #
 RPMTEST_SETUP([IF requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -587,7 +587,7 @@ done
 
 # unsatisfied IF require
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -599,7 +599,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied IF require
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -610,7 +610,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([IF-ELSE requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -625,7 +625,7 @@ done
 
 # unsatisfied IF-ELSE require
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
@@ -637,7 +637,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 
 # satisfied IF-ELSE require - right clause
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-four-1.0-1.noarch.rpm
 ],
@@ -647,7 +647,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied IF-ELSE require - left clause
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -660,7 +660,7 @@ RPMTEST_CLEANUP
 #
 RPMTEST_SETUP([nested AND-OR requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -674,7 +674,7 @@ for pkg in two three; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 # unsatisfied nested AND-OR require
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -686,7 +686,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied nested AND-OR require
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -699,7 +699,7 @@ RPMTEST_CLEANUP
 #
 RPMTEST_SETUP([nested AND-IF requires])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -714,7 +714,7 @@ done
 
 # satisfied nested AND-IF require - without right clause
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -724,7 +724,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied nested AND-IF require - with right clause
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-four-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -737,7 +737,7 @@ RPMTEST_CLEANUP
 #
 RPMTEST_SETUP([install to break installed rich dependency])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -756,7 +756,7 @@ runroot rpmbuild --quiet -bb \
 
 # installed conflict with "or" clause
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
@@ -769,7 +769,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 
 # installed requires with "if" clause
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/deptest-four-1.0-1.noarch.rpm
@@ -785,7 +785,7 @@ RPMTEST_CLEANUP
 #
 RPMTEST_SETUP([erase to break installed rich dependency])
 AT_KEYWORDS([install, boolean])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -807,7 +807,7 @@ runroot rpmbuild --quiet -bb \
 
 # installed requires with "or" clause
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 runroot rpm -e deptest-three
@@ -820,7 +820,7 @@ runroot rpm -e deptest-three
 
 # installed conflicts with "unless" clause
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-four-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-five-1.0-1.noarch.rpm
 runroot rpm -e deptest-four

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -3,7 +3,7 @@
 AT_BANNER([RPM dependencies])
 
 # ------------------------------
-AT_SETUP([unversioned requires])
+RPMTEST_SETUP([unversioned requires])
 AT_KEYWORDS([install depends])
 RPMDB_INIT
 
@@ -42,7 +42,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # 
-AT_SETUP([unsatisfied versioned require])
+RPMTEST_SETUP([unsatisfied versioned require])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -76,7 +76,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # 
-AT_SETUP([satisfied versioned require])
+RPMTEST_SETUP([satisfied versioned require])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -100,7 +100,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # 
-AT_SETUP([versioned conflicts])
+RPMTEST_SETUP([versioned conflicts])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -139,7 +139,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([install and verify self-conflicting package])
+RPMTEST_SETUP([install and verify self-conflicting package])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -159,7 +159,7 @@ runroot rpm -V --nofiles deptest-one
 RPMTEST_CLEANUP
 
 # explicit file conflicts
-AT_SETUP([explicit file conflicts])
+RPMTEST_SETUP([explicit file conflicts])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -196,7 +196,7 @@ error: Failed dependencies:
 RPMTEST_CLEANUP
 # ------------------------------
 # 
-AT_SETUP([erase to break dependencies])
+RPMTEST_SETUP([erase to break dependencies])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -222,7 +222,7 @@ runroot rpm -e deptest-two
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([erase to break colored file dependency])
+RPMTEST_SETUP([erase to break colored file dependency])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -249,7 +249,7 @@ runroot rpm -e hello.x86_64
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([erase on wrong-colored file dependency])
+RPMTEST_SETUP([erase on wrong-colored file dependency])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -275,7 +275,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([unsatisfied WITH requires])
+RPMTEST_SETUP([unsatisfied WITH requires])
 AT_KEYWORDS([install, boolean])
 
 RPMDB_INIT
@@ -321,7 +321,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([satisfied WITH requires])
+RPMTEST_SETUP([satisfied WITH requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -369,7 +369,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([unsatisfied WITHOUT requires])
+RPMTEST_SETUP([unsatisfied WITHOUT requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -410,7 +410,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([satisfied WITHOUT requires])
+RPMTEST_SETUP([satisfied WITHOUT requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -448,7 +448,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([AND requires])
+RPMTEST_SETUP([AND requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -511,7 +511,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([OR requires])
+RPMTEST_SETUP([OR requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -570,7 +570,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([IF requires])
+RPMTEST_SETUP([IF requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -608,7 +608,7 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([IF-ELSE requires])
+RPMTEST_SETUP([IF-ELSE requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -658,7 +658,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([nested AND-OR requires])
+RPMTEST_SETUP([nested AND-OR requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -697,7 +697,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([nested AND-IF requires])
+RPMTEST_SETUP([nested AND-IF requires])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -735,7 +735,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([install to break installed rich dependency])
+RPMTEST_SETUP([install to break installed rich dependency])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 
@@ -783,7 +783,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([erase to break installed rich dependency])
+RPMTEST_SETUP([erase to break installed rich dependency])
 AT_KEYWORDS([install, boolean])
 RPMDB_INIT
 

--- a/tests/rpmdevel.at
+++ b/tests/rpmdevel.at
@@ -37,7 +37,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm plugin development])
 AT_KEYWORDS([devel])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	/data/SPECS/simple.spec \

--- a/tests/rpmdevel.at
+++ b/tests/rpmdevel.at
@@ -1,6 +1,6 @@
 AT_BANNER([Rpm development])
 
-AT_SETUP([rpm API user])
+RPMTEST_SETUP([rpm API user])
 AT_KEYWORDS([devel])
 
 cat << EOF > CMakeLists.txt
@@ -35,7 +35,7 @@ LD_PRELOAD=${ASANLIB} ./trpm
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm plugin development])
+RPMTEST_SETUP([rpm plugin development])
 AT_KEYWORDS([devel])
 RPMDB_INIT
 

--- a/tests/rpme.at
+++ b/tests/rpme.at
@@ -1,7 +1,7 @@
 
 RPMTEST_SETUP([rpm -e and verify files removed])
 AT_KEYWORDS([install erase rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -27,7 +27,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -e suid hardlink])
 AT_KEYWORDS([install erase])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		/data/SPECS/attrtest.spec
@@ -49,7 +49,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm reinstall with shared files])
 AT_KEYWORDS([install erase update rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 3" \
@@ -92,7 +92,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -e and shared files removed 1.1])
 AT_KEYWORDS([install erase rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 3" \
@@ -137,7 +137,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -e and shared files removed 1.2])
 AT_KEYWORDS([install erase rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 3" \
@@ -183,7 +183,7 @@ RPMTEST_CLEANUP
 # Test that removing shared or wrong colored files has no effect
 RPMTEST_SETUP([rpm -e and verify colored files removed 1.1])
 AT_KEYWORDS([install erase rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -209,9 +209,9 @@ RPMTEST_CLEANUP
 # in verify failure.
 RPMTEST_SETUP([rpm -e and verify colored files removed 1.2])
 AT_KEYWORDS([install erase rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 3" \
@@ -234,9 +234,9 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -e and verify colored files removed 2.1])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_KEYWORDS([install erase rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 2" \
@@ -259,9 +259,9 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -e and verify colored files removed 2.2])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_KEYWORDS([install erase rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 2" \
@@ -282,7 +282,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -e and verify conflicting files removed 1])
 AT_KEYWORDS([install erase rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 for p in a b; do
     runroot rpmbuild -bb --quiet \
 		--define "pkg ${p}" \
@@ -362,7 +362,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -e and verify netshared files not removed])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	/data/RPMS/hello-2.0-1.x86_64.rpm

--- a/tests/rpme.at
+++ b/tests/rpme.at
@@ -1,5 +1,5 @@
 
-AT_SETUP([rpm -e and verify files removed])
+RPMTEST_SETUP([rpm -e and verify files removed])
 AT_KEYWORDS([install erase rpmdb])
 RPMDB_INIT
 
@@ -25,7 +25,7 @@ missing   d /usr/share/doc/hello-2.0/README
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -e suid hardlink])
+RPMTEST_SETUP([rpm -e suid hardlink])
 AT_KEYWORDS([install erase])
 RPMDB_INIT
 
@@ -47,7 +47,7 @@ exists
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm reinstall with shared files])
+RPMTEST_SETUP([rpm reinstall with shared files])
 AT_KEYWORDS([install erase update rpmdb])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -90,7 +90,7 @@ runroot rpm -Vv --nodeps --nogroup --nouser hello.i686 hello.x86_64
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -e and shared files removed 1.1])
+RPMTEST_SETUP([rpm -e and shared files removed 1.1])
 AT_KEYWORDS([install erase rpmdb])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -135,7 +135,7 @@ missing     /usr/bin/hello
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -e and shared files removed 1.2])
+RPMTEST_SETUP([rpm -e and shared files removed 1.2])
 AT_KEYWORDS([install erase rpmdb])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -181,7 +181,7 @@ missing   d /usr/share/doc/hello-2.0/README
 
 RPMTEST_CLEANUP
 # Test that removing shared or wrong colored files has no effect
-AT_SETUP([rpm -e and verify colored files removed 1.1])
+RPMTEST_SETUP([rpm -e and verify colored files removed 1.1])
 AT_KEYWORDS([install erase rpmdb])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -207,7 +207,7 @@ RPMTEST_CLEANUP
 # XXX This is wrong really, rpm shouldn't let the real provider of
 # a shared file get removed - and unforced action shouldn't result
 # in verify failure.
-AT_SETUP([rpm -e and verify colored files removed 1.2])
+RPMTEST_SETUP([rpm -e and verify colored files removed 1.2])
 AT_KEYWORDS([install erase rpmdb])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -231,7 +231,7 @@ runroot rpm -Vv --nodeps --nogroup --nouser hello
 RPMTEST_CLEANUP
 
 # Test that shared colored files actually get removed regardless of order 1
-AT_SETUP([rpm -e and verify colored files removed 2.1])
+RPMTEST_SETUP([rpm -e and verify colored files removed 2.1])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_KEYWORDS([install erase rpmdb])
 RPMDB_INIT
@@ -256,7 +256,7 @@ missing   d /usr/share/doc/hello-2.0/README
 RPMTEST_CLEANUP
 
 # Test that shared colored files actually get removed regardless of order 2
-AT_SETUP([rpm -e and verify colored files removed 2.2])
+RPMTEST_SETUP([rpm -e and verify colored files removed 2.2])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_KEYWORDS([install erase rpmdb])
 RPMDB_INIT
@@ -280,7 +280,7 @@ missing   d /usr/share/doc/hello-2.0/README
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -e and verify conflicting files removed 1])
+RPMTEST_SETUP([rpm -e and verify conflicting files removed 1])
 AT_KEYWORDS([install erase rpmdb])
 RPMDB_INIT
 for p in a b; do
@@ -359,7 +359,7 @@ RPMTEST_CLEANUP
 
 # Test %_netsharedpath erasure. It's a bit weird as we're abusing verify
 # on non-installed package to see if files are there.
-AT_SETUP([rpm -e and verify netshared files not removed])
+RPMTEST_SETUP([rpm -e and verify netshared files not removed])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -53,7 +53,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([rpm --showrc])
 AT_KEYWORDS([basic])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 mkdir -p ${RPMTEST}/${RPMSYSCONFDIR}
 echo x86_64_v3-Linux > ${RPMTEST}/${RPMSYSCONFDIR}/platform
@@ -433,7 +433,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([urlhelper missing])
 AT_KEYWORDS([urlhelper])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 # runroot rpm --define "_urlhelper /not/there" --root /srv/test -qp https://example.com/foo-0.1-1.noarch.rpm
 runroot rpm --define "_urlhelper /not/there" -qp https://www.example.com/foo-1.0-1.x86_64.rpm
@@ -447,7 +447,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([urlhelper fails])
 AT_KEYWORDS([urlhelper])
-RPMDB_INIT
+RPMTEST_INIT
 
 cat << EOF > "${RPMTEST}"/tmp/fakecurl
 #!/bin/sh

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -19,7 +19,7 @@
 AT_BANNER([Basic tests])
 
 # ------------------------------
-AT_SETUP([rpm --version])
+RPMTEST_SETUP([rpm --version])
 AT_KEYWORDS([basic])
 RPMTEST_CHECK([runroot rpm --version],[0],
 [RPM version AT_PACKAGE_VERSION
@@ -27,14 +27,14 @@ RPMTEST_CHECK([runroot rpm --version],[0],
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpmbuild --version])
+RPMTEST_SETUP([rpmbuild --version])
 AT_KEYWORDS([basic])
 RPMTEST_CHECK([runroot rpmbuild --version],[0],
 [RPM version AT_PACKAGE_VERSION
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm invalid option])
+RPMTEST_SETUP([rpm invalid option])
 AT_KEYWORDS([basic])
 RPMTEST_CHECK([runroot rpm --badopt],
 [1],
@@ -44,14 +44,14 @@ RPMTEST_CHECK([runroot rpm --badopt],
 RPMTEST_CLEANUP
 
 # Check that libtool versioning matches expectations, it's easy to screw up.
-AT_SETUP([rpm library version])
+RPMTEST_SETUP([rpm library version])
 AT_KEYWORDS([basic])
 AT_SKIP_IF(test -f "${RPMTEST}/${RPMLIBDIR}/librpm.a")
 RPMTEST_CHECK_PINNED([rpmlibver])
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpm --showrc])
+RPMTEST_SETUP([rpm --showrc])
 AT_KEYWORDS([basic])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -103,7 +103,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check rpm --querytags
 # * Some versions of rpm append extraneous whitespaces
-AT_SETUP([rpm --querytags])
+RPMTEST_SETUP([rpm --querytags])
 AT_KEYWORDS([basic])
 RPMTEST_CHECK([runroot rpm --querytags],[0],
 [ARCH
@@ -373,7 +373,7 @@ XPM
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm2cpio])
+RPMTEST_SETUP([rpm2cpio])
 AT_KEYWORDS([basic])
 RPMTEST_CHECK([
 runroot_other rpm2cpio /data/RPMS/hello-2.0-1.x86_64.rpm | cpio -t --quiet
@@ -396,7 +396,7 @@ runroot_other rpm2cpio /data/SRPMS/hello-1.0-1.src.rpm | cpio -t --quiet
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm2archive])
+RPMTEST_SETUP([rpm2archive])
 AT_KEYWORDS([basic])
 RPMTEST_CHECK([
 runroot_other rpm2archive "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm | tar tzf -
@@ -431,7 +431,7 @@ runroot_other rpm2archive "${RPMTEST}"/data/SRPMS/hello-1.0-1.src.rpm | tar tzf 
 
 RPMTEST_CLEANUP
 
-AT_SETUP([urlhelper missing])
+RPMTEST_SETUP([urlhelper missing])
 AT_KEYWORDS([urlhelper])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -445,7 +445,7 @@ error: open of https://www.example.com/foo-1.0-1.x86_64.rpm failed: No such file
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([urlhelper fails])
+RPMTEST_SETUP([urlhelper fails])
 AT_KEYWORDS([urlhelper])
 RPMDB_INIT
 

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -18,7 +18,7 @@
 
 AT_BANNER([RPM install tests])
 
-AT_SETUP([rpm -U <manifest>])
+RPMTEST_SETUP([rpm -U <manifest>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -32,7 +32,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <manifest glob>])
+RPMTEST_SETUP([rpm -U <manifest glob>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -46,7 +46,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <manifest glob fallback>])
+RPMTEST_SETUP([rpm -U <manifest glob fallback>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -64,7 +64,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <manifest notfound 1>])
+RPMTEST_SETUP([rpm -U <manifest notfound 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -79,7 +79,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <manifest notfound 2>])
+RPMTEST_SETUP([rpm -U <manifest notfound 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -94,7 +94,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <manifest notfound 3>])
+RPMTEST_SETUP([rpm -U <manifest notfound 3>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -113,7 +113,7 @@ error: open of /data/RPMS/hello-not-there-3.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <manifest notfound 4>])
+RPMTEST_SETUP([rpm -U <manifest notfound 4>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -132,7 +132,7 @@ error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <notfound>])
+RPMTEST_SETUP([rpm -U <notfound>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -146,7 +146,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <notfound 2>])
+RPMTEST_SETUP([rpm -U <notfound 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -164,7 +164,7 @@ error: open of /data/RPMS/hello-not-there-3.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <unsigned 1>])
+RPMTEST_SETUP([rpm -U <unsigned 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -177,7 +177,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <unsigned 2>])
+RPMTEST_SETUP([rpm -U <unsigned 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -192,7 +192,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <corrupted unsigned 1>])
+RPMTEST_SETUP([rpm -U <corrupted unsigned 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -238,7 +238,7 @@ error: hello-2.0-1.x86_64: install failed
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <corrupted unsigned 2>])
+RPMTEST_SETUP([rpm -U <corrupted unsigned 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -281,7 +281,7 @@ error: hello-2.0-1.x86_64: install failed
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <signed nokey 1>])
+RPMTEST_SETUP([rpm -U <signed nokey 1>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -296,7 +296,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <signed nokey 2>])
+RPMTEST_SETUP([rpm -U <signed nokey 2>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -313,7 +313,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <signed 1>])
+RPMTEST_SETUP([rpm -U <signed 1>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -328,7 +328,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <signed 2>])
+RPMTEST_SETUP([rpm -U <signed 2>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -344,7 +344,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <corrupted signed 1>])
+RPMTEST_SETUP([rpm -U <corrupted signed 1>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK_UNQUOTED([
@@ -371,7 +371,7 @@ error: /tmp/hello-2.0-1.x86_64-signed.rpm cannot be installed
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <corrupted signed 2>])
+RPMTEST_SETUP([rpm -U <corrupted signed 2>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -394,7 +394,7 @@ error: /tmp/hello-2.0-1.x86_64-signed.rpm cannot be installed
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <corrupted signed 3>])
+RPMTEST_SETUP([rpm -U <corrupted signed 3>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -453,7 +453,7 @@ error: hello-2.0-1.x86_64: install failed
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <glob>])
+RPMTEST_SETUP([rpm -U <glob>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -466,7 +466,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <glob notfound>])
+RPMTEST_SETUP([rpm -U <glob notfound>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -484,7 +484,7 @@ error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <glob fallback>])
+RPMTEST_SETUP([rpm -U <glob fallback>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -502,7 +502,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test tid/time overrides using SOURCE_DATE_EPOCH
-AT_SETUP([rpm -i <overridden time>])
+RPMTEST_SETUP([rpm -i <overridden time>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -531,7 +531,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test multiple installs using SOURCE_DATE_EPOCH
-AT_SETUP([rpm -i <overridden time keeps ticking>])
+RPMTEST_SETUP([rpm -i <overridden time keeps ticking>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -555,7 +555,7 @@ Install Date: Wed Oct 21 07:28:56 2015
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i --nodb])
+RPMTEST_SETUP([rpm -i --nodb])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -579,7 +579,7 @@ runroot_other find /foo|sort
 
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i --justdb])
+RPMTEST_SETUP([rpm -i --justdb])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -600,7 +600,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpm -U *.src.rpm works
-AT_SETUP([rpm -U *.src.rpm])
+RPMTEST_SETUP([rpm -U *.src.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 rpm \
@@ -620,7 +620,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpm -i *.src.rpm works
-AT_SETUP([rpm -i *.src.rpm])
+RPMTEST_SETUP([rpm -i *.src.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 rpm \
@@ -640,7 +640,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpm -i *.src.rpm *.rpm works
-AT_SETUP([rpm -i *.src.rpm *.rpm])
+RPMTEST_SETUP([rpm -i *.src.rpm *.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -668,7 +668,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Various error behavior tests
 #
-AT_SETUP([rpm -i <nonexistent file>])
+RPMTEST_SETUP([rpm -i <nonexistent file>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -681,7 +681,7 @@ runroot rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i --nomanifest <garbage text file>])
+RPMTEST_SETUP([rpm -i --nomanifest <garbage text file>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -700,7 +700,7 @@ runroot rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i <garbage text file])
+RPMTEST_SETUP([rpm -i <garbage text file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -721,7 +721,7 @@ error: open of not_pkg.rpm failed: No such file or directory
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpm upgrade/downgrade])
+RPMTEST_SETUP([rpm upgrade/downgrade])
 RPMDB_INIT
 
 for v in "1.0" "2.0"; do
@@ -894,7 +894,7 @@ runroot rpm -q versiontest
 
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm upgrade/downgrade epoch])
+RPMTEST_SETUP([rpm upgrade/downgrade epoch])
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb --define "ver 1.0" /data/SPECS/versiontest.spec
@@ -1031,7 +1031,7 @@ runroot rpm -U --replacepkgs /tmp/epoch1.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U obsoleted packages])
+RPMTEST_SETUP([rpm -U obsoleted packages])
 AT_KEYWORDS([install obsolete])
 RPMDB_INIT
 runroot rpmbuild --quiet -bb \
@@ -1096,7 +1096,7 @@ deptest-one-1.0-1.noarch
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U with invalid --relocate])
+RPMTEST_SETUP([rpm -U with invalid --relocate])
 AT_KEYWORDS([install relocate])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1112,7 +1112,7 @@ runroot rpm -U --test --ignoreos --relocate /usr=/opt \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U --badreloc with invalid --relocate])
+RPMTEST_SETUP([rpm -U --badreloc with invalid --relocate])
 AT_KEYWORDS([install relocate])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1127,7 +1127,7 @@ runroot rpm -U --test --ignoreos --badreloc --relocate /usr=/opt \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i relocatable package])
+RPMTEST_SETUP([rpm -i relocatable package])
 AT_KEYWORDS([install relocate])
 RPMDB_INIT
 
@@ -1172,7 +1172,7 @@ runroot rpm -U --relocate /opt/bin=/bin \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i relocatable package 2])
+RPMTEST_SETUP([rpm -i relocatable package 2])
 AT_KEYWORDS([install relocate])
 RPMDB_INIT
 
@@ -1207,7 +1207,7 @@ runroot rpm -ql reloc
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i relocatable package 3])
+RPMTEST_SETUP([rpm -i relocatable package 3])
 AT_KEYWORDS([install relocate])
 RPMTEST_USER
 RPMDB_INIT
@@ -1232,7 +1232,7 @@ runroot_user test ! -d \$PWD/root
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i with/without --excludedocs])
+RPMTEST_SETUP([rpm -i with/without --excludedocs])
 AT_KEYWORDS([install excludedocs])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1265,7 +1265,7 @@ runroot rpm -e testdoc
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i --excludeartifacts])
+RPMTEST_SETUP([rpm -i --excludeartifacts])
 AT_KEYWORDS([install])
 RPMDB_INIT
 runroot rpmbuild --quiet -bb /data/SPECS/vattrtest.spec
@@ -1283,7 +1283,7 @@ test -e ${RPMTEST}/opt/vattrtest/a || exit 1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U <suicidal>])
+RPMTEST_SETUP([rpm -U <suicidal>])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -1324,7 +1324,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # hardlink tests
-AT_SETUP([rpm -i hardlinks])
+RPMTEST_SETUP([rpm -i hardlinks])
 AT_KEYWORDS([build install])
 RPMDB_INIT
 
@@ -1493,7 +1493,7 @@ runroot rpm -Vav --nouser --nogroup
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U filesystem])
+RPMTEST_SETUP([rpm -U filesystem])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1509,7 +1509,7 @@ runroot rpm -q --whatprovides /
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U fifo])
+RPMTEST_SETUP([rpm -U fifo])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1524,7 +1524,7 @@ runroot rpm -Vv --nouser --nogroup fifo
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U dev])
+RPMTEST_SETUP([rpm -U dev])
 AT_KEYWORDS([install])
 AT_SKIP_IF([$MKNOD_DISABLED])
 RPMTEST_CHECK([
@@ -1541,7 +1541,7 @@ runroot rpm -Vv --nouser --nogroup dev
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U with Obsoletes])
+RPMTEST_SETUP([rpm -U with Obsoletes])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1561,7 +1561,7 @@ deptest-test-obsoletes-1.0-1.noarch
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i create user])
+RPMTEST_SETUP([rpm -i create user])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1578,7 +1578,7 @@ runroot rpm -V --root /alt ${VERIFYOPTS} deptest-user
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i create group])
+RPMTEST_SETUP([rpm -i create group])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1595,7 +1595,7 @@ runroot rpm -V ${VERIFYOPTS} deptest-user
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -i sysusers])
+RPMTEST_SETUP([rpm -i sysusers])
 AT_KEYWORDS([install build sysusers])
 RPMDB_INIT
 
@@ -1716,7 +1716,7 @@ klangd
 
 RPMTEST_CLEANUP
 
-AT_SETUP([install on invalid symlinked directory])
+RPMTEST_SETUP([install on invalid symlinked directory])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -1737,7 +1737,7 @@ error: replacetest-1.0-1.noarch: install failed
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([update on invalid symlinked directory])
+RPMTEST_SETUP([update on invalid symlinked directory])
 AT_KEYWORDS([install update symlink])
 RPMDB_INIT
 
@@ -1777,7 +1777,7 @@ runroot rpm -V --nomtime pamupdate
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -U diskspace])
+RPMTEST_SETUP([rpm -U diskspace])
 AT_KEYWORDS([install diskspace])
 RPMTEST_CHECK([
 

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -21,7 +21,7 @@ AT_BANNER([RPM install tests])
 RPMTEST_SETUP([rpm -U <manifest>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo /data/RPMS/hello-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -35,7 +35,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <manifest glob>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo "/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm" > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -49,7 +49,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <manifest glob fallback>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}/data/RPMS/hello-2.0-1.i686.rpm" \
    "${RPMTEST}/tmp/fallback-[[123]].0-1.i686.rpm"
@@ -67,7 +67,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <manifest notfound 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo /data/RPMS/hello-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -82,7 +82,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <manifest notfound 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo /data/RPMS/hello-not-there-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -97,7 +97,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <manifest notfound 3>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo /data/RPMS/hello-not-there-1.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
 echo /data/RPMS/hello-not-there-2.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
@@ -116,7 +116,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <manifest notfound 4>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo "/data/RPMS/hello-not-there-*.x86_64.rpm" > ${RPMTEST}/tmp/test.mft
 echo /data/RPMS/hello-not-there-1.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
@@ -135,7 +135,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <notfound>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-not-there-2.0-1.x86_64.rpm
@@ -149,7 +149,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <notfound 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
@@ -167,7 +167,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <unsigned 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
@@ -180,7 +180,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <unsigned 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	--define "_pkgverify_level signature" \
@@ -195,7 +195,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <corrupted unsigned 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -241,7 +241,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <corrupted unsigned 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -285,7 +285,7 @@ RPMTEST_SETUP([rpm -U <signed nokey 1>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-2.0-1.x86_64-signed.rpm
@@ -300,7 +300,7 @@ RPMTEST_SETUP([rpm -U <signed nokey 2>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	--define "_pkgverify_level signature" \
@@ -317,7 +317,7 @@ RPMTEST_SETUP([rpm -U <signed 1>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -332,7 +332,7 @@ RPMTEST_SETUP([rpm -U <signed 2>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -348,7 +348,7 @@ RPMTEST_SETUP([rpm -U <corrupted signed 1>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK_UNQUOTED([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -375,7 +375,7 @@ RPMTEST_SETUP([rpm -U <corrupted signed 2>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -398,7 +398,7 @@ RPMTEST_SETUP([rpm -U <corrupted signed 3>])
 AT_KEYWORDS([install])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -456,7 +456,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <glob>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	"/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm"
@@ -469,7 +469,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <glob notfound>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	"/data/RPMS/hello-not-there-*.x86_64.rpm" \
@@ -487,7 +487,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U <glob fallback>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}/data/RPMS/hello-2.0-1.i686.rpm" \
    "${RPMTEST}/tmp/fallback-[[123]].0-1.i686.rpm"
@@ -505,7 +505,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i <overridden time>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64"
 timestamp=97445
@@ -534,7 +534,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i <overridden time keeps ticking>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 timestamp=1445412535
 
@@ -558,7 +558,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i --nodb])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm \
   -U --nodb /data/RPMS/hlinktest-1.0-1.noarch.rpm
@@ -582,7 +582,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i --justdb])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # avoid having to deal with non-existent /foo in the find below
 runroot_other mkdir /foo
@@ -643,7 +643,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i *.src.rpm *.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm \
   --define "_topdir /tmp/build" \
@@ -671,7 +671,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i <nonexistent file>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   -i no_such_file
 ],
@@ -684,7 +684,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i --nomanifest <garbage text file>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 junk="${RPMTEST}/textfile"
 cat << EOF > "${junk}"
 no_such.file
@@ -703,7 +703,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i <garbage text file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 junk="${RPMTEST}/not_an.rpm"
 cat << EOF > "${junk}"
 no_such.file
@@ -722,7 +722,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 RPMTEST_SETUP([rpm upgrade/downgrade])
-RPMDB_INIT
+RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -732,7 +732,7 @@ done
 
 # Test normal upgrade
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -q versiontest
@@ -744,7 +744,7 @@ runroot rpm -q versiontest
 
 # Test upgrading to older package (should fail)
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
@@ -756,7 +756,7 @@ runroot rpm -U /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
 
 # Test downgrading to older package with --oldpackage
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -U --oldpackage /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
@@ -769,7 +769,7 @@ runroot rpm -q versiontest
 
 # Test upgrade of different versions in same transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -Uv \
   /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm \
@@ -787,7 +787,7 @@ versiontest-2.0-1.noarch
 
 # Test upgrade of different versions in same transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -Uv \
   /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm \
@@ -805,7 +805,7 @@ versiontest-2.0-1.noarch
 
 # Test install of two different versions in same transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -i \
   /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm \
@@ -821,7 +821,7 @@ versiontest-1.0-1.noarch
 # Test install of two different versions in same transaction
 # TODO: test only one was installed
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -i \
   /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm \
@@ -835,7 +835,7 @@ runroot rpm -q versiontest
 
 # Test freshen
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
 runroot rpm -F /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -q versiontest
@@ -847,7 +847,7 @@ runroot rpm -q versiontest
 
 # Test freshen on uninstalled package
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -F /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -q versiontest
 ],
@@ -858,7 +858,7 @@ runroot rpm -q versiontest
 
 # Test freshen with older package
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -F /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
 runroot rpm -q versiontest
@@ -870,7 +870,7 @@ runroot rpm -q versiontest
 
 # Test freshen --oldpackage
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -F --oldpackage /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
 runroot rpm -q versiontest
@@ -882,7 +882,7 @@ runroot rpm -q versiontest
 
 # Test freshen --oldpackage same version
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -F --oldpackage /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -q versiontest
@@ -895,7 +895,7 @@ runroot rpm -q versiontest
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm upgrade/downgrade epoch])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb --define "ver 1.0" /data/SPECS/versiontest.spec
 runroot_other cp /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm /tmp/noepoch.rpm
@@ -907,7 +907,7 @@ done
 echo '%_query_all_fmt %%{nevra}' >> ${HOME}/.config/rpm/macros
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/noepoch.rpm
 runroot rpm -U /tmp/epoch1.rpm
 runroot rpm -q versiontest
@@ -918,7 +918,7 @@ runroot rpm -q versiontest
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/epoch1.rpm
 runroot rpm -U /tmp/epoch2.rpm
 runroot rpm -q versiontest
@@ -930,7 +930,7 @@ runroot rpm -q versiontest
 
 # XXX this should be FAIL, but don't want to fail all the test just because...
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/epoch1.rpm
 runroot rpm -U /tmp/noepoch.rpm
 ],
@@ -940,7 +940,7 @@ runroot rpm -U /tmp/noepoch.rpm
 ])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/epoch2.rpm
 runroot rpm -U /tmp/epoch1.rpm
 ],
@@ -950,7 +950,7 @@ runroot rpm -U /tmp/epoch1.rpm
 ])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/epoch2.rpm
 runroot rpm -U --oldpackage /tmp/epoch1.rpm
 runroot rpm -q versiontest
@@ -962,7 +962,7 @@ runroot rpm -q versiontest
 
 # XXX this should be FAIL, but don't want to fail all the test just because...
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/epoch1.rpm
 runroot rpm -U --oldpackage /tmp/noepoch.rpm
 runroot rpm -q versiontest
@@ -973,7 +973,7 @@ runroot rpm -q versiontest
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/noepoch.rpm
 runroot rpm -e versiontest-1.0-1
 ],
@@ -982,7 +982,7 @@ runroot rpm -e versiontest-1.0-1
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/epoch1.rpm
 runroot rpm -e versiontest-1.0-1
 ],
@@ -991,7 +991,7 @@ runroot rpm -e versiontest-1.0-1
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -i /tmp/noepoch.rpm
 runroot rpm -i /tmp/epoch1.rpm
 
@@ -1013,7 +1013,7 @@ error: "versiontest-1.0-1" specifies multiple packages:
 ])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/noepoch.rpm
 runroot rpm -U --replacepkgs /tmp/noepoch.rpm
 ],
@@ -1022,7 +1022,7 @@ runroot rpm -U --replacepkgs /tmp/noepoch.rpm
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /tmp/epoch1.rpm
 runroot rpm -U --replacepkgs /tmp/epoch1.rpm
 ],
@@ -1033,7 +1033,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U obsoleted packages])
 AT_KEYWORDS([install obsolete])
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
 	--define "obs deptest-two <= 1.0" \
@@ -1048,7 +1048,7 @@ runroot rpmbuild --quiet -bb \
 
 # Test package obsoleting another
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/deptest-obsoletes-1.0-1.noarch.rpm
 runroot rpm -q deptest-two deptest-obsoletes
@@ -1061,7 +1061,7 @@ deptest-obsoletes-1.0-1.noarch
 
 # Test upgrade of obsoleted package in same transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -Uv \
   /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm \
@@ -1079,7 +1079,7 @@ deptest-one-1.0-1.noarch
 
 # Test upgrade of obsoleted package in same transaction
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpm -Uv \
   /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm \
@@ -1099,7 +1099,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U with invalid --relocate])
 AT_KEYWORDS([install relocate])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -1115,7 +1115,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U --badreloc with invalid --relocate])
 AT_KEYWORDS([install relocate])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -1129,7 +1129,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -i relocatable package])
 AT_KEYWORDS([install relocate])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/reloc.spec
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
@@ -1174,7 +1174,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -i relocatable package 2])
 AT_KEYWORDS([install relocate])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/reloc.spec
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
@@ -1210,7 +1210,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i relocatable package 3])
 AT_KEYWORDS([install relocate])
 RPMTEST_USER
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/rootfs.spec
 
@@ -1235,7 +1235,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i with/without --excludedocs])
 AT_KEYWORDS([install excludedocs])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/testdoc.spec
 
@@ -1267,11 +1267,11 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -i --excludeartifacts])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpmbuild --quiet -bb /data/SPECS/vattrtest.spec
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i --excludeartifacts /build/RPMS/noarch/vattrtest-1.0-1.noarch.rpm
 test -e ${RPMTEST}/opt/vattrtest/a && exit 1
 runroot rpm -e vattrtest
@@ -1285,7 +1285,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U <suicidal>])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 for r in 1 2; do
     runroot rpmbuild -bb --quiet \
@@ -1294,7 +1294,7 @@ for r in 1 2; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 for r in 1 2; do
     runroot rpm -U \
@@ -1308,7 +1308,7 @@ runroot rpm -V --nouser --nogroup suicidal
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 for r in 1 2; do
     runroot rpm -U \
@@ -1326,7 +1326,7 @@ RPMTEST_CLEANUP
 # hardlink tests
 RPMTEST_SETUP([rpm -i hardlinks])
 AT_KEYWORDS([build install])
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="/data/RPMS/hlinktest-1.0-1.noarch.rpm"
 
@@ -1343,7 +1343,7 @@ dd if=/dev/zero of="${RPMTEST}/tmp/3.rpm" \
    conv=notrunc bs=1 seek=8050 count=6 2> /dev/null
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i --noverify /tmp/1.rpm
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
@@ -1355,7 +1355,7 @@ error: hlinktest-1.0-1.noarch: install failed
 ])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i --noverify /tmp/2.rpm
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
@@ -1367,7 +1367,7 @@ error: hlinktest-1.0-1.noarch: install failed
 ])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i --noverify /tmp/3.rpm 2>&1| sed 's/;.*:/:/g'
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
@@ -1379,7 +1379,7 @@ error: hlinktest-1.0-1.noarch: install failed
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i "${pkg}"
 runroot rpm -q --qf "[[%{filenlinks} %{filenames}\n]]%{longsize}\n" hlinktest
 ls -i "${RPMTEST}"/foo/hello* | awk {'print $1'} | sort -u | wc -l
@@ -1401,7 +1401,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i --excludepath=/foo/zzzz "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
@@ -1419,7 +1419,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i --excludepath=/foo/aaaa "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
@@ -1437,7 +1437,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i --excludepath=/foo/aaaa --excludepath=/foo/zzzz "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
@@ -1455,7 +1455,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -i --excludepath=/foo/hello-foo "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
@@ -1473,7 +1473,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpmbuild -bb --quiet --with crossdir_links /data/SPECS/hlinktest.spec
 runroot rpm -U /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
 runroot rpm -Vav --nouser --nogroup
@@ -1496,7 +1496,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U filesystem])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/fs.spec
 runroot rpm -U --ignoreos /build/RPMS/noarch/fs-1.0-1.noarch.rpm
@@ -1512,7 +1512,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U fifo])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/fifo.spec
 runroot rpm -U --ignoreos /build/RPMS/noarch/fifo-1.0-1.noarch.rpm
@@ -1528,7 +1528,7 @@ RPMTEST_SETUP([rpm -U dev])
 AT_KEYWORDS([install])
 AT_SKIP_IF([$MKNOD_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/dev.spec
 runroot rpm -U --ignoreos /build/RPMS/noarch/dev-1.0-1.noarch.rpm
@@ -1544,7 +1544,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -U with Obsoletes])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet --define "pkg obsoletes" \
   /data/SPECS/deptest.spec
@@ -1564,7 +1564,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i create user])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser u myuser 876 - /home/myuser /bin/sh}"\
   /data/SPECS/deptest.spec
@@ -1581,7 +1581,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -i create group])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser g mygroup 678}"\
   /data/SPECS/deptest.spec
@@ -1597,7 +1597,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -i sysusers])
 AT_KEYWORDS([install build sysusers])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild -bb -D "_use_weak_usergroup_deps 1" --quiet /data/SPECS/klang.spec
@@ -1718,7 +1718,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([install on invalid symlinked directory])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
           /data/SPECS/replacetest.spec
@@ -1739,7 +1739,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([update on invalid symlinked directory])
 AT_KEYWORDS([install update symlink])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 for r in 1 2; do
@@ -1781,7 +1781,7 @@ RPMTEST_SETUP([rpm -U diskspace])
 AT_KEYWORDS([install diskspace])
 RPMTEST_CHECK([
 
-# Skip RPMDB_INIT to leave the fs read-only for a reproducible result
+# Skip RPMTEST_INIT to leave the fs read-only for a reproducible result
 runroot rpm -U --nodb --test --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 ],

--- a/tests/rpmio.at
+++ b/tests/rpmio.at
@@ -7,7 +7,7 @@ AT_BANNER([I/O])
 #AT_KEYWORDS([signals])
 #RPMTEST_CHECK([
 #RPMDB_CLEAR
-#RPMDB_INIT
+#RPMTEST_INIT
 #
 #runroot rpmbuild --quiet --with manyfiles -bb /data/SPECS/sigpipe.spec
 #runroot rpm -qpl /build/RPMS/noarch/sigpipe-1.0-1.noarch.rpm --pipe "cat" | head -1
@@ -21,7 +21,7 @@ AT_BANNER([I/O])
 RPMTEST_SETUP([SIGPIPE from install scriptlet])
 AT_KEYWORDS([signals])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/sigpipe.spec
 runroot rpm -U --nodeps /build/RPMS/noarch/sigpipe-1.0-1.noarch.rpm
@@ -38,7 +38,7 @@ RPMTEST_CLEANUP
 #AT_KEYWORDS([signals])
 #RPMTEST_CHECK([
 #RPMDB_CLEAR
-#RPMDB_INIT
+#RPMTEST_INIT
 #
 #run rpmbuild --quiet --with buildpipe -bb "${RPMDATA}/SPECS/sigpipe.spec"
 #],
@@ -50,7 +50,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmlog error handling])
 AT_KEYWORDS([log])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -qpl /data/RPMS/hello-2.0-1.x86_64.rpm > /dev/full
 ],

--- a/tests/rpmio.at
+++ b/tests/rpmio.at
@@ -3,7 +3,7 @@
 AT_BANNER([I/O])
 
 # test too unstable for production
-#AT_SETUP([SIGPIPE from --pipe])
+#RPMTEST_SETUP([SIGPIPE from --pipe])
 #AT_KEYWORDS([signals])
 #RPMTEST_CHECK([
 #RPMDB_CLEAR
@@ -18,7 +18,7 @@ AT_BANNER([I/O])
 #[])
 #RPMTEST_CLEANUP
 
-AT_SETUP([SIGPIPE from install scriptlet])
+RPMTEST_SETUP([SIGPIPE from install scriptlet])
 AT_KEYWORDS([signals])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -34,7 +34,7 @@ RPMTEST_CLEANUP
 # XXX TODO: test for RhBug:471591 too, but needs a simpler reproducer
 
 # test too unstable for production
-#AT_SETUP([SIGPIPE in build scriptlet])
+#RPMTEST_SETUP([SIGPIPE in build scriptlet])
 #AT_KEYWORDS([signals])
 #RPMTEST_CHECK([
 #RPMDB_CLEAR
@@ -47,7 +47,7 @@ RPMTEST_CLEANUP
 #[])
 #RPMTEST_CLEANUP
 
-AT_SETUP([rpmlog error handling])
+RPMTEST_SETUP([rpmlog error handling])
 AT_KEYWORDS([log])
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -42,7 +42,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 AT_SETUP([macro path: skip editor backups])
 AT_KEYWORDS([macros])
-RPMTEST_SETUP
+RPMTEST_INIT
 RPMTEST_CHECK([
 echo '%this that' > $RPMTEST/$RPM_CONFIGDIR_PATH/macros.d/macros.this
 runroot rpm --eval '%{this}'
@@ -1521,7 +1521,7 @@ RPMTEST_CLEANUP
 
 AT_SETUP([rpmlua])
 AT_KEYWORDS([lua])
-RPMTEST_SETUP
+RPMTEST_INIT
 RPMTEST_CHECK([
 rpmlua /data/t1.lua a b
 ],

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -2,7 +2,7 @@
 #
 AT_BANNER([RPM macros])
 
-AT_SETUP([macro path])
+RPMTEST_SETUP([macro path])
 AT_KEYWORDS([macros])
 RPMDB_INIT
 
@@ -40,7 +40,7 @@ runroot --setenv  XDG_CONFIG_HOME "~/.zzz" rpm --showrc | awk '/^Macro path/{pri
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([macro path: skip editor backups])
+RPMTEST_SETUP([macro path: skip editor backups])
 AT_KEYWORDS([macros])
 RPMTEST_INIT
 RPMTEST_CHECK([
@@ -57,7 +57,7 @@ runroot rpm --eval '%{this}'
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([simple rpm --eval])
+RPMTEST_SETUP([simple rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --define "this that" --eval '%{this}' --eval '%not_defined' --eval '%{not_defined}' --eval '%{}'
@@ -81,7 +81,7 @@ rpm --eval '%{not_defined}'
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([invalid rpm --eval])
+RPMTEST_SETUP([invalid rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --eval '%define _ that'
@@ -93,7 +93,7 @@ rpm --eval '%define _ that'
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([invalid rpm --define])
+RPMTEST_SETUP([invalid rpm --define])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --define "_ that"
@@ -106,7 +106,7 @@ error: Macro %undefine is a built-in (%define)
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm --undefine])
+RPMTEST_SETUP([rpm --undefine])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --define "this that" --eval '1. %{this}' --undefine 'this' --eval '2. %{this'}
@@ -121,7 +121,7 @@ rpm --eval '1. %{this}' --define "this that" --eval '2. %{this}' --undefine 'thi
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([simple true conditional rpm --eval])
+RPMTEST_SETUP([simple true conditional rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --define "this that" --eval '%{?this}'
@@ -131,7 +131,7 @@ rpm --define "this that" --eval '%{?this}'
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([simple false conditional rpm --eval])
+RPMTEST_SETUP([simple false conditional rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --define "this that" --eval '%{?that}'
@@ -141,7 +141,7 @@ rpm --define "this that" --eval '%{?that}'
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([nested macro in name])
+RPMTEST_SETUP([nested macro in name])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --define "this that" --define "that_that foo" --eval '%{expand:%{%{this}_that}}'
@@ -151,7 +151,7 @@ rpm --define "this that" --define "that_that foo" --eval '%{expand:%{%{this}_tha
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([recursive macro])
+RPMTEST_SETUP([recursive macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --define 'aaa %aaa' --eval '%aaa'
@@ -162,7 +162,7 @@ rpm --define 'aaa %aaa' --eval '%aaa'
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([recursive expression])
+RPMTEST_SETUP([recursive expression])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --define 'aaa %\\[%aaa\\]' --eval '%aaa'
@@ -173,7 +173,7 @@ rpm --define 'aaa %\\[%aaa\\]' --eval '%aaa'
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([parametrized macro 1])
+RPMTEST_SETUP([parametrized macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -210,7 +210,7 @@ foo 5
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([parametrized macro 2])
+RPMTEST_SETUP([parametrized macro 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -223,7 +223,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([parametrized macro 3])
+RPMTEST_SETUP([parametrized macro 3])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -235,7 +235,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([parametrized macro 4])
+RPMTEST_SETUP([parametrized macro 4])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -250,7 +250,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([parametrized macro 5])
+RPMTEST_SETUP([parametrized macro 5])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -286,7 +286,7 @@ bar' \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([parametrized macro 6])
+RPMTEST_SETUP([parametrized macro 6])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -298,7 +298,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([parametrized macro 7])
+RPMTEST_SETUP([parametrized macro 7])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -310,7 +310,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([parametrized macro 8])
+RPMTEST_SETUP([parametrized macro 8])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -324,7 +324,7 @@ arg
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([uncompress macro 1])
+RPMTEST_SETUP([uncompress macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -336,7 +336,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([uncompress 1])
+RPMTEST_SETUP([uncompress 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 ${RPM_CONFIGDIR_PATH}/rpmuncompress /data/SOURCES/hello-2.0.tar.gz | tar t
@@ -352,7 +352,7 @@ hello-2.0/FAQ
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([uncompress 2])
+RPMTEST_SETUP([uncompress 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -364,7 +364,7 @@ ${RPM_CONFIGDIR_PATH}/rpmuncompress "some%%ath"
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([uncompress 3])
+RPMTEST_SETUP([uncompress 3])
 AT_KEYWORDS([macros rpmuncompress])
 
 RPMTEST_CHECK([
@@ -402,7 +402,7 @@ test-1.2.3-7/src/README.txt
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([uncompress 4])
+RPMTEST_SETUP([uncompress 4])
 AT_KEYWORDS([macros rpmuncompress])
 RPMDB_INIT
 
@@ -451,7 +451,7 @@ runroot_other --chdir /tmp/2 find . | sort
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([getncpus macro])
+RPMTEST_SETUP([getncpus macro])
 AT_KEYWORDS([macros])
 # skip if nproc not available
 AT_SKIP_IF([test -z "$(nproc 2>/dev/null)"])
@@ -469,7 +469,7 @@ expr $(rpm --define "_smp_tasksize_proc ${mem}" --eval "%{getncpus:proc}") = 1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([basename macro])
+RPMTEST_SETUP([basename macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -480,7 +480,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([shrink macro])
+RPMTEST_SETUP([shrink macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -491,7 +491,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([suffix macro])
+RPMTEST_SETUP([suffix macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -502,7 +502,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([url2path macro])
+RPMTEST_SETUP([url2path macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -513,7 +513,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([macrobody macro])
+RPMTEST_SETUP([macrobody macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -530,7 +530,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmversion macro])
+RPMTEST_SETUP([rpmversion macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --eval "%{rpmversion}"
@@ -541,7 +541,7 @@ rpm --eval "%{rpmversion}"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([builtin macro arguments])
+RPMTEST_SETUP([builtin macro arguments])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --eval "%{dirname}"
@@ -620,7 +620,7 @@ error: %dump: unexpected argument
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([macro arguments])
+RPMTEST_SETUP([macro arguments])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -663,7 +663,7 @@ warning: unexpected argument to non-parametric macro %zzz
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([string functions])
+RPMTEST_SETUP([string functions])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -696,7 +696,7 @@ bba
 RPMTEST_CLEANUP
 
 
-AT_SETUP([expr macro 1])
+RPMTEST_SETUP([expr macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -738,7 +738,7 @@ foo
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([expr macro 2])
+RPMTEST_SETUP([expr macro 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --eval '%{expr:"a"*1}'
@@ -772,7 +772,7 @@ error: types must match: 0 < 1 ? "a" : 2
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([ternary expressions])
+RPMTEST_SETUP([ternary expressions])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -802,7 +802,7 @@ rpm \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([expression macro level])
+RPMTEST_SETUP([expression macro level])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([[
 rpm \
@@ -839,7 +839,7 @@ bb the -r option was set
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([short circuiting])
+RPMTEST_SETUP([short circuiting])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -855,7 +855,7 @@ rpm \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([shell expansion])
+RPMTEST_SETUP([shell expansion])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -866,7 +866,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([expression expansion 1])
+RPMTEST_SETUP([expression expansion 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([[
 rpm \
@@ -894,7 +894,7 @@ rpm \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([expression expansion 2])
+RPMTEST_SETUP([expression expansion 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([[
 rpm --define "aaa hello" --eval '%[%aaa]'
@@ -918,7 +918,7 @@ error:                                          ^
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([expression version comparison])
+RPMTEST_SETUP([expression version comparison])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([[
 rpm \
@@ -936,7 +936,7 @@ rpm \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([simple lua --eval])
+RPMTEST_SETUP([simple lua --eval])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpm --eval '%{lua:print(5*5)}'
@@ -946,7 +946,7 @@ rpm --eval '%{lua:print(5*5)}'
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua glob])
+RPMTEST_SETUP([lua glob])
 RPMTEST_CHECK([
 mkdir -p aaa/{123,223,323,322,321}
 rpm --eval "%{lua:for i,p in ipairs(rpm.glob('aaa/3*')) do print(p..'\\n') end}"
@@ -963,7 +963,7 @@ aaa/b*
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua macro arguments])
+RPMTEST_SETUP([lua macro arguments])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
 rpm \
@@ -976,7 +976,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua macros table])
+RPMTEST_SETUP([lua macros table])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
 rpm \
@@ -1017,7 +1017,7 @@ rpm \
 ]])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua macros recursion])
+RPMTEST_SETUP([lua macros recursion])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
 rpm \
@@ -1029,7 +1029,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua rpm extensions 1])
+RPMTEST_SETUP([lua rpm extensions 1])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpm --eval '%{lua: rpm.define("foo bar") print(rpm.expand("%{foo}"))}'
@@ -1039,7 +1039,7 @@ rpm --eval '%{lua: rpm.define("foo bar") print(rpm.expand("%{foo}"))}'
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua rpm extensions 2])
+RPMTEST_SETUP([lua rpm extensions 2])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpm --eval '%{lua: print(rpm.vercmp("1.0", "2.0"))}'
@@ -1049,7 +1049,7 @@ rpm --eval '%{lua: print(rpm.vercmp("1.0", "2.0"))}'
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua rpm isdefined])
+RPMTEST_SETUP([lua rpm isdefined])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpm \
@@ -1064,7 +1064,7 @@ false	false
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua rpm split/unsplitargs])
+RPMTEST_SETUP([lua rpm split/unsplitargs])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
 rpm \
@@ -1076,7 +1076,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua posix extensions])
+RPMTEST_SETUP([lua posix extensions])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpm \
@@ -1087,7 +1087,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua script exit behavior])
+RPMTEST_SETUP([lua script exit behavior])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpm \
@@ -1099,7 +1099,7 @@ rpm \
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([lua script redirect2null])
+RPMTEST_SETUP([lua script redirect2null])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpm \
@@ -1112,7 +1112,7 @@ error: lua script failed: [[string "<lua>"]]:1: redirect2null not permitted in t
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([lua library path])
+RPMTEST_SETUP([lua library path])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1127,7 +1127,7 @@ rm -f ${RPMTEST}/${f}
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua auto-print])
+RPMTEST_SETUP([lua auto-print])
 AT_KEYWORDS([macros lua])
 RPMDB_INIT
 RPMTEST_CHECK([[
@@ -1142,7 +1142,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua rpm version objects])
+RPMTEST_SETUP([lua rpm version objects])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpm \
@@ -1159,7 +1159,7 @@ false	false	true	true
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua rpm io stream])
+RPMTEST_SETUP([lua rpm io stream])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1175,7 +1175,7 @@ gggg
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua functions in expressions])
+RPMTEST_SETUP([lua functions in expressions])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
 rpm \
@@ -1186,7 +1186,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua hooks])
+RPMTEST_SETUP([lua hooks])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([[
 rpm \
@@ -1203,7 +1203,7 @@ rpm.call("test", "foo", 6, 29 / 4)
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([%define + %undefine in nested levels 1])
+RPMTEST_SETUP([%define + %undefine in nested levels 1])
 AT_KEYWORDS([macros define undefine])
 RPMTEST_CHECK([
 # basic %define in nested scoping level
@@ -1218,7 +1218,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([%define + %undefine in nested levels 2])
+RPMTEST_SETUP([%define + %undefine in nested levels 2])
 AT_KEYWORDS([macros define])
 RPMTEST_CHECK([
 # %define macro once in a nested scope
@@ -1234,7 +1234,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([%define + %undefine in nested levels 3])
+RPMTEST_SETUP([%define + %undefine in nested levels 3])
 AT_KEYWORDS([macros define])
 RPMTEST_CHECK([
 # %define macro twice in a nested scope
@@ -1260,7 +1260,7 @@ rpm --define "aa 0" --define "my() %{define:aa 1}%{define:aa 2}" --eval "%my" --
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([%define + %undefine in nested levels 4])
+RPMTEST_SETUP([%define + %undefine in nested levels 4])
 AT_KEYWORDS([macros define global])
 RPMTEST_CHECK([
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
@@ -1282,7 +1282,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([%define in conditional macro])
+RPMTEST_SETUP([%define in conditional macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -1300,7 +1300,7 @@ bar
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([%verbose macro])
+RPMTEST_SETUP([%verbose macro])
 AT_KEYWORDS([macros verbose])
 RPMTEST_CHECK([
 rpm --eval '%{verbose}'
@@ -1316,7 +1316,7 @@ zzz
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([%exists macro])
+RPMTEST_SETUP([%exists macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -1332,7 +1332,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([%shescape macro])
+RPMTEST_SETUP([%shescape macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -1344,7 +1344,7 @@ rpm \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([%shescape macro with multiple arguments])
+RPMTEST_SETUP([%shescape macro with multiple arguments])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -1356,7 +1356,7 @@ rpm \
 [])
 
 RPMTEST_CLEANUP
-AT_SETUP([macro with a line starting by "{"])
+RPMTEST_SETUP([macro with a line starting by "{"])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --macros "/data/macros.testfile" \
@@ -1368,7 +1368,7 @@ macro_2
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([macro with %if-%endif])
+RPMTEST_SETUP([macro with %if-%endif])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpmspec -q --qf "%{summary}\n%{description}\n" /data/SPECS/iftest.spec
@@ -1380,7 +1380,7 @@ ccc1
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([macro file errors])
+RPMTEST_SETUP([macro file errors])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 cat << EOF > macros.bad
@@ -1404,7 +1404,7 @@ warning: macros.bad: line 8: Macro %bad needs whitespace before body
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([macro comments])
+RPMTEST_SETUP([macro comments])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -1423,7 +1423,7 @@ this
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([macro comments 2])
+RPMTEST_SETUP([macro comments 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -1438,7 +1438,7 @@ read
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([macro file empty lines])
+RPMTEST_SETUP([macro file empty lines])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm \
@@ -1455,7 +1455,7 @@ thing
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([macro traceback])
+RPMTEST_SETUP([macro traceback])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 for o in "-v" ""; do
@@ -1478,7 +1478,7 @@ error: bad
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([error macro return])
+RPMTEST_SETUP([error macro return])
 AT_KEYWORDS([macros lua])
 
 RPMTEST_CHECK([
@@ -1508,7 +1508,7 @@ error: lua script failed: [string "<lua>"]:1: error expanding macro
 ]])
 RPMTEST_CLEANUP
 
-AT_SETUP([no space left on stdout])
+RPMTEST_SETUP([no space left on stdout])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 rpm --eval 1 >/dev/full
@@ -1519,7 +1519,7 @@ rpm --eval 1 >/dev/full
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmlua])
+RPMTEST_SETUP([rpmlua])
 AT_KEYWORDS([lua])
 RPMTEST_INIT
 RPMTEST_CHECK([
@@ -1587,7 +1587,7 @@ warning: runaway fork() in Lua script
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([lua rpm spawn])
+RPMTEST_SETUP([lua rpm spawn])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
 rpmlua -e "rpm.spawn({'echo', '1', '2', '3'})"
@@ -1657,7 +1657,7 @@ rpmlua -e "rpm.spawn({'cat'}, {stdin='aaa'})"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmlua hooks])
+RPMTEST_SETUP([rpmlua hooks])
 AT_KEYWORDS([lua])
 
 RPMTEST_CHECK([

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -4,7 +4,7 @@ AT_BANNER([RPM macros])
 
 RPMTEST_SETUP([macro path])
 AT_KEYWORDS([macros])
-RPMDB_INIT
+RPMTEST_INIT
 
 # .rpmmacros exists, new directory not
 RPMTEST_CHECK([[
@@ -176,7 +176,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([parametrized macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 cat << EOF > mtest
 %bar() bar
 %foo()\\
@@ -355,7 +355,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([uncompress 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 echo xxxxxxxxxxxxxxxxxxxxxxxxx > "some%%ath"
 ${RPM_CONFIGDIR_PATH}/rpmuncompress "some%%ath"
 ],
@@ -404,7 +404,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([uncompress 4])
 AT_KEYWORDS([macros rpmuncompress])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other mkdir -p /tmp/1
@@ -1115,7 +1115,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([lua library path])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 f=$(rpm --eval "%{_rpmconfigdir}/lua/foo.lua")
 echo "bar = 'graak'" > ${RPMTEST}/${f}
 runroot rpm \
@@ -1129,7 +1129,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([lua auto-print])
 AT_KEYWORDS([macros lua])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([[
 rpm \
     --define 'foo() %{lua:return string.reverse(arg[1])}' \
@@ -1162,7 +1162,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([lua rpm io stream])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --eval '%{lua: local f = rpm.open("zzz", "w+"); f:write("gggg"); print(f:seek("cur")); f:close()}' \
   --eval '%{lua: local f = rpm.open("zzz"); print(f:read()); f:close()}' \

--- a/tests/rpmorder.at
+++ b/tests/rpmorder.at
@@ -1,6 +1,6 @@
 AT_BANNER([RPM install/erase ordering])
 
-AT_SETUP([basic install/erase order 1])
+RPMTEST_SETUP([basic install/erase order 1])
 AT_KEYWORDS([install erase order])
 RPMDB_INIT
 
@@ -47,7 +47,7 @@ deptest-three-1.0-1.noarch
 RPMTEST_CLEANUP
 
 # same as above but with mixed weak dependencies
-AT_SETUP([basic install/erase order 2])
+RPMTEST_SETUP([basic install/erase order 2])
 AT_KEYWORDS([install erase order])
 RPMDB_INIT
 
@@ -96,7 +96,7 @@ RPMTEST_CLEANUP
 # same as above but with all weak reverse dependencies
 # these are all considered meta by ordering, so order is simply reverse
 # of the cli
-AT_SETUP([basic install/erase order 3])
+RPMTEST_SETUP([basic install/erase order 3])
 AT_KEYWORDS([install erase order])
 RPMDB_INIT
 

--- a/tests/rpmorder.at
+++ b/tests/rpmorder.at
@@ -2,7 +2,7 @@ AT_BANNER([RPM install/erase ordering])
 
 RPMTEST_SETUP([basic install/erase order 1])
 AT_KEYWORDS([install erase order])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -49,7 +49,7 @@ RPMTEST_CLEANUP
 # same as above but with mixed weak dependencies
 RPMTEST_SETUP([basic install/erase order 2])
 AT_KEYWORDS([install erase order])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -98,7 +98,7 @@ RPMTEST_CLEANUP
 # of the cli
 RPMTEST_SETUP([basic install/erase order 3])
 AT_KEYWORDS([install erase order])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \

--- a/tests/rpmpgp.at
+++ b/tests/rpmpgp.at
@@ -3,7 +3,7 @@
 AT_BANNER([RPM OpenPGP parsing])
 
 # Test OpenPGP parsing
-AT_SETUP([[Running tests for malformed OpenPGP packages]])
+RPMTEST_SETUP([[Running tests for malformed OpenPGP packages]])
 AT_KEYWORDS([[rpmkeys digest OpenPGP]])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([[
@@ -12,7 +12,7 @@ rpmpgpcheck
 RPMTEST_CLEANUP
 
 # Test pgpPubkeyFingerprint
-AT_SETUP([[Running tests for computing OpenPGP fingerprints]])
+RPMTEST_SETUP([[Running tests for computing OpenPGP fingerprints]])
 AT_KEYWORDS([[rpmkeys digest OpenPGP]])
 AT_SKIP_IF([test x$PGP = xdummy])
 # Note: the internal OpenPGP parser produces a warning when fed

--- a/tests/rpmpkgfmt.at
+++ b/tests/rpmpkgfmt.at
@@ -1,4 +1,4 @@
-AT_SETUP([rpm v4 format])
+RPMTEST_SETUP([rpm v4 format])
 AT_KEYWORDS([rpmformat v4])
 RPMDB_INIT
 
@@ -23,7 +23,7 @@ rpm -qp --qf "%{rpmformat}\n" ${RPMTEST}/build/RPMS/4/noarch/attrtest-1.0-1.noar
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm v6 format])
+RPMTEST_SETUP([rpm v6 format])
 AT_KEYWORDS([rpmformat v6])
 RPMDB_INIT
 
@@ -48,7 +48,7 @@ rpm -qp --qf "%{rpmformat}\n" ${RPMTEST}/build/RPMS/6/noarch/attrtest-1.0-1.noar
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm v3 format])
+RPMTEST_SETUP([rpm v3 format])
 AT_KEYWORDS([rpmformat install query v3])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -100,7 +100,7 @@ rpm -qp --qf "%{rpmformat}\n" /data/RPMS/hello-1.0-1.x86_64.rpm-v3
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([invalid rpmformat])
+RPMTEST_SETUP([invalid rpmformat])
 AT_KEYWORDS([rpmformat build])
 
 RPMTEST_CHECK([

--- a/tests/rpmpkgfmt.at
+++ b/tests/rpmpkgfmt.at
@@ -1,6 +1,6 @@
 RPMTEST_SETUP([rpm v4 format])
 AT_KEYWORDS([rpmformat v4])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 cp /data/misc/rpmdump4.txt expout
@@ -25,7 +25,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm v6 format])
 AT_KEYWORDS([rpmformat v6])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 cp /data/misc/rpmdump6.txt expout
@@ -50,7 +50,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm v3 format])
 AT_KEYWORDS([rpmformat install query v3])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -qpl /data/RPMS/hello-1.0-1.x86_64.rpm-v3
 ],

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -446,7 +446,7 @@ ts.run(callback=ncb, data=cbd)
 
 RPMTEST_SETUP([database iterators])
 AT_KEYWORDS([python rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -i \
   --justdb --nodeps --ignorearch --ignoreos \
@@ -536,7 +536,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([database cookies])
 AT_KEYWORDS([python rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 ],
 [0],

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -217,7 +217,7 @@ myprint(h['arch'])
 [ppc64]
 )
 
-AT_SETUP([reading a signed package file])
+RPMTEST_SETUP([reading a signed package file])
 AT_KEYWORDS([python])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMPY_CHECK([
@@ -444,7 +444,7 @@ ts.run(callback=ncb, data=cbd)
 <class 'NoneType'> 64 6 1 mine]
 )
 
-AT_SETUP([database iterators])
+RPMTEST_SETUP([database iterators])
 AT_KEYWORDS([python rpmdb])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -534,7 +534,7 @@ hi
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([database cookies])
+RPMTEST_SETUP([database cookies])
 AT_KEYWORDS([python rpmdb])
 RPMDB_INIT
 RPMTEST_CHECK([

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -19,7 +19,7 @@
 AT_BANNER([RPM queries])
 
 # ------------------------------
-AT_SETUP([rpm --qf -p *.i386.rpm])
+RPMTEST_SETUP([rpm --qf -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -34,7 +34,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpm --qf -p *.src.rpm])
+RPMTEST_SETUP([rpm --qf -p *.src.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -49,7 +49,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpm -qp <glob>])
+RPMTEST_SETUP([rpm -qp <glob>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -63,7 +63,7 @@ hello-2.0-1.x86_64
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -qp <glob fallback>])
+RPMTEST_SETUP([rpm -qp <glob fallback>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -80,7 +80,7 @@ rpm \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -qp <notfound>])
+RPMTEST_SETUP([rpm -qp <notfound>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -97,7 +97,7 @@ error: open of /data/RPMS/hello-not-there-3.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -qp <glob notfound>])
+RPMTEST_SETUP([rpm -qp <glob notfound>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -115,7 +115,7 @@ error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file 
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpm -ql -p *.src.rpm])
+RPMTEST_SETUP([rpm -ql -p *.src.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -131,7 +131,7 @@ hello.spec
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpm -ql multiple *.rpm])
+RPMTEST_SETUP([rpm -ql multiple *.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -149,7 +149,7 @@ hello.spec
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -qp --dump])
+RPMTEST_SETUP([rpm -qp --dump])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -168,7 +168,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpmspec -q])
+RPMTEST_SETUP([rpmspec -q])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -181,7 +181,7 @@ rpmspec \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([rpm -ql -p *.i386.rpm])
+RPMTEST_SETUP([rpm -ql -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -199,7 +199,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test query on manifest
-AT_SETUP([rpm -qp <manifest>])
+RPMTEST_SETUP([rpm -qp <manifest>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -221,7 +221,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Try to check "scripts"
 # * Gets rpmpopt-$(VERSION) involved
-AT_SETUP([rpm -q --scripts -p *.i386.rpm])
+RPMTEST_SETUP([rpm -q --scripts -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -242,7 +242,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # install a package into a local rpmdb
 # * Use --ignorearch because we don't know the arch
-AT_SETUP([rpm -q on installed package])
+RPMTEST_SETUP([rpm -q on installed package])
 AT_KEYWORDS([rpmdb install query])
 
 RPMTEST_CHECK([
@@ -288,7 +288,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # query a package by a file
-AT_SETUP([rpm -qf])
+RPMTEST_SETUP([rpm -qf])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -305,7 +305,7 @@ runroot rpm \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -qf on non-installed file])
+RPMTEST_SETUP([rpm -qf on non-installed file])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -323,7 +323,7 @@ runroot rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -q --path on non-installed file])
+RPMTEST_SETUP([rpm -q --path on non-installed file])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -342,7 +342,7 @@ runroot rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([integer array query])
+RPMTEST_SETUP([integer array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -359,7 +359,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([formatted filesbypkg query])
+RPMTEST_SETUP([formatted filesbypkg query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -376,7 +376,7 @@ hello      /usr/share/doc/hello-1.0/FAQ
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([hex formatted integer array extension query])
+RPMTEST_SETUP([hex formatted integer array extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -393,7 +393,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([base64 extension query])
+RPMTEST_SETUP([base64 extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -407,7 +407,7 @@ runroot rpm \
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([pgpsig extension query])
+RPMTEST_SETUP([pgpsig extension query])
 AT_KEYWORDS([query signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -435,7 +435,7 @@ RSA/SHA256, Thu Apr  6 13:02:32 2017, Key ID 4344591e1964c5fc
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([integer array perms format query])
+RPMTEST_SETUP([integer array perms format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -452,7 +452,7 @@ drwxr-xr-x
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([string array query])
+RPMTEST_SETUP([string array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -466,7 +466,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([empty string array query])
+RPMTEST_SETUP([empty string array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -480,7 +480,7 @@ runroot rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([empty string array extension array format])
+RPMTEST_SETUP([empty string array extension array format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -494,7 +494,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([empty string array extension query])
+RPMTEST_SETUP([empty string array extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -508,7 +508,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([different sizes arrays query 1])
+RPMTEST_SETUP([different sizes arrays query 1])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -525,7 +525,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 # This is succeeds because there happens to be exactly one changelog entry
 # so the size matches with name.
-AT_SETUP([different sizes arrays query 2])
+RPMTEST_SETUP([different sizes arrays query 2])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -540,7 +540,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([different sizes arrays query 3])
+RPMTEST_SETUP([different sizes arrays query 3])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -555,7 +555,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([different sizes arrays query 4])
+RPMTEST_SETUP([different sizes arrays query 4])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -572,7 +572,7 @@ hello FAQ
 
 RPMTEST_CLEANUP
 # ------------------------------
-AT_SETUP([non-existent string tag])
+RPMTEST_SETUP([non-existent string tag])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -586,7 +586,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([non-existent integer tag query])
+RPMTEST_SETUP([non-existent integer tag query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -600,7 +600,7 @@ runroot rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([conditional queryformat])
+RPMTEST_SETUP([conditional queryformat])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -614,7 +614,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([invalid tag query])
+RPMTEST_SETUP([invalid tag query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -629,7 +629,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([invalid data for format query])
+RPMTEST_SETUP([invalid data for format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -643,7 +643,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([invalid format width query])
+RPMTEST_SETUP([invalid format width query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -657,7 +657,7 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([xml format])
+RPMTEST_SETUP([xml format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -957,7 +957,7 @@ rpm -qp --xml  /data/RPMS/hello-2.0-1.x86_64.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([json format 1])
+RPMTEST_SETUP([json format 1])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1196,7 +1196,7 @@ rpm -qp --json  /data/RPMS/hello-2.0-1.x86_64.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([json format 2])
+RPMTEST_SETUP([json format 2])
 AT_KEYWORDS([query])
 RPMDB_INIT
 runroot rpmbuild --quiet -bb /data/SPECS/weirdnames.spec
@@ -1219,7 +1219,7 @@ print(len(json.loads(s)))
 RPMTEST_CLEANUP
 
 
-AT_SETUP([query file attribute filtering])
+RPMTEST_SETUP([query file attribute filtering])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1274,7 +1274,7 @@ done
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([formatting name humansi, humaniec])
+RPMTEST_SETUP([formatting name humansi, humaniec])
 AT_KEYWORDS([query, humansi, humaniec])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1297,7 +1297,7 @@ rpm \
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([incomplete escape sequence for format query])
+RPMTEST_SETUP([incomplete escape sequence for format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -1312,7 +1312,7 @@ rpm \
 )
 RPMTEST_CLEANUP
 
-AT_SETUP([query format iteration])
+RPMTEST_SETUP([query format iteration])
 AT_KEYWORDS([query])
 RPMDB_INIT
 
@@ -1354,7 +1354,7 @@ Sourcepackage
 RPMTEST_CLEANUP
 
 # my autotest fu fails to deal with trailing whitespace except by trimming it
-AT_SETUP([file classes query])
+RPMTEST_SETUP([file classes query])
 AT_KEYWORDS([query])
 RPMDB_INIT
 RPMTEST_CHECK([[
@@ -1431,7 +1431,7 @@ rpmlib(PayloadIsZstd) <= 5.4.18-1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([info query output])
+RPMTEST_SETUP([info query output])
 AT_KEYWORDS([query signature])
 RPMTEST_CHECK([
 runroot rpm -qi --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -22,7 +22,7 @@ AT_BANNER([RPM queries])
 RPMTEST_SETUP([rpm --qf -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -q --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
   -p /data/RPMS/hello-2.0-1.i686.rpm
@@ -37,7 +37,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm --qf -p *.src.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -q --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
   -p /data/SRPMS/hello-1.0-1.src.rpm
@@ -52,7 +52,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <glob>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -qp "/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm"
 ],
@@ -66,7 +66,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <glob fallback>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "/data/RPMS/hello-1.0-1.i386.rpm" \
    "/tmp/fallback-[[123]].0-1.i386.rpm"
@@ -83,7 +83,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <notfound>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -qp /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
       /data/RPMS/hello-not-there-2.0-1.x86_64.rpm \
@@ -100,7 +100,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <glob notfound>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -qp "/data/RPMS/hello-not-there-*.x86_64.rpm" \
       /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
@@ -118,7 +118,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -ql -p *.src.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -ql \
   -p /data/SRPMS/hello-1.0-1.src.rpm
@@ -134,7 +134,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -ql multiple *.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -ql \
   /data/SRPMS/hello-1.0-1.src.rpm /data/RPMS/hello-1.0-1.i386.rpm
@@ -152,7 +152,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp --dump])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -qp --dump \
   /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -171,7 +171,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmspec -q])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpmspec \
   -q --qf "%{name}" /data/SPECS/hello.spec
 ],
@@ -184,7 +184,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -ql -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -ql \
   -p /data/RPMS/hello-1.0-1.i386.rpm
@@ -202,7 +202,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <manifest>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 cat << EOF > query.mft
 /data/RPMS/hello-1.0-1.i386.rpm
 /data/RPMS/hello-1.0-1.ppc64.rpm
@@ -224,7 +224,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -q --scripts -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   -q --scripts \
   -p /data/RPMS/hello-1.0-1.i386.rpm
@@ -246,7 +246,7 @@ RPMTEST_SETUP([rpm -q on installed package])
 AT_KEYWORDS([rpmdb install query])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm \
   --noscripts --nodeps --ignorearch \
@@ -291,7 +291,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qf])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   --nodeps \
   --ignorearch \
@@ -308,7 +308,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qf on non-installed file])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   --nodeps \
   --excludedocs \
@@ -326,7 +326,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -q --path on non-installed file])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   --nodeps \
   --excludedocs \
@@ -345,7 +345,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([integer array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%{filemodes}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -362,7 +362,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([formatted filesbypkg query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%-10{=NAME} %{FILENAMES}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -379,7 +379,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([hex formatted integer array extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%5{longfilesizes:hex}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -396,7 +396,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([base64 extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   --queryformat="%{pkgid:base64}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -411,7 +411,7 @@ RPMTEST_SETUP([pgpsig extension query])
 AT_KEYWORDS([query signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
     --queryformat="%{rsaheader:pgpsig}" \
     -qp /data/RPMS/hello-2.0-1.x86_64-signed.rpm
@@ -438,7 +438,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([integer array perms format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   --queryformat="[[%{filemodes:perms}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -455,7 +455,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([string array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%{basenames} ]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -469,7 +469,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([empty string array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   --queryformat="[[%{basenames}]]" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -483,7 +483,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([empty string array extension array format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%{filenames}]]" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -497,7 +497,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([empty string array extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="%{filenames}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -511,7 +511,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([different sizes arrays query 1])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%{basenames} %{changelogname}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -528,7 +528,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([different sizes arrays query 2])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%{name} %{changelogtime}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -543,7 +543,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([different sizes arrays query 3])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%{name} %{basenames}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -558,7 +558,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([different sizes arrays query 4])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="[[%{=name} %{basenames}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -575,7 +575,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([non-existent string tag])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="%{vendor}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -589,7 +589,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([non-existent integer tag query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm \
   --queryformat="%{installcolor}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -603,7 +603,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([conditional queryformat])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="%|name?{%{name}}:{no}| %|installtime?{%{installtime}}:{(not installed)}|" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -617,7 +617,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([invalid tag query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="%{notag}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -632,7 +632,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([invalid data for format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="%{name:depflags}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -646,7 +646,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([invalid format width query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat="%ss{size}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -660,7 +660,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([xml format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm -qp --xml  /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
@@ -960,7 +960,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([json format 1])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm -qp --json  /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
@@ -1198,7 +1198,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([json format 2])
 AT_KEYWORDS([query])
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpmbuild --quiet -bb /data/SPECS/weirdnames.spec
 
 RPMTEST_CHECK([
@@ -1222,7 +1222,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([query file attribute filtering])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpmbuild -bb --quiet \
   /data/SPECS/vattrtest.spec
 
@@ -1277,7 +1277,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([formatting name humansi, humaniec])
 AT_KEYWORDS([query, humansi, humaniec])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat '%{SIZE:humansi} %{SIZE:humaniec}\n' \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -1300,7 +1300,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([incomplete escape sequence for format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 rpm \
   --queryformat='%{NAME}\n\' \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -1314,7 +1314,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([query format iteration])
 AT_KEYWORDS([query])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 rpmspec -q --qf "[[%{*:tagnum}\n]]" --srpm /data/SPECS/mini.spec
@@ -1356,7 +1356,7 @@ RPMTEST_CLEANUP
 # my autotest fu fails to deal with trailing whitespace except by trimming it
 RPMTEST_SETUP([file classes query])
 AT_KEYWORDS([query])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([[
 # v4 packages
 runroot rpmbuild -bb --quiet \

--- a/tests/rpmreplace.at
+++ b/tests/rpmreplace.at
@@ -4,7 +4,7 @@ AT_BANNER([RPM file replacement])
 RPMTEST_SETUP([upgrade to/from regular file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
 
@@ -37,7 +37,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([upgrade regular file to/from link])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -53,7 +53,7 @@ runroot rpmbuild --quiet -bb \
 
 # upgrade regular file to/from broken link
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -72,7 +72,7 @@ foo
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -95,7 +95,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade broken link to broken link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -126,7 +126,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade file link to file link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -157,7 +157,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade directory link to directory link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -188,7 +188,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade regular file to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -217,7 +217,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade broken link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -246,7 +246,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade file link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -275,7 +275,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade directory link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -304,7 +304,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade empty directory to empty directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -330,7 +330,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade empty directory to regular file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -357,7 +357,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade locally symlinked directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -391,7 +391,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade invalid locally symlinked directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -420,7 +420,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([upgrade empty directory to broken link])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -435,7 +435,7 @@ runroot rpmbuild --quiet -bb \
 
 # upgrade empty directory to broken link
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -449,7 +449,7 @@ test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rp
 
 # upgrade empty directory to file link
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -464,7 +464,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([upgrade empty directory to file link])
 AT_KEYWORDS([install])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -479,7 +479,7 @@ runroot rpmbuild --quiet -bb \
 
 # upgrade removed empty directory to file link
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -494,7 +494,7 @@ readlink "${tf}"
 
 # upgrade replaced empty directory to file link
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -511,7 +511,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([upgrade empty directory to file link with pretrans])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 

--- a/tests/rpmreplace.at
+++ b/tests/rpmreplace.at
@@ -1,7 +1,7 @@
 
 AT_BANNER([RPM file replacement])
 
-AT_SETUP([upgrade to/from regular file])
+RPMTEST_SETUP([upgrade to/from regular file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -35,7 +35,7 @@ foo
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade regular file to/from link])
+RPMTEST_SETUP([upgrade regular file to/from link])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -92,7 +92,7 @@ foo
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade broken link to broken link])
+RPMTEST_SETUP([upgrade broken link to broken link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -123,7 +123,7 @@ stuff
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade file link to file link])
+RPMTEST_SETUP([upgrade file link to file link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -154,7 +154,7 @@ goo
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade directory link to directory link])
+RPMTEST_SETUP([upgrade directory link to directory link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -185,7 +185,7 @@ zoo
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade regular file to directory])
+RPMTEST_SETUP([upgrade regular file to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -214,7 +214,7 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade broken link to directory])
+RPMTEST_SETUP([upgrade broken link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -243,7 +243,7 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade file link to directory])
+RPMTEST_SETUP([upgrade file link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -272,7 +272,7 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade directory link to directory])
+RPMTEST_SETUP([upgrade directory link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -301,7 +301,7 @@ runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade empty directory to empty directory])
+RPMTEST_SETUP([upgrade empty directory to empty directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -327,7 +327,7 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade empty directory to regular file])
+RPMTEST_SETUP([upgrade empty directory to regular file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -354,7 +354,7 @@ test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rp
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade locally symlinked directory])
+RPMTEST_SETUP([upgrade locally symlinked directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -388,7 +388,7 @@ test -L "${tf}" && test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade invalid locally symlinked directory])
+RPMTEST_SETUP([upgrade invalid locally symlinked directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -418,7 +418,7 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade empty directory to broken link])
+RPMTEST_SETUP([upgrade empty directory to broken link])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -462,7 +462,7 @@ test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rp
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade empty directory to file link])
+RPMTEST_SETUP([upgrade empty directory to file link])
 AT_KEYWORDS([install])
 RPMDB_INIT
 
@@ -508,7 +508,7 @@ readlink "${tf}"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([upgrade empty directory to file link with pretrans])
+RPMTEST_SETUP([upgrade empty directory to file link with pretrans])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -4,7 +4,7 @@ AT_BANNER([RPM scriptlets])
 
 RPMTEST_SETUP([basic script failures 1])
 AT_KEYWORDS([script])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 for v in 1.0 2.0; do
@@ -231,7 +231,7 @@ RPMTEST_CLEANUP
 # 
 RPMTEST_SETUP([basic scripts and arguments])
 AT_KEYWORDS([verify script])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb --define "rel 1" /data/SPECS/scripts.spec
@@ -295,7 +295,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([basic trigger scripts: package args])
 AT_KEYWORDS([trigger script])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -366,7 +366,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([basic trigger scripts: runtime args])
 AT_KEYWORDS([trigger script])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb --define "rel 1" /data/SPECS/scripts.spec
@@ -441,7 +441,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([basic file trigger scripts])
 AT_KEYWORDS([filetrigger script])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -548,7 +548,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([basic file triggers: prefix args])
 AT_KEYWORDS([filetrigger script])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -682,7 +682,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([basic file triggers: runtime args])
 AT_KEYWORDS([filetrigger script])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 for v in 1.0 2.0 3.0; do
@@ -775,13 +775,13 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([script running environment])
 AT_KEYWORDS([script])
 AT_SKIP_IF([test ${HAVE_UNSHARE} = 0])
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpmbuild -bb --quiet \
 	/data/SPECS/fakeshell.spec \
 	/data/SPECS/scriptwrite.spec
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot_other rm -f /tmp/scriptwrite.log
 runroot rpm -U /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm /build/RPMS/noarch/scriptwrite-1.0-1.noarch.rpm
 runroot_other test -f /tmp/scriptwrite.log
@@ -791,7 +791,7 @@ runroot_other test -f /tmp/scriptwrite.log
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot_other rm -f /tmp/scriptwrite.log
 runroot rpm -U --noplugins /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm /build/RPMS/noarch/scriptwrite-1.0-1.noarch.rpm
 runroot_other test -f /tmp/scriptwrite.log
@@ -803,10 +803,11 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([deprecated Lua functions])
 AT_KEYWORDS([script lua])
+RPMTEST_INIT
 
 # binary pre-built on rpm 4.18 should emit no warnings
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 runroot rpm -U /data/RPMS/luafork-1.0-1.noarch.rpm
 ],
 [0],
@@ -815,7 +816,7 @@ runroot rpm -U /data/RPMS/luafork-1.0-1.noarch.rpm
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 runroot rpmbuild -bb --quiet /data/SPECS/luafork.spec
 runroot rpm -U /build/RPMS/noarch/luafork-1.0-1.noarch.rpm

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -2,7 +2,7 @@
 
 AT_BANNER([RPM scriptlets])
 
-AT_SETUP([basic script failures 1])
+RPMTEST_SETUP([basic script failures 1])
 AT_KEYWORDS([script])
 RPMDB_INIT
 
@@ -229,7 +229,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # 
-AT_SETUP([basic scripts and arguments])
+RPMTEST_SETUP([basic scripts and arguments])
 AT_KEYWORDS([verify script])
 RPMDB_INIT
 
@@ -293,7 +293,7 @@ scripts-1.0-2 POSTUNTRANS 0
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([basic trigger scripts: package args])
+RPMTEST_SETUP([basic trigger scripts: package args])
 AT_KEYWORDS([trigger script])
 RPMDB_INIT
 
@@ -364,7 +364,7 @@ triggers-1.0-1 TRIGGERUN 0 1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([basic trigger scripts: runtime args])
+RPMTEST_SETUP([basic trigger scripts: runtime args])
 AT_KEYWORDS([trigger script])
 RPMDB_INIT
 
@@ -439,7 +439,7 @@ scripts-1.0-2 POSTUNTRANS 0
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([basic file trigger scripts])
+RPMTEST_SETUP([basic file trigger scripts])
 AT_KEYWORDS([filetrigger script])
 RPMDB_INIT
 
@@ -546,7 +546,7 @@ transfiletriggerpostun(/foo*):
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([basic file triggers: prefix args])
+RPMTEST_SETUP([basic file triggers: prefix args])
 AT_KEYWORDS([filetrigger script])
 RPMDB_INIT
 
@@ -680,7 +680,7 @@ filetriggerun:
 
 RPMTEST_CLEANUP
 
-AT_SETUP([basic file triggers: runtime args])
+RPMTEST_SETUP([basic file triggers: runtime args])
 AT_KEYWORDS([filetrigger script])
 RPMDB_INIT
 
@@ -772,7 +772,7 @@ runroot rpm -e parallel-trigger
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([script running environment])
+RPMTEST_SETUP([script running environment])
 AT_KEYWORDS([script])
 AT_SKIP_IF([test ${HAVE_UNSHARE} = 0])
 RPMDB_INIT
@@ -801,7 +801,7 @@ runroot_other test -f /tmp/scriptwrite.log
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([deprecated Lua functions])
+RPMTEST_SETUP([deprecated Lua functions])
 AT_KEYWORDS([script lua])
 
 # binary pre-built on rpm 4.18 should emit no warnings

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -7,7 +7,7 @@ m4_define([RPMOUTPUT_SEQUOIA], [m4_if(RPM_PGP, [sequoia], [$1
 m4_define([RPMOUTPUT_LEGACY], [m4_if(RPM_PGP, [legacy], [$1
 ])])
 
-AT_SETUP([seen signer id tracking])
+RPMTEST_SETUP([seen signer id tracking])
 AT_KEYWORDS([query signature])
 RPMTEST_CHECK([
 # stderr redirected to stdout to test the exact order of output
@@ -33,7 +33,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built package verification
-AT_SETUP([rpmkeys -Kv <unsigned> 1])
+RPMTEST_SETUP([rpmkeys -Kv <unsigned> 1])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -59,7 +59,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-1.0-1.i386.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys key update and delete (rpmdb)])
+RPMTEST_SETUP([rpmkeys key update and delete (rpmdb)])
 AT_KEYWORDS([rpmkeys signature])
 RPMDB_INIT
 # currently the default but make it explicit
@@ -133,7 +133,7 @@ runroot rpm -qa gpg-pubkey
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys migrate from keyid to fingerprint (rpmdb)])
+RPMTEST_SETUP([rpmkeys migrate from keyid to fingerprint (rpmdb)])
 AT_KEYWORDS([rpmkeys rpmdb])
 RPMDB_INIT
 RPMTEST_CHECK([
@@ -160,7 +160,7 @@ runroot rpm -q --dbpath /data/misc/ gpg-pubkey
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys migrate from keyid to fingerprint (fs)])
+RPMTEST_SETUP([rpmkeys migrate from keyid to fingerprint (fs)])
 AT_KEYWORDS([rpmkeys rpmdb])
 RPMDB_INIT
 echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
@@ -194,7 +194,7 @@ runroot_other ls ${krpath}
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys key update (fs)])
+RPMTEST_SETUP([rpmkeys key update (fs)])
 AT_KEYWORDS([rpmkeys signature])
 RPMDB_INIT
 echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
@@ -261,7 +261,7 @@ runroot rpmkeys --list | wc -l
 RPMTEST_CLEANUP
 # ------------------------------
 # Test rpmkeys write errors
-AT_SETUP([[rpmkeys -K no space left on stdout]])
+RPMTEST_SETUP([[rpmkeys -K no space left on stdout]])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 RPMDB_INIT[
@@ -272,7 +272,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i38
 RPMTEST_CLEANUP
 
 
-AT_SETUP([rpmkeys key update (openpgp)])
+RPMTEST_SETUP([rpmkeys key update (openpgp)])
 AT_KEYWORDS([rpmkeys signature])
 RPMDB_INIT
 echo "%_keyring openpgp" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
@@ -364,7 +364,7 @@ runroot rpmkeys --list | wc -l
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys -Kv <reconstructed> 1])
+RPMTEST_SETUP([rpmkeys -Kv <reconstructed> 1])
 AT_KEYWORDS([rpmkeys digest])
 RPMDB_INIT
 
@@ -408,7 +408,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test corrupted package verification (corrupted md5 hash in signature)
-AT_SETUP([rpmkeys -Kv <corrupted unsigned> 1])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 1])
 AT_KEYWORDS([rpmkeys digest])
 RPMDB_INIT
 
@@ -442,7 +442,7 @@ runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/${pkg}
 RPMTEST_CLEANUP
 # ------------------------------
 # Test corrupted package verification (corrupted header)
-AT_SETUP([rpmkeys -Kv <corrupted unsigned> 2])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 2])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -465,7 +465,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test corrupted package verification (corrupted payload)
-AT_SETUP([rpmkeys -Kv <corrupted unsigned> 3])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 3])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -488,7 +488,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test corrupted package verification (corrupted header)
-AT_SETUP([rpmkeys -Kv <corrupted unsigned> 4])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 4])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -507,7 +507,7 @@ runroot rpmkeys -Kv /tmp/${pkg}
 RPMTEST_CLEANUP
 # ------------------------------
 # Reproducably build and verify a package
-AT_SETUP([rpmkeys -Kv <unsigned> 2])
+RPMTEST_SETUP([rpmkeys -Kv <unsigned> 2])
 AT_KEYWORDS([rpmkeys digest v4 v6])
 RPMDB_INIT
 RPMTEST_CHECK_PINNED([rpmsigdig])
@@ -523,7 +523,7 @@ RPMTEST_CLEANUP
 # is because a key's validity depends on the current time.  Thus, the
 # time to check for validity is when the key is used, not when it is
 # imported.
-AT_SETUP([rpmkeys --import rsa (rpmdb)])
+RPMTEST_SETUP([rpmkeys --import rsa (rpmdb)])
 AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -585,7 +585,7 @@ gpg(4344591e1964c5fc) = 4:771b18d3d7baa28734333c424344591e1964c5fc-58e63918
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys --import rsa (fs)])
+RPMTEST_SETUP([rpmkeys --import rsa (fs)])
 AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -633,7 +633,7 @@ RPMTEST_CLEANUP
 
 # -----------------------------------------
 # Check a package signed with a subkey
-AT_SETUP([rpmkeys --import, signed with a good subkey])
+RPMTEST_SETUP([rpmkeys --import, signed with a good subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -692,7 +692,7 @@ RPMTEST_CLEANUP
 
 # -----------------------------------------
 # Check a package signed with an expired subkey
-AT_SETUP([rpmkeys --import, signed with an expired subkey])
+RPMTEST_SETUP([rpmkeys --import, signed with an expired subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -765,7 +765,7 @@ RPMTEST_CLEANUP
 
 # -----------------------------------------
 # Check a package signed with a revoked subkey
-AT_SETUP([rpmkeys --import, signed with a revoked subkey])
+RPMTEST_SETUP([rpmkeys --import, signed with a revoked subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -832,7 +832,7 @@ Checking package after importing key, no signature:
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys --import invalid keys])
+RPMTEST_SETUP([rpmkeys --import invalid keys])
 AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -887,7 +887,7 @@ RPMTEST_CLEANUP
 # If the key is identified as gpg-pubkey-62837bea-62553ec1, then the
 # implementation is using the binding signature's creation time
 # instead of the key's creation time.
-AT_SETUP([rpmkeys --import different-creation-times])
+RPMTEST_SETUP([rpmkeys --import different-creation-times])
 AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -946,7 +946,7 @@ RPMTEST_CLEANUP
 # The internal OpenPGP parser rejects the key.  The Sequoia parser
 # just ignores the invalid components and imports the rest.  This test
 # checks the behavior of the internal parser.
-AT_SETUP([rpmkeys type confusion])
+RPMTEST_SETUP([rpmkeys type confusion])
 AT_SKIP_IF([test x$PGP != xlegacy])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -962,7 +962,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built package verification
-AT_SETUP([rpmkeys -K <signed> 1])
+RPMTEST_SETUP([rpmkeys -K <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -981,7 +981,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built package verification
-AT_SETUP([rpmkeys -Kv <signed> 1])
+RPMTEST_SETUP([rpmkeys -Kv <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -1045,7 +1045,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted signature)
-AT_SETUP([rpmkeys -Kv <corrupted signed> 1])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -1085,7 +1085,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted header)
-AT_SETUP([rpmkeys -Kv <corrupted signed> 2.1])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 2.1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -1120,7 +1120,7 @@ runroot rpmkeys -Kv /tmp/${pkg}
 RPMTEST_CLEANUP
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted header)
-AT_SETUP([rpmkeys -Kv <corrupted signed> 2.2])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 2.2])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -1156,7 +1156,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted payload)
-AT_SETUP([rpmkeys -Kv <corrupted signed> 3])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 3])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -1193,7 +1193,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted payload)
-AT_SETUP([rpmkeys -Kv <corrupted signed> 4])
+RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 4])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -1233,7 +1233,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test --addsign
-AT_SETUP([rpmsign --addsign])
+RPMTEST_SETUP([rpmsign --addsign])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -1401,7 +1401,7 @@ gpgconf --kill gpg-agent
 RPMTEST_CLEANUP
 
 # Signing test(s) using Sequoia
-AT_SETUP([rpmsign --addsign sequoia])
+RPMTEST_SETUP([rpmsign --addsign sequoia])
 AT_KEYWORDS([rpmsign sequoia signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -1461,7 +1461,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmsign --addsign multisig v4])
+RPMTEST_SETUP([rpmsign --addsign multisig v4])
 AT_KEYWORDS([rpmsign signature multisig v4])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -1571,7 +1571,7 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmsign --addsign multisig v6])
+RPMTEST_SETUP([rpmsign --addsign multisig v6])
 AT_KEYWORDS([rpmsign signature multisig v6])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -1652,7 +1652,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test --delsign
-AT_SETUP([rpmsign --delsign])
+RPMTEST_SETUP([rpmsign --delsign])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -1676,7 +1676,7 @@ POST-DELSIGN
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([without openpgp])
+RPMTEST_SETUP([without openpgp])
 AT_KEYWORDS([dummy])
 AT_SKIP_IF([test x$PGP != xdummy])
 RPMTEST_CHECK([
@@ -1700,7 +1700,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test ed25519 signature creation and verification
-AT_SETUP([Ed25519 signatures])
+RPMTEST_SETUP([Ed25519 signatures])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -1731,7 +1731,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test NIST p-256 signature creation and verification
-AT_SETUP([NIST P-256 signatures])
+RPMTEST_SETUP([NIST P-256 signatures])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -1762,7 +1762,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test key id collision
-AT_SETUP([key id collision])
+RPMTEST_SETUP([key id collision])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -1799,7 +1799,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test key id collision
-AT_SETUP([key id collision])
+RPMTEST_SETUP([key id collision])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMDB_INIT
@@ -1834,7 +1834,7 @@ POST-IMPORT
 gpgconf --kill gpg-agent
 RPMTEST_CLEANUP
 
-AT_SETUP([ima file signatures])
+RPMTEST_SETUP([ima file signatures])
 AT_KEYWORDS([rpmsign ima signature])
 AT_SKIP_IF([$IMA_DISABLED])
 
@@ -1900,7 +1900,7 @@ RPMTEST_CLEANUP
 # The installation should succeed in all cases, but whether setting the
 # IMA signature succeeds depends on container privileges - in rootless
 # we can't do this.
-AT_SETUP([install ima file signatures])
+RPMTEST_SETUP([install ima file signatures])
 AT_KEYWORDS([install ima signature])
 AT_SKIP_IF([$IMA_DISABLED])
 
@@ -1927,7 +1927,7 @@ runroot_other getfattr --absolute-names -d -m security.ima /usr/share/example1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([--delsign with misplaced ima signature])
+RPMTEST_SETUP([--delsign with misplaced ima signature])
 AT_KEYWORDS([rpmsign ima signature])
 RPMTEST_CHECK([
 cp /data/RPMS/hello-2.0-1.x86_64-badima.rpm .

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -61,7 +61,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys key update and delete (rpmdb)])
 AT_KEYWORDS([rpmkeys signature])
-RPMDB_INIT
+RPMTEST_INIT
 # currently the default but make it explicit
 echo "%_keyring rpmdb" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 RPMTEST_CHECK([
@@ -135,7 +135,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys migrate from keyid to fingerprint (rpmdb)])
 AT_KEYWORDS([rpmkeys rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -q --dbpath /data/misc/ gpg-pubkey
 ],
@@ -162,7 +162,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys migrate from keyid to fingerprint (fs)])
 AT_KEYWORDS([rpmkeys rpmdb])
-RPMDB_INIT
+RPMTEST_INIT
 echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 krpath="$(rpm --eval %{_keyringpath})"
 
@@ -196,7 +196,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys key update (fs)])
 AT_KEYWORDS([rpmkeys signature])
-RPMDB_INIT
+RPMTEST_INIT
 echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -264,7 +264,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([[rpmkeys -K no space left on stdout]])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMDB_INIT[
+RPMTEST_INIT[
 
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i386.rpm >/dev/full
 ]],255,,[[Error writing to log: No space left on device
@@ -274,7 +274,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys key update (openpgp)])
 AT_KEYWORDS([rpmkeys signature])
-RPMDB_INIT
+RPMTEST_INIT
 echo "%_keyring openpgp" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 krpath=$(rpm --eval "%{_keyringpath}")
 
@@ -366,7 +366,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys -Kv <reconstructed> 1])
 AT_KEYWORDS([rpmkeys digest])
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}"/data/misc/hello.intro "${RPMTEST}"/data/misc/hello.payload .
 gzip -cd < hello.payload > hello.uc-payload
@@ -410,7 +410,7 @@ RPMTEST_CLEANUP
 # Test corrupted package verification (corrupted md5 hash in signature)
 RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 1])
 AT_KEYWORDS([rpmkeys digest])
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -445,7 +445,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 2])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -468,7 +468,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 3])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -491,7 +491,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 4])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -509,7 +509,7 @@ RPMTEST_CLEANUP
 # Reproducably build and verify a package
 RPMTEST_SETUP([rpmkeys -Kv <unsigned> 2])
 AT_KEYWORDS([rpmkeys digest v4 v6])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK_PINNED([rpmsigdig])
 RPMTEST_CHECK_PINNED([rpmsigdig6])
 RPMTEST_CLEANUP
@@ -527,7 +527,7 @@ RPMTEST_SETUP([rpmkeys --import rsa (rpmdb)])
 AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmkeys \
 	--define "_keyring rpmdb" \
@@ -589,7 +589,7 @@ RPMTEST_SETUP([rpmkeys --import rsa (fs)])
 AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmkeys \
 	--define "_keyringpath /tmp/kr" \
@@ -637,7 +637,7 @@ RPMTEST_SETUP([rpmkeys --import, signed with a good subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm; echo $?
@@ -696,7 +696,7 @@ RPMTEST_SETUP([rpmkeys --import, signed with an expired subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm 2>&1; echo $?
@@ -769,7 +769,7 @@ RPMTEST_SETUP([rpmkeys --import, signed with a revoked subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm; echo $?
@@ -835,7 +835,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys --import invalid keys])
 AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 
 # The following certificates include subkeys with errors.  The internal
 # OpenPGP implementation rejects those keys at import time whereas
@@ -890,7 +890,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys --import different-creation-times])
 AT_KEYWORDS([rpmkeys import])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmkeys \
 	--define "_keyring rpmdb" \
@@ -949,7 +949,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys type confusion])
 AT_SKIP_IF([test x$PGP != xlegacy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmkeys --import /data/keys/type-confusion.asc
 ],
@@ -966,7 +966,7 @@ RPMTEST_SETUP([rpmkeys -K <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmkeys -K /data/RPMS/hello-2.0-1.x86_64-signed.rpm
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -985,7 +985,7 @@ RPMTEST_SETUP([rpmkeys -Kv <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm; echo $?
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo $?
@@ -1049,7 +1049,7 @@ RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1089,7 +1089,7 @@ RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 2.1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-v3-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1124,7 +1124,7 @@ RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 2.2])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1160,7 +1160,7 @@ RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 3])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1197,7 +1197,7 @@ RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 4])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT[(
+RPMTEST_INIT[(
 
 dorpm () {
     runroot rpmkeys --define '_pkgverify_level digest' \
@@ -1236,12 +1236,12 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmsign --addsign])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/rpm.org-rsa-2048-test.secret
 
 # rpmsign --addsign --rpmv3 <unsigned>
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 4344591E1964C5FC --rpmv3 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1270,7 +1270,7 @@ POST-DELSIGN
 
 # rpmsign --addsign <unsigned>
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1297,7 +1297,7 @@ POST-DELSIGN
 
 # test --delsign restores the old package bit-per-bit
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 ORIG="/data/RPMS/hello-2.0-1.x86_64.rpm"
 NEW="/tmp/hello-2.0-1.x86_64.rpm"
@@ -1333,7 +1333,7 @@ error: /gnus/not/here exec failed (1)
 
 # rpmsign --addsign <signed>
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64-signed.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64-signed.rpm 2>&1 |grep -q "already contains identical signature, skipping"
@@ -1346,7 +1346,7 @@ runroot rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign /tmp/he
 # This is behaves counter-intuitively / is buggy if md5 verification is
 # disabled, see https://github.com/rpm-software-management/rpm/issues/3291
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1373,7 +1373,7 @@ runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/hello-2.0-1.x86_64.rpm
 
 # rpmsign --addsign corrupted payload
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1404,7 +1404,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmsign --addsign sequoia])
 AT_KEYWORDS([rpmsign sequoia signature])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 cat << EOF >> ${HOME}/.config/rpm/macros
@@ -1464,7 +1464,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmsign --addsign multisig v4])
 AT_KEYWORDS([rpmsign signature multisig v4])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 cat << EOF >> ${HOME}/.config/rpm/macros
@@ -1574,7 +1574,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmsign --addsign multisig v6])
 AT_KEYWORDS([rpmsign signature multisig v6])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 
 RPMTEST_CHECK([
 cat << EOF >> ${HOME}/.config/rpm/macros
@@ -1656,7 +1656,7 @@ RPMTEST_SETUP([rpmsign --delsign])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64-signed.rpm "${RPMTEST}"/tmp/
 echo PRE-DELSIGN
@@ -1703,10 +1703,10 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([Ed25519 signatures])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/*.secret
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id B0645AEC757BF69E --digest-algo sha512 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1734,10 +1734,10 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([NIST P-256 signatures])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/*.secret
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 7f1c21f95f65bbe8 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1765,10 +1765,10 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([key id collision])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/keyidcollision1.asc
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 79cc07f167fee8841829acaa42655a75156b3de0 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1802,10 +1802,10 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([key id collision])
 AT_KEYWORDS([rpmsign signature])
 AT_SKIP_IF([test x$PGP = xdummy])
-RPMDB_INIT
+RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/keyidcollision2.asc
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 94706f8da571389e8642bdfd42655a75156b3de0 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1838,7 +1838,7 @@ AT_SETUP([ima file signatures])
 AT_KEYWORDS([rpmsign ima signature])
 AT_SKIP_IF([$IMA_DISABLED])
 
-RPMTEST_SETUP
+RPMTEST_INIT
 cp /data/RPMS/hello-2.0-1.x86_64.rpm /tmp/
 gpg2 --import /data/keys/rpm.org-rsa-2048-test.secret
 rpmsign --key-id 4344591E1964C5FC --addsign --signfiles --fskpath=/data/keys/privkey.pem /tmp/hello-2.0-1.x86_64.rpm
@@ -1904,7 +1904,7 @@ AT_SETUP([install ima file signatures])
 AT_KEYWORDS([install ima signature])
 AT_SKIP_IF([$IMA_DISABLED])
 
-RPMTEST_SETUP
+RPMTEST_INIT
 
 cat << EOF > expout
 # file: /usr/share/example1

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -9,7 +9,7 @@
 
 AT_BANNER([RPM Spec Tool])
 
-AT_SETUP([rpmspec --query Requires])
+RPMTEST_SETUP([rpmspec --query Requires])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -34,7 +34,7 @@ good.9.1 22
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(,)])
+RPMTEST_SETUP([rpmspec --query Requires(,)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -49,7 +49,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(;)])
+RPMTEST_SETUP([rpmspec --query Requires(;)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -64,7 +64,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(junk)])
+RPMTEST_SETUP([rpmspec --query Requires(junk)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -79,7 +79,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(pre,junk)])
+RPMTEST_SETUP([rpmspec --query Requires(pre,junk)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -94,7 +94,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(junk,pre)])
+RPMTEST_SETUP([rpmspec --query Requires(junk,pre)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -109,7 +109,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(,pre)])
+RPMTEST_SETUP([rpmspec --query Requires(,pre)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -124,7 +124,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(pre,)])
+RPMTEST_SETUP([rpmspec --query Requires(pre,)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -139,7 +139,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(pre,,postun)])
+RPMTEST_SETUP([rpmspec --query Requires(pre,,postun)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -154,7 +154,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(pre,,junk)])
+RPMTEST_SETUP([rpmspec --query Requires(pre,,junk)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -169,7 +169,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(;pre)])
+RPMTEST_SETUP([rpmspec --query Requires(;pre)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -184,7 +184,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(pre;)])
+RPMTEST_SETUP([rpmspec --query Requires(pre;)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -199,7 +199,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(pre;postun)])
+RPMTEST_SETUP([rpmspec --query Requires(pre;postun)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -214,7 +214,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --query Requires(pre;junk)])
+RPMTEST_SETUP([rpmspec --query Requires(pre;junk)])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([[
 rpmspec --query \
@@ -229,7 +229,7 @@ error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --parse])
+RPMTEST_SETUP([rpmspec --parse])
 AT_KEYWORDS([rpmspec])
 RPMTEST_CHECK([rpmspec --parse /data/SPECS/foo.spec],
 [0],
@@ -270,7 +270,7 @@ foo
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --srpm provides])
+RPMTEST_SETUP([rpmspec --srpm provides])
 AT_KEYWORDS([rpmspec])
 RPMTEST_CHECK([
 rpmspec -q --srpm --provides /data/SPECS/foo.spec
@@ -286,7 +286,7 @@ foo-bus = 1.0-1
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec --parse])
+RPMTEST_SETUP([rpmspec --parse])
 AT_KEYWORDS([rpmspec])
 RPMTEST_CHECK([
 RPMTEST_INIT
@@ -360,7 +360,7 @@ make DESTDIR=$RPM_BUILD_ROOT install
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmspec -q --rpms and --srpm])
+RPMTEST_SETUP([rpmspec -q --rpms and --srpm])
 AT_KEYWORDS([rpmspec query])
 RPMTEST_CHECK([
 rpmspec -q --rpms --target s390x \

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -289,7 +289,7 @@ RPMTEST_CLEANUP
 AT_SETUP([rpmspec --parse])
 AT_KEYWORDS([rpmspec])
 RPMTEST_CHECK([
-RPMTEST_SETUP
+RPMTEST_INIT
 
 # ensure the macros expand to expected values
 # debug packages disabled for simplicity, we're not testing for that here

--- a/tests/rpmvercmp.at
+++ b/tests/rpmvercmp.at
@@ -6,7 +6,7 @@ rpm --eval '%{lua: print(rpm.vercmp("$1", "$2"))}'], [0], [$3
 ], [])
 ])
 
-AT_SETUP([rpm version comparison])
+RPMTEST_SETUP([rpm version comparison])
 AT_KEYWORDS([vercmp])
 
 RPMVERCMP(1.0, 1.0, 0)

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -7,7 +7,7 @@ AT_BANNER([RPM verification])
 RPMTEST_SETUP([dependency problems])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -30,7 +30,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([files with no problems])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -45,7 +45,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([files with no problems in verbose mode])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -65,7 +65,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([directory replaced with a directory symlink])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -95,7 +95,7 @@ RPMTEST_SETUP([directory replaced with an invalid directory symlink])
 AT_KEYWORDS([verify])
 AT_SKIP_IF([test `id -u` != 0 ])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -124,7 +124,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([verify from db, with problems present])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -145,7 +145,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([verify from package, with problems present])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -165,7 +165,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([verify file attribute filtering])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
   /data/SPECS/vattrtest.spec
@@ -223,7 +223,7 @@ RPMTEST_CLEANUP
 # Test verify script success & failure behavior
 RPMTEST_SETUP([verifyscript])
 AT_KEYWORDS([verify])
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/verifyscript.spec
 runroot rpm -U --nodeps /build/RPMS/noarch/verifyscript-1.0-1.noarch.rpm
@@ -251,7 +251,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([shared file timestamp behavior])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 # create packages sharing a file but with different timestamp
 for p in "one" "two"; do
@@ -276,7 +276,7 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP([minimize writes (files)])
 AT_KEYWORDS([upgrade verify min_writes])
-RPMDB_INIT
+RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -295,7 +295,7 @@ for v in "3.0" "4.0"; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}"*
 
@@ -343,7 +343,7 @@ fox
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}"*
 
@@ -401,12 +401,12 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([minimize writes (hardlinks)])
 AT_KEYWORDS([upgrade verify min_writes])
-RPMDB_INIT
+RPMTEST_INIT
 for v in "0" "1"; do
     runroot rpmbuild --quiet -bb --define "ver ${v}" /data/SPECS/hlbreak.spec
 done
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 runroot rpm -U --define "_minimize_writes 1" /build/RPMS/noarch/hlbreak-0-0.noarch.rpm
 runroot rpm -Vav ${VERIFYOPTS}
 runroot rpm -U --define "_minimize_writes 1" /build/RPMS/noarch/hlbreak-1-0.noarch.rpm
@@ -423,7 +423,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([minimize writes (symlinks)])
 AT_KEYWORDS([upgrade verify min_writes])
-RPMDB_INIT
+RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -441,7 +441,7 @@ for v in "3.0" "4.0"; do
 done
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}"*
 
@@ -486,7 +486,7 @@ fox
 [])
 
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMDB_RESET
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
 
@@ -542,7 +542,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([minimize writes (SUID files)])
 AT_KEYWORDS([upgrade verify min_writes])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
 
@@ -577,7 +577,7 @@ RPMTEST_SETUP([verify empty/no capabilities 1])
 AT_KEYWORDS([verify])
 AT_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --nocaps --ignoreos \
 	/data/RPMS/capstest-1.0-1.noarch.rpm
@@ -596,7 +596,7 @@ RPMTEST_SETUP([verify empty/no capabilities 2])
 AT_KEYWORDS([verify])
 AT_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --nocaps --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -611,7 +611,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm --restore])
 AT_KEYWORDS([verify restore])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -631,7 +631,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([test for %verify in %files])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/verifyfiles.spec
 runroot rpm -i /build/RPMS/noarch/verifyfiles-1.0-1.noarch.rpm

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -4,7 +4,7 @@ AT_BANNER([RPM verification])
 
 # ------------------------------
 # 
-AT_SETUP([dependency problems])
+RPMTEST_SETUP([dependency problems])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -27,7 +27,7 @@ RPMTEST_CLEANUP
 # Test file verify when no errors expected.
 # Ignore dependencies here as we're not testing for them, and
 # --nogroup --nouser is required when running tests as non-root.
-AT_SETUP([files with no problems])
+RPMTEST_SETUP([files with no problems])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -42,7 +42,7 @@ runroot rpm -Va --nodeps ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 # Test file verify when no errors expected in verbose mode.
-AT_SETUP([files with no problems in verbose mode])
+RPMTEST_SETUP([files with no problems in verbose mode])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -62,7 +62,7 @@ runroot rpm -Vva --nodeps ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 # Test file verify when no errors expected in verbose mode.
-AT_SETUP([directory replaced with a directory symlink])
+RPMTEST_SETUP([directory replaced with a directory symlink])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -91,7 +91,7 @@ runroot rpm -Vv replacetest
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([directory replaced with an invalid directory symlink])
+RPMTEST_SETUP([directory replaced with an invalid directory symlink])
 AT_KEYWORDS([verify])
 AT_SKIP_IF([test `id -u` != 0 ])
 RPMTEST_CHECK([
@@ -121,7 +121,7 @@ runroot rpm -Vv replacetest
 RPMTEST_CLEANUP
 
 # Test file verify after mutilating the files a bit.
-AT_SETUP([verify from db, with problems present])
+RPMTEST_SETUP([verify from db, with problems present])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -142,7 +142,7 @@ missing   d /usr/share/doc/hello-2.0/FAQ
 RPMTEST_CLEANUP
 
 # Test file verify from original package after mutilating the files a bit.
-AT_SETUP([verify from package, with problems present])
+RPMTEST_SETUP([verify from package, with problems present])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -162,7 +162,7 @@ missing   d /usr/share/doc/hello-2.0/FAQ
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([verify file attribute filtering])
+RPMTEST_SETUP([verify file attribute filtering])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -221,7 +221,7 @@ done
 RPMTEST_CLEANUP
 
 # Test verify script success & failure behavior
-AT_SETUP([verifyscript])
+RPMTEST_SETUP([verifyscript])
 AT_KEYWORDS([verify])
 RPMDB_INIT
 
@@ -248,7 +248,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # shared file timestamp behavior
-AT_SETUP([shared file timestamp behavior])
+RPMTEST_SETUP([shared file timestamp behavior])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -274,7 +274,7 @@ runroot rpm -Va ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 # ------------------------------
-AT_SETUP([minimize writes (files)])
+RPMTEST_SETUP([minimize writes (files)])
 AT_KEYWORDS([upgrade verify min_writes])
 RPMDB_INIT
 
@@ -399,7 +399,7 @@ fox
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([minimize writes (hardlinks)])
+RPMTEST_SETUP([minimize writes (hardlinks)])
 AT_KEYWORDS([upgrade verify min_writes])
 RPMDB_INIT
 for v in "0" "1"; do
@@ -421,7 +421,7 @@ runroot rpm -Vav ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 
-AT_SETUP([minimize writes (symlinks)])
+RPMTEST_SETUP([minimize writes (symlinks)])
 AT_KEYWORDS([upgrade verify min_writes])
 RPMDB_INIT
 for v in "1.0" "2.0"; do
@@ -539,7 +539,7 @@ fox
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([minimize writes (SUID files)])
+RPMTEST_SETUP([minimize writes (SUID files)])
 AT_KEYWORDS([upgrade verify min_writes])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -573,7 +573,7 @@ runroot rpm -V ${VERIFYOPTS} replacetest
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([verify empty/no capabilities 1])
+RPMTEST_SETUP([verify empty/no capabilities 1])
 AT_KEYWORDS([verify])
 AT_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
@@ -592,7 +592,7 @@ runroot rpm -Va ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 
-AT_SETUP([verify empty/no capabilities 2])
+RPMTEST_SETUP([verify empty/no capabilities 2])
 AT_KEYWORDS([verify])
 AT_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
@@ -608,7 +608,7 @@ runroot rpm -Va ${VERIFYOPTS} --nodeps | grep "/bin/hello"
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm --restore])
+RPMTEST_SETUP([rpm --restore])
 AT_KEYWORDS([verify restore])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -628,7 +628,7 @@ runroot rpm -Va --nodeps ${VERIFYOPTS}
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([test for %verify in %files])
+RPMTEST_SETUP([test for %verify in %files])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 RPMDB_INIT

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -3,7 +3,7 @@ AT_BANNER([RPM signature/digest verifylevel])
 RPMTEST_SETUP([rpmkeys -K <unsigned 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 for lvl in none digest signature all; do
     echo "LEVEL ${lvl}"
@@ -75,7 +75,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys -K <unsigned 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 nomd5="0x20000"
 nopld="0x10000"
@@ -147,7 +147,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys -K <signed 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 for lvl in none digest signature all; do
     echo "LEVEL ${lvl}"
@@ -220,7 +220,7 @@ RPMTEST_SETUP([rpmkeys -K <signed 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 for lvl in none digest signature all; do
@@ -294,7 +294,7 @@ RPMTEST_SETUP([rpmkeys -K <signed 3> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMDB_INIT
+RPMTEST_INIT
 
 nomd5="0x20000"
 nopld="0x10000"

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -1,6 +1,6 @@
 AT_BANNER([RPM signature/digest verifylevel])
 
-AT_SETUP([rpmkeys -K <unsigned 1> verifylevel])
+RPMTEST_SETUP([rpmkeys -K <unsigned 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -72,7 +72,7 @@ LEVEL all
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys -K <unsigned 2> verifylevel])
+RPMTEST_SETUP([rpmkeys -K <unsigned 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -144,7 +144,7 @@ nohdr
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys -K <signed 1> verifylevel])
+RPMTEST_SETUP([rpmkeys -K <signed 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 RPMDB_INIT
@@ -216,7 +216,7 @@ LEVEL all
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys -K <signed 2> verifylevel])
+RPMTEST_SETUP([rpmkeys -K <signed 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
@@ -290,7 +290,7 @@ LEVEL all
 [])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpmkeys -K <signed 3> verifylevel])
+RPMTEST_SETUP([rpmkeys -K <signed 3> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([


### PR DESCRIPTION
More details in commits but addressing various items from #2773:
- rename RPMTEST_SETUP to RPMTEST_INIT to free the name
- introduce RPMTEST_SETUP as a wrapper to AT_SETUP and use it everywhere, to pair with RPMTEST_CLEANUP and gives a central place to control rpm-specifics of test setup
- remove now redundant rpmdb reinitializations from the test by making rpmdb reset explicitly called when absolutely needed

Besides making for more consistent names and allowing future consolidation, gives a nice speed boost (from 2m 50s to 2m 20s on my laptop)
