### PR TITLE
Check not configured keystore backends for keys

### DIFF
--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -38,6 +38,14 @@ rpmKeyring rpmKeyringNew(void);
 rpmKeyring rpmKeyringFree(rpmKeyring keyring);
 
 /** \ingroup rpmkeyring
+ * Get number of primary keys
+ * @param keyring	keyring handle
+ * @param count_subkeys	0 for primary keys only, 1 for all
+ * @return		Number of primary keys in the keyring
+ */
+size_t rpmKeyringSize(rpmKeyring keyring, int count_subkeys);
+
+/** \ingroup rpmkeyring
  * Add a public key to keyring.
  * @param keyring	keyring handle
  * @param key		pubkey handle

--- a/lib/keystore.hh
+++ b/lib/keystore.hh
@@ -10,11 +10,13 @@ namespace rpm {
 
 class keystore {
 public:
+    const std::string name;
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring) = 0;
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0) = 0;
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key) = 0;
 
     virtual ~keystore() = default;
+    keystore(std::string n): name(n) {};
 };
 
 class keystore_fs : public keystore {
@@ -22,7 +24,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
-
+    keystore_fs(): keystore("fs") {};
 private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, const std::string & newname = "");
 };
@@ -32,7 +34,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
-
+    keystore_rpmdb(): keystore("rpmdb") {};
 private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, unsigned int newinstance = 0);
 };
@@ -42,6 +44,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
+    keystore_openpgp_cert_d(): keystore("openpgp") {};
 };
 
 }; /* namespace */

--- a/rpmio/rpmkeyring.cc
+++ b/rpmio/rpmkeyring.cc
@@ -71,6 +71,19 @@ rpmKeyring rpmKeyringFree(rpmKeyring keyring)
     return NULL;
 }
 
+size_t rpmKeyringSize(rpmKeyring keyring, int count_subkeys)
+{
+    if (!keyring) return 0;
+    rdlock lock(keyring->mutex);
+
+    size_t size = 0;
+    for (auto &pair : keyring->keys) {
+	if (count_subkeys or !pair.second->primarykey)
+	    size++;
+    }
+    return size;
+}
+
 rpmKeyringIterator rpmKeyringInitIterator(rpmKeyring keyring, int unused)
 {
     if (!keyring || unused != 0)


### PR DESCRIPTION
Give an warning if they contain public keys. This allows the user to
detect misconfigurations or missing conversion from one backend to
another.

The warning will need adjusting to point the user to the rebuild functionality to do the actual fixing. But this should be done in the PR adding that. 

The test case needs to be adjusted as part of #3535 or after it being merged.

Split out of #3474