### PR TITLE
Eliminate the need for explicit RPMTEST_INIT

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -138,6 +138,7 @@ as well as the existing tests.  Below are the specifics of RPM's test-suite:
 * Use `RPMTEST_SETUP` instead of `AT_SETUP`
 * Use `RPMTEST_CHECK` instead of `AT_CHECK`
 * Use `RPMTEST_CLEANUP` instead of `AT_CLEANUP`
+* Use `RPMTEST_SKIP_IF` instead of `AT_SKIP_IF`
 * Use `RPMTEST_INIT` to create a mutable snapshot (optional)
     * The absolute path to the snapshot's root is stored in the `$RPMTEST`
       environment variable, modify the directory tree as you wish

--- a/tests/README.md
+++ b/tests/README.md
@@ -135,11 +135,11 @@ For the typical structure of a single test, consult GNU Autotest's
 [documentation](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/autoconf.html#Writing-Testsuites)
 as well as the existing tests.  Below are the specifics of RPM's test-suite:
 
-* Use `RPMTEST_SETUP` instead of `AT_SETUP`
-* Use `RPMTEST_CHECK` instead of `AT_CHECK`
-* Use `RPMTEST_CLEANUP` instead of `AT_CLEANUP`
-* Use `RPMTEST_SKIP_IF` instead of `AT_SKIP_IF`
-* Use `RPMTEST_INIT` to create a mutable snapshot (optional)
+* Use `RPMTEST_SETUP` instead of `AT_SETUP` to setup a test in an immutable
+  system image with writable `.` and `/tmp`.
+* Use `RPMTEST_SETUP_RW` instead of `AT_SETUP` to prepare the use of a mutable
+  snapshot of the system image. To be used when the test needs to modify
+  the system image itself - to install a package, import keys and so on.
     * The absolute path to the snapshot's root is stored in the `$RPMTEST`
       environment variable, modify the directory tree as you wish
     * To run RPM inside the snapshot, use the `runroot` prefix, e.g. `runroot
@@ -149,6 +149,11 @@ as well as the existing tests.  Below are the specifics of RPM's test-suite:
       environment with only a handful of variables preset.  To pass your own
       variable(s), use `--setenv` (once for each variable), e.g. `runroot
       --setenv FOO "foo" rpm ...`
+    * Due to historical reasons, a mutable snapshot is currently needed for
+      merely building packages as well.
+* Use `RPMTEST_CHECK` instead of `AT_CHECK`
+* Use `RPMTEST_CLEANUP` instead of `AT_CLEANUP`
+* Use `RPMTEST_SKIP_IF` instead of `AT_SKIP_IF`
 * Use `RPMTEST_USER` to create a regular UNIX user in a mutable snapshot
     * The username is stored in the `$RPMUSER` environment variable
     * To run a binary as `$RPMUSER` inside the snapshot, use `runroot_user`
@@ -157,6 +162,8 @@ as well as the existing tests.  Below are the specifics of RPM's test-suite:
       to the macro, e.g. `RPMTEST_USER([user1, user2])`.  Then, use
       `runroot_user -n <name>` to run a binary as a specific user
 * Use `RPMDB_RESET` to reinitialize a snapshot to an empty rpmdb (avoid this)
+* Use `RPMTEST_SNAPSHOT_MOUNT` create a mutable snapshot inside an immutable
+  test (not normally needed, use RPMTEST_SETUP_RW instead)
 * If no snapshot was used, just call the RPM binaries normally
 * Store any working files in the current directory (it's always writable)
 

--- a/tests/local.at
+++ b/tests/local.at
@@ -4,6 +4,11 @@ m4_define([RPMTEST_SETUP],[
 AT_SETUP($1)
 ])
 
+m4_define([RPMTEST_SETUP_RW],[
+RPMTEST_SETUP($1)
+RPMTEST_SNAPSHOT_MOUNT
+])
+
 m4_define([RPMTEST_SNAPSHOT_MOUNT],[[
 export RPMTEST="${PWD}/tree"
 export HOME="${RPMTEST}/root"
@@ -18,10 +23,6 @@ if [ -d "$RPMTEST" ]; then
     snapshot umount
 fi
 ]])
-
-m4_define([RPMTEST_INIT],[
-RPMTEST_SNAPSHOT_MOUNT
-])
 
 m4_define([RPMDB_RESET],[
 rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`
@@ -46,7 +47,13 @@ LD_PRELOAD=${ASANLIB} ASAN_OPTIONS=detect_leaks=0 ${PYTHON} test.py
 ]])
 
 m4_define([RPMTEST_SKIP_IF],[
-AT_SKIP_IF($1)
+AT_CHECK([
+if $1; then
+    RPMTEST_SNAPSHOT_UMOUNT
+    # autotest's documented "skip this" code
+    exit 77
+fi
+])
 ])
 
 m4_define([RPMTEST_CHECK],[
@@ -73,7 +80,7 @@ RPMTEST_CHECK_UNQUOTED(
 ])
 
 m4_define([RPMPY_CHECK],[
-RPMTEST_SKIP_IF([$PYTHON_DISABLED])
+AT_SKIP_IF([$PYTHON_DISABLED])
 RPMTEST_CHECK([RPMPY_RUN([$1])], [], [$2], [$3])
 ])
 
@@ -86,7 +93,6 @@ RPMTEST_CLEANUP
 ])
 
 m4_define([RPMTEST_USER],[
-RPMTEST_INIT
 [[ $# != 0 ]] && export RPMUSER=$1
 useradd -m -R $RPMTEST $RPMUSER
 ])

--- a/tests/local.at
+++ b/tests/local.at
@@ -14,7 +14,9 @@ m4_define([RPMTEST_SNAPSHOT_UMOUNT],[[
 # Make sure we unmount RPMTEST even if it was mounted (and thus the variable
 # exported) in an RPMTEST_CHECK subshell, by setting RPMTEST explicitly here.
 export RPMTEST="${PWD}/tree"
-snapshot umount
+if [ -d "$RPMTEST" ]; then
+    snapshot umount
+fi
 ]])
 
 m4_define([RPMTEST_INIT],[

--- a/tests/local.at
+++ b/tests/local.at
@@ -4,11 +4,22 @@ m4_define([RPMTEST_SETUP],[
 AT_SETUP($1)
 ])
 
-m4_define([RPMTEST_INIT],[[
+m4_define([RPMTEST_SNAPSHOT_MOUNT],[[
 export RPMTEST="${PWD}/tree"
 export HOME="${RPMTEST}/root"
 [ -d "$RPMTEST" ] || snapshot mount "${PWD}"
 ]])
+
+m4_define([RPMTEST_SNAPSHOT_UMOUNT],[[
+# Make sure we unmount RPMTEST even if it was mounted (and thus the variable
+# exported) in an RPMTEST_CHECK subshell, by setting RPMTEST explicitly here.
+export RPMTEST="${PWD}/tree"
+snapshot umount
+]])
+
+m4_define([RPMTEST_INIT],[
+RPMTEST_SNAPSHOT_MOUNT
+])
 
 m4_define([RPMDB_RESET],[
 rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`
@@ -47,10 +58,7 @@ AT_CHECK_UNQUOTED($@)
 ])
 
 m4_define([RPMTEST_CLEANUP],[
-# Make sure we unmount RPMTEST even if it was mounted (and thus the variable
-# exported) in an RPMTEST_CHECK subshell, by setting RPMTEST explicitly here.
-export RPMTEST="${PWD}/tree"
-snapshot umount
+RPMTEST_SNAPSHOT_UMOUNT
 AT_CLEANUP
 ])
 

--- a/tests/local.at
+++ b/tests/local.at
@@ -32,6 +32,10 @@ EOF
 LD_PRELOAD=${ASANLIB} ASAN_OPTIONS=detect_leaks=0 ${PYTHON} test.py
 ]])
 
+m4_define([RPMTEST_SKIP_IF],[
+AT_SKIP_IF($1)
+])
+
 m4_define([RPMTEST_CHECK],[
 setup_env
 AT_CHECK($@)
@@ -59,7 +63,7 @@ RPMTEST_CHECK_UNQUOTED(
 ])
 
 m4_define([RPMPY_CHECK],[
-AT_SKIP_IF([$PYTHON_DISABLED])
+RPMTEST_SKIP_IF([$PYTHON_DISABLED])
 RPMTEST_CHECK([RPMPY_RUN([$1])], [], [$2], [$3])
 ])
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -20,9 +20,8 @@ AT_BANNER([RPM build])
 
 # ------------------------------
 # Check if rpmbuild -ba *.spec works
-RPMTEST_SETUP([rpmbuild -ba *.spec])
+RPMTEST_SETUP_RW([rpmbuild -ba *.spec])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -63,9 +62,8 @@ Iam
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -bs spec])
+RPMTEST_SETUP_RW([rpmbuild -bs spec])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild -bs \
@@ -94,9 +92,8 @@ runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-1.0-1.src.rpm
 
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -b buildsystem])
+RPMTEST_SETUP_RW([rpmbuild -b buildsystem])
 AT_KEYWORDS([build buildsystem])
-RPMTEST_INIT
 
 cp "${RPMTEST}/data/macros.buildsystem" "${RPMTEST}/${RPM_CONFIGDIR_PATH}/macros.d/"
 
@@ -211,9 +208,8 @@ runroot rpmspec -q --qf "%{nvr}\n" /data/SPECS/amhello.spec
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -b steps])
+RPMTEST_SETUP_RW([rpmbuild -b steps])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bp /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
@@ -325,9 +321,8 @@ runroot rpmbuild -bs /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild script prepend/append])
+RPMTEST_SETUP_RW([rpmbuild script prepend/append])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bb --quiet ${RPMDATA}/SPECS/append.spec
 runroot_other rpm2cpio /build/RPMS/noarch/append-1.0-1.noarch.rpm | cpio -id 2> /dev/null
@@ -343,9 +338,8 @@ DDD
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild dir layout])
+RPMTEST_SETUP_RW([rpmbuild dir layout])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 rpmbuild \
 	-bi --target noarch --quiet \
@@ -389,9 +383,8 @@ runroot_other find /build/BUILD|sort
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -ba autosetup])
+RPMTEST_SETUP_RW([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -402,9 +395,8 @@ rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -bp autosetup without patches])
+RPMTEST_SETUP_RW([rpmbuild -bp autosetup without patches])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild -D="nopatches 1" \
@@ -422,9 +414,8 @@ grep warning: stderr
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild --build-in-place 1])
+RPMTEST_SETUP_RW([rpmbuild --build-in-place 1])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
@@ -485,9 +476,8 @@ hello-2.0/hello.c
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild --build-in-place --noprep])
+RPMTEST_SETUP_RW([rpmbuild --build-in-place --noprep])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
@@ -506,9 +496,8 @@ runroot --chdir hello-2.0 rpmbuild -bb --quiet \
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild --build-in-place --short-circuit])
+RPMTEST_SETUP_RW([rpmbuild --build-in-place --short-circuit])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other tar xf /data/SOURCES/hello-2.0.tar.gz
@@ -529,9 +518,8 @@ hello-debuginfo-2.0-1
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild with %autosetup -C])
+RPMTEST_SETUP_RW([rpmbuild with %autosetup -C])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -567,9 +555,8 @@ rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -ba autopatch])
+RPMTEST_SETUP_RW([rpmbuild -ba autopatch])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -588,9 +575,8 @@ grep warning: stderr
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -ba find-lang])
+RPMTEST_SETUP_RW([rpmbuild -ba find-lang])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild \
   -ba /data/SPECS/find-lang-test.spec
@@ -612,9 +598,8 @@ pl /usr/share/man/pl/man1/find-lang-test.1.gz
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -ba find-lang --generate-subpackages])
+RPMTEST_SETUP_RW([rpmbuild -ba find-lang --generate-subpackages])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -D "langpacks 1"\
   -ba /data/SPECS/find-lang-test.spec
@@ -642,9 +627,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpmbuild --rebuild *.src.rpm works
-RPMTEST_SETUP([rpmbuild --rebuild])
+RPMTEST_SETUP_RW([rpmbuild --rebuild])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -664,9 +648,8 @@ runroot rpm -qp --qf "%{packager}\n" /build/RPMS/*/hello-1.0-1.*.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild --short-circuit -bl])
+RPMTEST_SETUP_RW([rpmbuild --short-circuit -bl])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild -bi ${RPMDATA}/SPECS/hello.spec &> /dev/null
@@ -679,9 +662,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if tar unpacking works
-RPMTEST_SETUP([rpmbuild -tb <tar with bad spec>])
+RPMTEST_SETUP_RW([rpmbuild -tb <tar with bad spec>])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild \
@@ -693,9 +675,8 @@ runroot rpmbuild \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -ts <spec>])
+RPMTEST_SETUP_RW([rpmbuild -ts <spec>])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet \
@@ -719,9 +700,8 @@ runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-2.0-1.src.rpm
 RPMTEST_CLEANUP
 
 # weird filename survival test
-RPMTEST_SETUP([rpmbuild package with weird filenames])
+RPMTEST_SETUP_RW([rpmbuild package with weird filenames])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild -bb --quiet /data/SPECS/weirdnames.spec
@@ -751,9 +731,8 @@ runroot rpm -qpl /build/RPMS/noarch/weirdnames-1.0-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild package with illegal filenames])
+RPMTEST_SETUP_RW([rpmbuild package with illegal filenames])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 # XXX current output is not well suited for grab + compare, just ignore
 runroot rpmbuild -bb --quiet --with illegal /data/SPECS/weirdnames.spec
@@ -766,9 +745,8 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if tar build works
 # TODO: test that the rpms are actually created...
-RPMTEST_SETUP([rpmbuild -tb])
+RPMTEST_SETUP_RW([rpmbuild -tb])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -779,9 +757,8 @@ rpmbuild \
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild with deprecated patch])
+RPMTEST_SETUP_RW([rpmbuild with deprecated patch])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bp --quiet /data/SPECS/hello-patch.spec
 ],
@@ -792,9 +769,8 @@ runroot rpmbuild -bp --quiet /data/SPECS/hello-patch.spec
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild scriptlet -f])
+RPMTEST_SETUP_RW([rpmbuild scriptlet -f])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild \
@@ -860,9 +836,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # %attr/%defattr tests
-RPMTEST_SETUP([rpmbuild %attr and %defattr])
+RPMTEST_SETUP_RW([rpmbuild %attr and %defattr])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 runroot \
   --setenv SOURCE_DATE_EPOCH 1582222800 \
@@ -930,10 +905,9 @@ drwxrwxrwx   1 root     root            0 Feb 20  2020 ./j/dir
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild SOURCE_DATE_EPOCH])
+RPMTEST_SETUP_RW([rpmbuild SOURCE_DATE_EPOCH])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot \
   --setenv SOURCE_DATE_EPOCH 1699460418 \
@@ -951,10 +925,9 @@ runroot rpm -q --dump /build/RPMS/noarch/test-1-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild SOURCE_DATE_EPOCH=0])
+RPMTEST_SETUP_RW([rpmbuild SOURCE_DATE_EPOCH=0])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot \
   --setenv SOURCE_DATE_EPOCH 0 \
@@ -972,10 +945,9 @@ runroot rpm -q --dump /build/RPMS/noarch/test-1-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild _buildtime macro])
+RPMTEST_SETUP_RW([rpmbuild _buildtime macro])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot \
   rpmbuild \
@@ -994,11 +966,9 @@ runroot rpm -q --qf '%{BUILDTIME}\n' /build/RPMS/noarch/test-1-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild unpackaged files])
+RPMTEST_SETUP_RW([rpmbuild unpackaged files])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -bb --quiet --with unpackaged_files /data/SPECS/hlinktest.spec
@@ -1011,12 +981,10 @@ runroot rpmbuild \
 RPMTEST_CLEANUP
 
 # rpm doesn't detect unpackaged directories but should, really
-RPMTEST_SETUP([rpmbuild unpackaged directories])
+RPMTEST_SETUP_RW([rpmbuild unpackaged directories])
 AT_KEYWORDS([build])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
-RPMTEST_INIT
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -bb --quiet --with unpackaged_dirs /data/SPECS/hlinktest.spec
@@ -1030,11 +998,9 @@ runroot rpmbuild \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild glob])
+RPMTEST_SETUP_RW([rpmbuild glob])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/globtest.spec
 runroot rpm -qp \
@@ -1066,10 +1032,9 @@ warning: absolute symlink: /opt/globtest/linkgood -> /opt/globtest/zab
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild glob escape])
+RPMTEST_SETUP_RW([rpmbuild glob escape])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
 runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
@@ -1132,10 +1097,9 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 )
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild bad escape])
+RPMTEST_SETUP_RW([rpmbuild bad escape])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/badescape.spec
 ],
@@ -1147,10 +1111,9 @@ runroot rpmbuild -bb --quiet /data/SPECS/badescape.spec
 )
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild bad quote])
+RPMTEST_SETUP_RW([rpmbuild bad quote])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/badquote.spec
 ],
@@ -1162,10 +1125,9 @@ runroot rpmbuild -bb --quiet /data/SPECS/badquote.spec
 )
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild prefixpostfix])
+RPMTEST_SETUP_RW([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 	/data/SPECS/prefixtest.spec
@@ -1197,10 +1159,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if weak and reverse requires can be built
-RPMTEST_SETUP([Weak and reverse requires])
+RPMTEST_SETUP_RW([Weak and reverse requires])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 	--define "pkg weakdeps" \
@@ -1228,10 +1189,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test BuildRequire functionality
-RPMTEST_SETUP([Build requires])
+RPMTEST_SETUP_RW([Build requires])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define "pkg buildreq" \
@@ -1245,9 +1205,8 @@ runroot rpmbuild -bb --quiet \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([Dependency generation 1])
+RPMTEST_SETUP_RW([Dependency generation 1])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define "_binary_payload w9.gzdio" \
@@ -1298,10 +1257,9 @@ runroot rpm -qp --qf '[["%{FILENAMES}\t%{FILEPROVIDE}"\n]]' /build/RPMS/noarch/f
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([Dependency generation 2])
+RPMTEST_SETUP_RW([Dependency generation 2])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		/data/SPECS/shebang.spec
@@ -1313,10 +1271,9 @@ runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([Dependency generation 3])
+RPMTEST_SETUP_RW([Dependency generation 3])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 cat << EOF > "${RPMTEST}"/tmp/bad.req
 #!/bin/sh
@@ -1334,10 +1291,9 @@ runroot rpmbuild -bb --quiet \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([Dependency generation 4])
+RPMTEST_SETUP_RW([Dependency generation 4])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '__script_requires() \
@@ -1363,10 +1319,9 @@ one(shebang) = 77
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([Dependency generation 5])
+RPMTEST_SETUP_RW([Dependency generation 5])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '__script_mime text/plain' \
@@ -1381,10 +1336,9 @@ runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([Local dependency generator])
+RPMTEST_SETUP_RW([Local dependency generator])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '_local_file_attrs my_test_attr' \
@@ -1400,7 +1354,6 @@ shebang = 0.1-1
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '_local_file_attrs script' \
@@ -1415,7 +1368,6 @@ shebang = 0.1-1
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '_local_file_attrs my_test_attr:script' \
@@ -1433,9 +1385,8 @@ shebang = 0.1-1
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([elf dependencies])
+RPMTEST_SETUP_RW([elf dependencies])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other chmod a-x /data/misc/libhello.so
@@ -1496,7 +1447,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test spec query functionality
-RPMTEST_SETUP([rpmspec query 1])
+RPMTEST_SETUP_RW([rpmspec query 1])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
 
@@ -1516,10 +1467,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # archive sanity check
-RPMTEST_SETUP([rpmbuild archive sanity])
+RPMTEST_SETUP_RW([rpmbuild archive sanity])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -bb --quiet /data/SPECS/attrtest.spec
@@ -1534,11 +1484,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpmbuild creates the minisymtab section in the main hello binary
-RPMTEST_SETUP([rpmbuild debuginfo minisymtab])
+RPMTEST_SETUP_RW([rpmbuild debuginfo minisymtab])
 AT_KEYWORDS([build] [debuginfo])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Use macros.debug to generate a debuginfo package.
 export CFLAGS="-g"
@@ -1572,11 +1521,10 @@ RPMTEST_CLEANUP
 # Check if rpmbuild doesn't create the minisymtab section if we keep symtab
 # Some package might want to use strip -g to keep the symbol table and only
 # but the debug symbols/info in the debuginfo package.
-RPMTEST_SETUP([rpmbuild debuginfo minisymtab strip -g])
+RPMTEST_SETUP_RW([rpmbuild debuginfo minisymtab strip -g])
 AT_KEYWORDS([build] [debuginfo])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Use macros.debug to generate a debuginfo package.
 export CFLAGS="-g"
@@ -1612,11 +1560,10 @@ RPMTEST_CLEANUP
 # debuginfo. This is simply the hello example with one binary build twice
 # so dwz has enough slightly similar debug data.
 # Test the case without unique debug file names.
-RPMTEST_SETUP([rpmbuild debuginfo dwz])
+RPMTEST_SETUP_RW([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -1699,11 +1646,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that rpmbuild creates no debuginfo when --nodebuginfo is passed
-RPMTEST_SETUP([rpmbuild no debuginfo])
+RPMTEST_SETUP_RW([rpmbuild no debuginfo])
 AT_KEYWORDS([build] [debuginfo])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Use macros.debug to generate a debuginfo package,
 # but pass --nodebuginfo to skip it.
@@ -1733,11 +1679,10 @@ RPMTEST_CLEANUP
 # debuginfo. This is simply the hello example with one binary build twice
 # so dwz has enough slightly similar debug data.
 # Test with unique debug file names.
-RPMTEST_SETUP([rpmbuild debuginfo dwz unique debug names])
+RPMTEST_SETUP_RW([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -1820,11 +1765,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that an implicit suid binary get included with the suid bit set.
 # We explicitly build with all debug.macros to test those helpers.
-RPMTEST_SETUP([rpmbuild implicit suid binary])
+RPMTEST_SETUP_RW([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build a package that has some debuginfo
 rundebug rpmbuild --quiet \
@@ -1852,11 +1796,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that a GDB index is included when requested.
-RPMTEST_SETUP([rpmbuild debuginfo gdb index included])
+RPMTEST_SETUP_RW([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build a package that has some debuginfo
 rundebug rpmbuild --quiet \
@@ -1879,11 +1822,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that a GDB index is NOT included when not requested.
-RPMTEST_SETUP([rpmbuild debuginfo no gdb index included])
+RPMTEST_SETUP_RW([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build a package that has some debuginfo
 rundebug rpmbuild --quiet \
@@ -1905,11 +1847,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that a -g3 (macros) build creates a valid .debug file.
-RPMTEST_SETUP([rpmbuild debuginfo -g3 .debug_macro])
+RPMTEST_SETUP_RW([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build a package that has some debuginfo generated with -g3.
 # Specifically it uses -DDEBUG_DEFINE=1, which we want to see back
@@ -1937,11 +1878,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # ------------------------------
 # Check that a debug source is in a "unique" directory when requested.
-RPMTEST_SETUP([rpmbuild debuginfo unique debug src dir])
+RPMTEST_SETUP_RW([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build a package that has some debuginfo
 # Note that the spec defines hello2 as name, but the source is hello-1.0.
@@ -1974,11 +1914,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that a debug source is NOT in a "unique" directory when not requested.
 # It will be in the "build directory" name under /usr/src/debug.
-RPMTEST_SETUP([rpmbuild debuginfo no unique debug src dir])
+RPMTEST_SETUP_RW([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build a package that has some debuginfo
 # Note that the spec defines hello2 as name, but the source is hello-1.0.
@@ -2008,11 +1947,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that defining _debugsource_packages creates -debugsource package
-RPMTEST_SETUP([rpmbuild debugsource])
+RPMTEST_SETUP_RW([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_debugsource_packages 1" \
@@ -2040,11 +1978,10 @@ RPMTEST_CLEANUP
 # Check that defining _debugsource_packages creates -debugsource package
 # even if %install changes the working directory (debugsourcefiles.list
 # should be in expected build dir).
-RPMTEST_SETUP([rpmbuild debugsource debugsourcefiles.list path])
+RPMTEST_SETUP_RW([rpmbuild debugsource debugsourcefiles.list path])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_debugsource_packages 1" \
@@ -2065,11 +2002,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that undefining _debuginfo_subpackages creates one single -debuginfo.
-RPMTEST_SETUP([rpmbuild debuginfo subpackages single])
+RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages single])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -2104,11 +2040,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
-RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple])
+RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -2185,11 +2120,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
 # With unique debug and source names
-RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple unique])
+RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple unique])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -2266,11 +2200,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
 # Unique with debugsources.
-RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple unique debugsource])
+RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple unique debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -2350,11 +2283,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that defining _debuginfo_subpackages works with excluded files.
-RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple excluded])
+RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -2411,11 +2343,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that defining _debuginfo_subpackages works with RemovePathPostfixes.
-RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple excluded])
+RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -2475,10 +2406,9 @@ No hello.debug
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([manual debuginfo package])
+RPMTEST_SETUP_RW([manual debuginfo package])
 AT_KEYWORDS([build debuginfo])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 		--define "_prefix /usr/local" \
@@ -2523,9 +2453,8 @@ runroot rpmbuild --quiet -bb \
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([manual %debug_package use])
+RPMTEST_SETUP_RW([manual %debug_package use])
 AT_KEYWORDS([build debuginfo])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bb \
 		/data/SPECS/manualdebug.spec
@@ -2535,10 +2464,9 @@ runroot rpmbuild -bb \
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([explicit %_enable_debug_package on noarch])
+RPMTEST_SETUP_RW([explicit %_enable_debug_package on noarch])
 AT_KEYWORDS([build debuginfo])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 		--define "%_enable_debug_packages 1" \
@@ -2563,10 +2491,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
-RPMTEST_SETUP([dynamic build requires rpmbuild -bs])
+RPMTEST_SETUP_RW([dynamic build requires rpmbuild -bs])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   --quiet -bs /data/SPECS/buildrequires.spec
@@ -2584,10 +2511,9 @@ RPMTEST_CLEANUP
 # Check dynamic build requires
 # Mimick what mock does: repeat build with --noprep --noclean
 # until -br succeeds, and finally build the package.
-RPMTEST_SETUP([rpmbuild -br])
+RPMTEST_SETUP_RW([rpmbuild -br])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -br  --quiet /data/SPECS/buildrequires.spec
@@ -2619,10 +2545,9 @@ runroot rpmbuild \
 RPMTEST_CLEANUP
 
 # Test that -br creates an src.rpm on success
-RPMTEST_SETUP([rpmbuild -br success])
+RPMTEST_SETUP_RW([rpmbuild -br success])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -br  /data/SPECS/mini.spec
@@ -2636,10 +2561,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
-RPMTEST_SETUP([rpmbuild -bd with errors])
+RPMTEST_SETUP_RW([rpmbuild -bd with errors])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -bd  --quiet /data/SPECS/buildrequires.spec
@@ -2656,9 +2580,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpmbuild -bd *.spec doesn't build anything
-RPMTEST_SETUP([rpmbuild -bd *.spec])
+RPMTEST_SETUP_RW([rpmbuild -bd *.spec])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 rpmbuild \
@@ -2673,10 +2596,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
-RPMTEST_SETUP([rpmbuild -ba])
+RPMTEST_SETUP_RW([rpmbuild -ba])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -ba  --quiet /data/SPECS/buildrequires.spec
@@ -2694,10 +2616,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check dynamic build requires
-RPMTEST_SETUP([rpmbuild -br --nodeps])
+RPMTEST_SETUP_RW([rpmbuild -br --nodeps])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -br  --quiet --nodeps /data/SPECS/buildrequires.spec
@@ -2717,9 +2638,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check that rpmbuild aborts with missing Source
-RPMTEST_SETUP([rpmbuild -ba missing source])
+RPMTEST_SETUP_RW([rpmbuild -ba missing source])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK_UNQUOTED([
 runroot rpmbuild \
@@ -2746,10 +2666,9 @@ error: Bad file: /notthere/hello-1.0.tar.gz: No such file or directory
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild minimal spec])
+RPMTEST_SETUP_RW([rpmbuild minimal spec])
 AT_KEYWORDS([build])
 RPMTEST_CHECK_UNQUOTED([
-RPMTEST_INIT
 
 runroot rpmbuild \
   -bb --quiet /data/SPECS/mini.spec
@@ -2759,10 +2678,9 @@ runroot rpmbuild \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild missing files])
+RPMTEST_SETUP_RW([rpmbuild missing files])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/filemiss.spec
 ],
@@ -2783,10 +2701,9 @@ error: File not found: /build/BUILD/filemisstest-1.0-build/BUILDROOT/opt/share/l
 )
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild missing doc])
+RPMTEST_SETUP_RW([rpmbuild missing doc])
 AT_KEYWORDS([build])
 RPMTEST_CHECK_UNQUOTED([
-RPMTEST_INIT
 
 for val in 1 0; do
     runroot rpmbuild \
@@ -2803,9 +2720,8 @@ done
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([spec conditionals])
+RPMTEST_SETUP_RW([spec conditionals])
 AT_KEYWORDS([if else elif build])
-RPMTEST_INIT
 
 # %if, %else, %elif test basic
 RPMTEST_CHECK([
@@ -2902,9 +2818,8 @@ runroot rpmbuild -ba --quiet      \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([bcond macro])
+RPMTEST_SETUP_RW([bcond macro])
 AT_KEYWORDS([bcond build])
-RPMTEST_INIT
 
 # basic bcond behavior with --eval
 RPMTEST_CHECK([
@@ -2975,9 +2890,8 @@ has_bcond(normally_on)
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([bcond_override_default macros])
+RPMTEST_SETUP_RW([bcond_override_default macros])
 AT_KEYWORDS([bcond build])
-RPMTEST_INIT
 
 # check bcond_override_default by defining
 RPMTEST_CHECK([
@@ -3070,11 +2984,9 @@ has_bcond(normally_off)
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild spec tag])
+RPMTEST_SETUP_RW([rpmbuild spec tag])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([
-RPMTEST_INIT
-RPMTEST_INIT
 runroot rpmbuild -bs --quiet /data/SPECS/foo.spec
 runroot rpm -qp --qf "%{spec}" /build/SRPMS/foo-1.0-1.src.rpm
 ],
@@ -3118,9 +3030,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check %sources and %patches with weird file names
-RPMTEST_SETUP([%sources and %patches])
+RPMTEST_SETUP_RW([%sources and %patches])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild \
@@ -3137,9 +3048,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if dynamic spec generation works
-RPMTEST_SETUP([rpmbuild with dynamic spec generation])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --define "_prefix /usr/local" -ba /data/SPECS/dynamic.spec
@@ -3164,10 +3074,9 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if dynamic spec generation works for main package, too
 # Fails now as feature is disbled
-RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -ba /data/SPECS/dynamic.spec
@@ -3193,9 +3102,8 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if dynamic spec generation works for main package, too
 # Check for failure as feature is disabled. Remove tests when enabled
-RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -ba /data/SPECS/dynamic.spec
@@ -3207,9 +3115,8 @@ error: License field must be present in package: dynamic
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild with dynamic spec generation for main package])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation for main package])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -bs /data/SPECS/dynamic.spec
@@ -3223,9 +3130,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "FAIL 1" -ba /data/SPECS/dynamic.spec
@@ -3240,9 +3146,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "DOUBLESUMMARY 1" -ba /data/SPECS/dynamic.spec
@@ -3256,9 +3161,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "WRONGTAG 1" -ba /data/SPECS/dynamic.spec
@@ -3273,9 +3177,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "FORBIDDENSECTION 1" -ba /data/SPECS/dynamic.spec
@@ -3290,9 +3193,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check failing dynamic spec generation
-RPMTEST_SETUP([rpmbuild with dynamic spec generation fail])
+RPMTEST_SETUP_RW([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -D "FORBIDDENTAG 1" -ba /data/SPECS/dynamic.spec
@@ -3308,9 +3210,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check source name with space
-RPMTEST_SETUP([rpmbuild source name with space])
+RPMTEST_SETUP_RW([rpmbuild source name with space])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpmbuild -bp --quiet /data/SPECS/source_space.spec
@@ -3320,9 +3221,8 @@ runroot rpmbuild -bp --quiet /data/SPECS/source_space.spec
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild bad filetrigger condition])
+RPMTEST_SETUP_RW([rpmbuild bad filetrigger condition])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 rpmspec --parse /data/SPECS/badftrigger.spec
@@ -3348,9 +3248,8 @@ rpmspec --define "nosuchmacro /bbb" --parse /data/SPECS/badftrigger.spec
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild interactive])
+RPMTEST_SETUP_RW([rpmbuild interactive])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild --quiet -bb /data/SPECS/interact.spec
@@ -3367,9 +3266,8 @@ runroot rpmbuild --quiet -bp /data/SPECS/stdin.spec
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild bpf file])
+RPMTEST_SETUP_RW([rpmbuild bpf file])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild --quiet -bb /data/SPECS/bpf.spec
@@ -3381,9 +3279,8 @@ RPMTEST_CLEANUP
 
 # XXX this always succeeds when rpmbuild is run as root so the test is
 # kinda meaningless until #3005 is done, but works as a manual reproducer.
-RPMTEST_SETUP([rpmbuild non-removable file in builddir])
+RPMTEST_SETUP_RW([rpmbuild non-removable file in builddir])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 # -bi doesn't run cleanup, test that we manage that situation too
 RPMTEST_CHECK([
@@ -3395,10 +3292,9 @@ runroot rpmbuild --quiet -bb /data/SPECS/noperms.spec
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild %caps])
+RPMTEST_SETUP_RW([rpmbuild %caps])
 AT_KEYWORDS([build])
 RPMTEST_SKIP_IF([$CAP_DISABLED])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild --quiet -bb /data/SPECS/caps.spec
@@ -3448,9 +3344,8 @@ runroot_other /usr/sbin/getcap /usr/bin/test
 
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild -bs with source macro])
+RPMTEST_SETUP_RW([rpmbuild -bs with source macro])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild --quiet -bs /data/SPECS/macrosource.spec
@@ -3479,9 +3374,8 @@ hello-1.0-install.patch
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild target macro sanity])
+RPMTEST_SETUP_RW([rpmbuild target macro sanity])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 
 # This is surprisingly tricky - we need to place these macros in a place
 # that is after the platform stuff in macro path so we can't just drop
@@ -3531,9 +3425,8 @@ BUILD_POST noarch noarch noarch
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmbuild install_pre override])
+RPMTEST_SETUP_RW([rpmbuild install_pre override])
 AT_KEYWORDS([build])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bb /data/SPECS/install-hack.spec
 ],
@@ -3544,10 +3437,9 @@ RPMTEST_CLEANUP
 
 # Mimick what cpack does. It's not how rpmbuild wants to be used, so
 # please don't copy this to any new usages.
-RPMTEST_SETUP([rpmbuild --buildroot])
+RPMTEST_SETUP_RW([rpmbuild --buildroot])
 AT_KEYWORDS([build])
 
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot_other mkdir -p /tmp/buildroot/out
 runroot_other touch /tmp/buildroot/out/sider
@@ -3568,10 +3460,9 @@ runroot rpm -qpl /build/RPMS/noarch/brtest-1.0-1.noarch.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([builddir])
+RPMTEST_SETUP_RW([builddir])
 AT_KEYWORDS([build builddir])
 
-RPMTEST_INIT
 # Trick for compatibly getting the builddir out of old and new rpm
 RPMTEST_CHECK([
 runroot rpmbuild \
@@ -3594,9 +3485,8 @@ mydir2=/build/BUILD/mydir-1.0-build/mydir-1.0
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([file digests])
+RPMTEST_SETUP_RW([file digests])
 AT_KEYWORDS([build digest])
-RPMTEST_INIT
 RPMTEST_CHECK([[
 runroot rpmbuild -bs --quiet /data/SPECS/hello.spec
 runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.src.rpm
@@ -3650,10 +3540,9 @@ b718a835936fd2f6c8855f210c4789a1 hello-1.0.tar.gz
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([file digests sha3])
+RPMTEST_SETUP_RW([file digests sha3])
 AT_KEYWORDS([build digest])
 RPMTEST_SKIP_IF([test x$PGP = xsequoia])
-RPMTEST_INIT
 RPMTEST_CHECK([[
 runroot rpmbuild -bs --quiet \
 		--define "_source_filedigest_algorithm 12" \

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1536,7 +1536,7 @@ RPMTEST_CLEANUP
 # Check if rpmbuild creates the minisymtab section in the main hello binary
 RPMTEST_SETUP([rpmbuild debuginfo minisymtab])
 AT_KEYWORDS([build] [debuginfo])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1574,7 +1574,7 @@ RPMTEST_CLEANUP
 # but the debug symbols/info in the debuginfo package.
 RPMTEST_SETUP([rpmbuild debuginfo minisymtab strip -g])
 AT_KEYWORDS([build] [debuginfo])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1614,7 +1614,7 @@ RPMTEST_CLEANUP
 # Test the case without unique debug file names.
 RPMTEST_SETUP([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1701,7 +1701,7 @@ RPMTEST_CLEANUP
 # Check that rpmbuild creates no debuginfo when --nodebuginfo is passed
 RPMTEST_SETUP([rpmbuild no debuginfo])
 AT_KEYWORDS([build] [debuginfo])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1735,7 +1735,7 @@ RPMTEST_CLEANUP
 # Test with unique debug file names.
 RPMTEST_SETUP([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1822,7 +1822,7 @@ RPMTEST_CLEANUP
 # We explicitly build with all debug.macros to test those helpers.
 RPMTEST_SETUP([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1854,7 +1854,7 @@ RPMTEST_CLEANUP
 # Check that a GDB index is included when requested.
 RPMTEST_SETUP([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1881,7 +1881,7 @@ RPMTEST_CLEANUP
 # Check that a GDB index is NOT included when not requested.
 RPMTEST_SETUP([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1907,7 +1907,7 @@ RPMTEST_CLEANUP
 # Check that a -g3 (macros) build creates a valid .debug file.
 RPMTEST_SETUP([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1939,7 +1939,7 @@ RPMTEST_CLEANUP
 # Check that a debug source is in a "unique" directory when requested.
 RPMTEST_SETUP([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1976,7 +1976,7 @@ RPMTEST_CLEANUP
 # It will be in the "build directory" name under /usr/src/debug.
 RPMTEST_SETUP([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -2010,7 +2010,7 @@ RPMTEST_CLEANUP
 # Check that defining _debugsource_packages creates -debugsource package
 RPMTEST_SETUP([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -2042,7 +2042,7 @@ RPMTEST_CLEANUP
 # should be in expected build dir).
 RPMTEST_SETUP([rpmbuild debugsource debugsourcefiles.list path])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -2067,7 +2067,7 @@ RPMTEST_CLEANUP
 # Check that undefining _debuginfo_subpackages creates one single -debuginfo.
 RPMTEST_SETUP([rpmbuild debuginfo subpackages single])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -2106,7 +2106,7 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
 RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -2187,7 +2187,7 @@ RPMTEST_CLEANUP
 # With unique debug and source names
 RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple unique])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -2268,7 +2268,7 @@ RPMTEST_CLEANUP
 # Unique with debugsources.
 RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple unique debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -2352,7 +2352,7 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages works with excluded files.
 RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -2413,7 +2413,7 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages works with RemovePathPostfixes.
 RPMTEST_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -3397,7 +3397,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmbuild %caps])
 AT_KEYWORDS([build])
-AT_SKIP_IF([$CAP_DISABLED])
+RPMTEST_SKIP_IF([$CAP_DISABLED])
 RPMTEST_INIT
 
 RPMTEST_CHECK([
@@ -3652,7 +3652,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([file digests sha3])
 AT_KEYWORDS([build digest])
-AT_SKIP_IF([test x$PGP = xsequoia])
+RPMTEST_SKIP_IF([test x$PGP = xsequoia])
 RPMTEST_INIT
 RPMTEST_CHECK([[
 runroot rpmbuild -bs --quiet \

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -22,7 +22,7 @@ AT_BANNER([RPM buildid tests])
 # Check if rpmbuild "none" doesn't generates buildid symlinks for hello program
 RPMTEST_SETUP([rpmbuild buildid none])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -53,7 +53,7 @@ RPMTEST_CLEANUP
 # Without unique debug file names.
 RPMTEST_SETUP([rpmbuild buildid alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -142,7 +142,7 @@ RPMTEST_CLEANUP
 # With unique debug file names.
 RPMTEST_SETUP([rpmbuild buildid alldebug unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -230,7 +230,7 @@ RPMTEST_CLEANUP
 # Without unique debug file names
 RPMTEST_SETUP([rpmbuild buildid separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -318,7 +318,7 @@ RPMTEST_CLEANUP
 # With unique debug file names
 RPMTEST_SETUP([rpmbuild buildid separate unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -405,7 +405,7 @@ RPMTEST_CLEANUP
 # Without unique debug file names
 RPMTEST_SETUP([rpmbuild buildid compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -506,7 +506,7 @@ RPMTEST_CLEANUP
 # With unique debug file names
 RPMTEST_SETUP([rpmbuild buildid compat unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -607,7 +607,7 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary copied.
 RPMTEST_SETUP([rpmbuild buildid duplicate alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # Should create two warnings
@@ -672,7 +672,7 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary hard linked.
 RPMTEST_SETUP([rpmbuild buildid hardlink alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # No warnings for hard links
@@ -734,7 +734,7 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary copied.
 RPMTEST_SETUP([rpmbuild buildid duplicate separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # Should create two warnings
@@ -796,7 +796,7 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary hard linked.
 RPMTEST_SETUP([rpmbuild buildid hardlink separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # No warnings for hard links
@@ -855,7 +855,7 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary copied.
 RPMTEST_SETUP([rpmbuild buildid duplicate compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # Should create two warnings
@@ -929,7 +929,7 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary hard linked.
 RPMTEST_SETUP([rpmbuild buildid hardlink compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # No warnings for hard links
@@ -999,7 +999,7 @@ RPMTEST_CLEANUP
 # but not with _no_recompute_build_ids
 RPMTEST_SETUP([rpmbuild buildid recompute])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # Make sure we get debuginfo
@@ -1110,7 +1110,7 @@ RPMTEST_CLEANUP
 # with _unique_build_ids defined.
 RPMTEST_SETUP([rpmbuild buildid unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # No warnings for hard links
@@ -1155,7 +1155,7 @@ RPMTEST_CLEANUP
 # with _unique_build_ids undefined (and exact same sources).
 RPMTEST_SETUP([rpmbuild buildid non-unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 # No warnings for hard links
@@ -1204,7 +1204,7 @@ RPMTEST_CLEANUP
 # even if the spec file sets attrs explicitly.
 RPMTEST_SETUP([rpmbuild buildid attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1235,7 +1235,7 @@ RPMTEST_CLEANUP
 # even if the spec file sets config explicitly.
 RPMTEST_SETUP([rpmbuild buildid config attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-AT_SKIP_IF([$DEBUGINFO_DISABLED])
+RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -20,11 +20,10 @@ AT_BANNER([RPM buildid tests])
 
 # ------------------------------
 # Check if rpmbuild "none" doesn't generates buildid symlinks for hello program
-RPMTEST_SETUP([rpmbuild buildid none])
+RPMTEST_SETUP_RW([rpmbuild buildid none])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -51,11 +50,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "alldebug" generates debuginfo buildid symlinks.
 # Without unique debug file names.
-RPMTEST_SETUP([rpmbuild buildid alldebug])
+RPMTEST_SETUP_RW([rpmbuild buildid alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -140,11 +138,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "alldebug" generates debuginfo buildid symlinks.
 # With unique debug file names.
-RPMTEST_SETUP([rpmbuild buildid alldebug unique debug names])
+RPMTEST_SETUP_RW([rpmbuild buildid alldebug unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -228,11 +225,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "separate" generates main and debuginfo buildid symlinks
 # Without unique debug file names
-RPMTEST_SETUP([rpmbuild buildid separate])
+RPMTEST_SETUP_RW([rpmbuild buildid separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -316,11 +312,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "separate" generates main and debuginfo buildid symlinks
 # With unique debug file names
-RPMTEST_SETUP([rpmbuild buildid separate unique debug names])
+RPMTEST_SETUP_RW([rpmbuild buildid separate unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -403,11 +398,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "compat" generates main and debuginfo buildid symlinks
 # Without unique debug file names
-RPMTEST_SETUP([rpmbuild buildid compat])
+RPMTEST_SETUP_RW([rpmbuild buildid compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -504,11 +498,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check if rpmbuild "compat" generates main and debuginfo buildid symlinks
 # With unique debug file names
-RPMTEST_SETUP([rpmbuild buildid compat unique debug names])
+RPMTEST_SETUP_RW([rpmbuild buildid compat unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -605,11 +598,10 @@ RPMTEST_CLEANUP
 # Check that (copied) files with duplicate build-ids are handled correctly.
 # This should create "numbered" build-id files.
 # This is simply the hello example with one binary copied.
-RPMTEST_SETUP([rpmbuild buildid duplicate alldebug])
+RPMTEST_SETUP_RW([rpmbuild buildid duplicate alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links alldebug" \
@@ -670,11 +662,10 @@ RPMTEST_CLEANUP
 # Since the hard linked files have duplicate build-ids,
 # it should create "numbered" build-id files.
 # This is simply the hello example with one binary hard linked.
-RPMTEST_SETUP([rpmbuild buildid hardlink alldebug])
+RPMTEST_SETUP_RW([rpmbuild buildid hardlink alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links alldebug" \
@@ -732,11 +723,10 @@ RPMTEST_CLEANUP
 # Check that (copied) files with duplicate build-ids are handled correctly.
 # This should create "numbered" build-id files.
 # This is simply the hello example with one binary copied.
-RPMTEST_SETUP([rpmbuild buildid duplicate separate])
+RPMTEST_SETUP_RW([rpmbuild buildid duplicate separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links separate" \
@@ -794,11 +784,10 @@ RPMTEST_CLEANUP
 # Since the hard linked files have duplicate build-ids,
 # it should create "numbered" build-id files.
 # This is simply the hello example with one binary hard linked.
-RPMTEST_SETUP([rpmbuild buildid hardlink separate])
+RPMTEST_SETUP_RW([rpmbuild buildid hardlink separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links separate" \
@@ -853,11 +842,10 @@ RPMTEST_CLEANUP
 # Check that (copied) files with duplicate build-ids are handled correctly.
 # This should create "numbered" build-id files.
 # This is simply the hello example with one binary copied.
-RPMTEST_SETUP([rpmbuild buildid duplicate compat])
+RPMTEST_SETUP_RW([rpmbuild buildid duplicate compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links compat" \
@@ -927,11 +915,10 @@ RPMTEST_CLEANUP
 # Since the hard linked files have duplicate build-ids,
 # it should create "numbered" build-id files.
 # This is simply the hello example with one binary hard linked.
-RPMTEST_SETUP([rpmbuild buildid hardlink compat])
+RPMTEST_SETUP_RW([rpmbuild buildid hardlink compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links compat" \
@@ -997,11 +984,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check build-ids are recomputed with unique_build_ids,
 # but not with _no_recompute_build_ids
-RPMTEST_SETUP([rpmbuild buildid recompute])
+RPMTEST_SETUP_RW([rpmbuild buildid recompute])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # Make sure we get debuginfo
 export CFLAGS="-g"
 
@@ -1108,11 +1094,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check build-ids are unique between versions/releases
 # with _unique_build_ids defined.
-RPMTEST_SETUP([rpmbuild buildid unique r1 r2])
+RPMTEST_SETUP_RW([rpmbuild buildid unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_unique_build_ids 1" \
@@ -1153,11 +1138,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check build-ids are non-unique between versions/releases
 # with _unique_build_ids undefined (and exact same sources).
-RPMTEST_SETUP([rpmbuild buildid non-unique r1 r2])
+RPMTEST_SETUP_RW([rpmbuild buildid non-unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --undefine="_unique_build_ids" \
@@ -1202,11 +1186,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that build-id directories are created with the right permissions
 # even if the spec file sets attrs explicitly.
-RPMTEST_SETUP([rpmbuild buildid attrs])
+RPMTEST_SETUP_RW([rpmbuild buildid attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -1233,11 +1216,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Check that build-id directories are created with the right attributes
 # even if the spec file sets config explicitly.
-RPMTEST_SETUP([rpmbuild buildid config attrs])
+RPMTEST_SETUP_RW([rpmbuild buildid config attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \

--- a/tests/rpmconfig.at
+++ b/tests/rpmconfig.at
@@ -2,9 +2,8 @@
 
 AT_BANNER([RPM config file behavior])
 
-RPMTEST_SETUP([config file install/upgrade/erase])
+RPMTEST_SETUP_RW([config file install/upgrade/erase])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -138,9 +137,8 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([config(noreplace) file install/upgrade/erase])
+RPMTEST_SETUP_RW([config(noreplace) file install/upgrade/erase])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -193,9 +191,8 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([upgrade changing config])
+RPMTEST_SETUP_RW([upgrade changing config])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -269,9 +266,8 @@ RPMTEST_CLEANUP
 
 # config(noreplace) variants of the same cases.
 # ------------------------------
-RPMTEST_SETUP([upgrade changing config(noreplace)])
+RPMTEST_SETUP_RW([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -321,9 +317,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # noreplace variants of the same
-RPMTEST_SETUP([upgrade changing config(noreplace)])
+RPMTEST_SETUP_RW([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -395,9 +390,8 @@ RPMTEST_CLEANUP
 
 # Shared config file variants of the same cases
 # ------------------------------
-RPMTEST_SETUP([upgrade shared config])
+RPMTEST_SETUP_RW([upgrade shared config])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
@@ -455,9 +449,8 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([upgrade changing shared config])
+RPMTEST_SETUP_RW([upgrade changing shared config])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
@@ -544,9 +537,8 @@ RPMTEST_CLEANUP
 # Shared config(noreplace) variants of the more interesting cases
 # ------------------------------
 # Upgrade package with locally modified config file, changed in pkg.
-RPMTEST_SETUP([upgrade shared config(noreplace)])
+RPMTEST_SETUP_RW([upgrade shared config(noreplace)])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -613,10 +605,9 @@ RPMTEST_CLEANUP
 
 ---------
 # Test pre-existing and post-install config ghost survival and erasure
-RPMTEST_SETUP([ghost config])
+RPMTEST_SETUP_RW([ghost config])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}"*
 

--- a/tests/rpmconfig2.at
+++ b/tests/rpmconfig2.at
@@ -2,9 +2,8 @@
 
 AT_BANNER([RPM config symlink behavior])
 
-RPMTEST_SETUP([config symlinks])
+RPMTEST_SETUP_RW([config symlinks])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -142,9 +141,8 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([changing config symlinks])
+RPMTEST_SETUP_RW([changing config symlinks])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -217,9 +215,8 @@ RPMTEST_CLEANUP
 # config(noreplace) variants of the same cases.
 #
 # ------------------------------
-RPMTEST_SETUP([upgrade unchanged config(noreplace) links])
+RPMTEST_SETUP_RW([upgrade unchanged config(noreplace) links])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -268,9 +265,8 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([upgrade changing config(noreplace) links])
+RPMTEST_SETUP_RW([upgrade changing config(noreplace) links])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -345,9 +341,8 @@ RPMTEST_CLEANUP
 
 # Shared config link variants of the same cases
 # ------------------------------
-RPMTEST_SETUP([upgrade unchanged shared config links])
+RPMTEST_SETUP_RW([upgrade unchanged shared config links])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -407,9 +402,8 @@ otherstuff
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([upgrade changing shared config links])
+RPMTEST_SETUP_RW([upgrade changing shared config links])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -497,9 +491,8 @@ RPMTEST_CLEANUP
 
 # Shared config(noreplace) variants of the more interesting cases
 # ------------------------------
-RPMTEST_SETUP([upgrade changing shared config(noreplace) links])
+RPMTEST_SETUP_RW([upgrade changing shared config(noreplace) links])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do

--- a/tests/rpmconfig3.at
+++ b/tests/rpmconfig3.at
@@ -2,9 +2,8 @@
 
 AT_BANNER([RPM config filetype changes])
 
-RPMTEST_SETUP([upgrade config to/from non-config])
+RPMTEST_SETUP_RW([upgrade config to/from non-config])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -89,9 +88,8 @@ foo
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade config to/from config link])
+RPMTEST_SETUP_RW([upgrade config to/from config link])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -150,10 +148,9 @@ otherstuff
 RPMTEST_CLEANUP
 
 # Modified config link changes to config file
-RPMTEST_SETUP([upgrade modified config link to config])
+RPMTEST_SETUP_RW([upgrade modified config link to config])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
 
@@ -187,9 +184,8 @@ otherstuff
 )
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade config to directory])
+RPMTEST_SETUP_RW([upgrade config to directory])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \

--- a/tests/rpmconflict.at
+++ b/tests/rpmconflict.at
@@ -3,9 +3,8 @@
 AT_BANNER([RPM implicit file conflicts])
 
 # ------------------------------
-RPMTEST_SETUP([packages with file conflicts])
+RPMTEST_SETUP_RW([packages with file conflicts])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for p in "one" "two"; do
     runroot rpmbuild --quiet -bb \
@@ -38,9 +37,8 @@ runroot rpm -U \
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([shareable files])
+RPMTEST_SETUP_RW([shareable files])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for p in "one" "two"; do
     runroot rpmbuild --quiet -bb \
@@ -74,10 +72,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # (Build and) install package with identical basename in different directories
-RPMTEST_SETUP([non-conflicting identical basenames])
+RPMTEST_SETUP_RW([non-conflicting identical basenames])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/selfconflict.spec
 rm -rf "${RPMTEST}"/opt/mydir
@@ -90,10 +87,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # (Build and) install package with a self-conflict due to directory symlinks
-RPMTEST_SETUP([conflicting identical basenames])
+RPMTEST_SETUP_RW([conflicting identical basenames])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/selfconflict.spec
 rm -rf "${RPMTEST}"/opt/mydir
@@ -108,10 +104,9 @@ runroot rpm -U /build/RPMS/noarch/selfconflict-1.0-1.noarch.rpm
 RPMTEST_CLEANUP
 # ------------------------------
 # File conflict between colored files, prefer 64bit
-RPMTEST_SETUP([multilib elf conflict, prefer 64bit 1])
+RPMTEST_SETUP_RW([multilib elf conflict, prefer 64bit 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -129,10 +124,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 64bit
-RPMTEST_SETUP([multilib elf conflict, prefer 64bit 2])
+RPMTEST_SETUP_RW([multilib elf conflict, prefer 64bit 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -155,10 +149,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 64bit
-RPMTEST_SETUP([multilib elf conflict, prefer 64bit 3])
+RPMTEST_SETUP_RW([multilib elf conflict, prefer 64bit 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -181,10 +174,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 32bit
-RPMTEST_SETUP([multilib elf conflict, prefer 32bit 1])
+RPMTEST_SETUP_RW([multilib elf conflict, prefer 32bit 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -202,10 +194,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 32bit
-RPMTEST_SETUP([multilib elf conflict, prefer 32bit 2])
+RPMTEST_SETUP_RW([multilib elf conflict, prefer 32bit 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -228,10 +219,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored files, prefer 32bit
-RPMTEST_SETUP([multilib elf conflict, prefer 32bit 3])
+RPMTEST_SETUP_RW([multilib elf conflict, prefer 32bit 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
   --define "_transaction_color 3" \
@@ -254,10 +244,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # File conflict between colored and non-colored file 1
-RPMTEST_SETUP([multilib elf vs non-elf file conflict 1])
+RPMTEST_SETUP_RW([multilib elf vs non-elf file conflict 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -274,10 +263,9 @@ runroot rpm -U --ignoreos --ignorearch --nodeps \
 RPMTEST_CLEANUP
 
 # File conflict between colored and non-colored file 2
-RPMTEST_SETUP([multilib elf vs non-elf file conflict 2])
+RPMTEST_SETUP_RW([multilib elf vs non-elf file conflict 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -298,10 +286,9 @@ runroot rpm -U --ignoreos --ignorearch --nodeps \
 RPMTEST_CLEANUP
 
 # File conflict between colored and non-colored file 3
-RPMTEST_SETUP([multilib elf vs non-elf file conflict 3])
+RPMTEST_SETUP_RW([multilib elf vs non-elf file conflict 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -323,10 +310,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Removal conflict on directory -> symlink change
-RPMTEST_SETUP([replacing directory with symlink])
+RPMTEST_SETUP_RW([replacing directory with symlink])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest*
 
 runroot rpmbuild --quiet -bb \
@@ -345,10 +331,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Replace symlink with a directory
-RPMTEST_SETUP([replacing symlink with directory])
+RPMTEST_SETUP_RW([replacing symlink with directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest*
 
 runroot rpmbuild --quiet -bb \
@@ -368,10 +353,9 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Regular file shared with a ghost, does not conflict
 # Regular file should be created and not removed when the ghost is removed
-RPMTEST_SETUP([real file with shared ghost])
+RPMTEST_SETUP_RW([real file with shared ghost])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 fn="${RPMTEST}"/usr/share/my.version
 
 runroot rpmbuild --quiet -bb \

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -23,7 +23,6 @@ AT_BANNER([RPM database access])
 RPMTEST_SETUP([rpm --initdb])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
-RPMTEST_INIT
 ],
 [0],
 [ignore],
@@ -35,7 +34,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qa 1])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   -qa
 ],
@@ -43,10 +41,9 @@ runroot rpm \
 RPMTEST_CLEANUP
 
 # Run rpm -qa on a non-existent rpmdb
-RPMTEST_SETUP([rpm -qa 2])
+RPMTEST_SETUP_RW([rpm -qa 2])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`
 runroot rpm \
   -qa
@@ -56,9 +53,8 @@ runroot rpm \
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -qa 3])
+RPMTEST_SETUP_RW([rpm -qa 3])
 AT_KEYWORDS([rpmdb query])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpm -U --nodeps --ignorearch --ignoreos --nosignature \
@@ -82,7 +78,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmdb --export and --import])
 AT_KEYWORDS([rpmdb])
 
-# This needs to run *without* RPMTEST_INIT to test behavior on read-only mount
+# This needs to run *without* RPMTEST_SNAPSHOT_MOUNT to test behavior on read-only mount
 RPMTEST_CHECK([
 # XXX FIXME: should not use system rpmdb for anything, but there's a
 # mystery failure here if pointed to /data/misc which should be equally
@@ -95,7 +91,7 @@ test -s rdonly.list
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
+RPMTEST_SNAPSHOT_MOUNT
 runroot rpm -U /data/RPMS/hlinktest-1.0-1.noarch.rpm
 ],
 [0],
@@ -128,10 +124,9 @@ runroot rpm -qa --dbpath ${PWD}
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -qa and rpmkeys])
+RPMTEST_SETUP_RW([rpm -qa and rpmkeys])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 
 echo "%_keyring rpmdb" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 
@@ -357,10 +352,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Run rpm -q <package> where <package> exists in the db.
-RPMTEST_SETUP([rpm -q foo])
+RPMTEST_SETUP_RW([rpm -q foo])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -i \
   /data/RPMS/foo-1.0-1.noarch.rpm
@@ -376,10 +370,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Run rpm -q <package>- where <package> exists in the db.
-RPMTEST_SETUP([rpm -q foo-])
+RPMTEST_SETUP_RW([rpm -q foo-])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -i \
   /data/RPMS/foo-1.0-1.noarch.rpm
@@ -393,10 +386,9 @@ runroot rpm -q foo-
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmdb header numbering])
+RPMTEST_SETUP_RW([rpmdb header numbering])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 for i in 1 2 3; do
     runroot rpm -i /data/RPMS/foo-1.0-1.noarch.rpm
@@ -413,10 +405,9 @@ done
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -q --querybynumber])
+RPMTEST_SETUP_RW([rpm -q --querybynumber])
 AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -i \
   /data/RPMS/foo-1.0-1.noarch.rpm
@@ -446,11 +437,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # install a noarch package into a local rpmdb without --relocate and --nodeps
 # * Should always succeed
-RPMTEST_SETUP([rpm -i *.noarch.rpm])
+RPMTEST_SETUP_RW([rpm -i *.noarch.rpm])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -i \
   /data/RPMS/foo-1.0-1.noarch.rpm
@@ -461,11 +451,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # reinstall a noarch package (with no files)
-RPMTEST_SETUP([rpm -U --replacepkgs 1])
+RPMTEST_SETUP_RW([rpm -U --replacepkgs 1])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 tpkg="/data/RPMS/foo-1.0-1.noarch.rpm"
 
@@ -482,11 +471,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # reinstall a package with different file policies
-RPMTEST_SETUP([rpm -U --replacepkgs 2])
+RPMTEST_SETUP_RW([rpm -U --replacepkgs 2])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 tpkg="/data/RPMS/hello-2.0-1.i686.rpm"
 
@@ -502,12 +490,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # reinstall a package with different file policies
-RPMTEST_SETUP([rpm --reinstall 1])
+RPMTEST_SETUP_RW([rpm --reinstall 1])
 AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
-
 tpkg="/data/RPMS/hello-2.0-1.i686.rpm"
 
 runroot rpm -U --nodeps --ignorearch "${tpkg}" && 
@@ -524,9 +510,8 @@ RPMTEST_CLEANUP
 # install a package into a local rpmdb
 # * Shall only work with if one is relocated
 # * Use --ignorearch because we don't know the arch
-RPMTEST_SETUP([rpm -i --relocate=.. *.i386.rpm])
+RPMTEST_SETUP_RW([rpm -i --relocate=.. *.i386.rpm])
 AT_KEYWORDS([rpmdb install])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpm -i \
@@ -565,10 +550,9 @@ runroot rpm -ql hello.i386 hello.ppc64
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmdb --rebuilddb])
+RPMTEST_SETUP_RW([rpmdb --rebuilddb])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
-RPMTEST_INIT
 RPMDB_RESET
 
 runroot rpm -U --noscripts --nodeps --ignorearch --noverify \
@@ -590,10 +574,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Attempt to initialize, rebuild and verify a db
-RPMTEST_SETUP([rpmdb --rebuilddb and verify empty database])
+RPMTEST_SETUP_RW([rpmdb --rebuilddb and verify empty database])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
-RPMTEST_INIT
 RPMDB_RESET
 runroot rpmdb --rebuilddb
 runroot rpmdb --verifydb
@@ -605,10 +588,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Install and verify status
-RPMTEST_SETUP([rpm -U and verify status])
+RPMTEST_SETUP_RW([rpm -U and verify status])
 AT_KEYWORDS([install rpmdb query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "pkg status" \
@@ -626,10 +608,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Install and verify status
-RPMTEST_SETUP([rpm -U with _install_lang and verify status])
+RPMTEST_SETUP_RW([rpm -U with _install_lang and verify status])
 AT_KEYWORDS([install rpmdb query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
           /data/SPECS/flangtest.spec
@@ -649,9 +630,8 @@ not installed /usr/share/flangtest/pl.txt
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([rpmdb query special chars])
+RPMTEST_SETUP_RW([rpmdb query special chars])
 AT_KEYWORDS([install rpmdb query])
-RPMTEST_INIT
 for v in "1.0+2" "1.0^2" "1.0~2"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -691,9 +671,8 @@ runroot rpm -q 'versiontest-1.0~2-1'
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([rpmdb vacuum])
+RPMTEST_SETUP_RW([rpmdb vacuum])
 AT_KEYWORDS([install rpmdb sqlite])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -U --noscripts --nodeps --ignorearch --noverify \
   /data/RPMS/hello-1.0-1.i386.rpm

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -130,7 +130,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -qa and rpmkeys])
 AT_KEYWORDS([rpmdb query])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 
 echo "%_keyring rpmdb" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -3,9 +3,8 @@
 AT_BANNER([RPM dependencies])
 
 # ------------------------------
-RPMTEST_SETUP([unversioned requires])
+RPMTEST_SETUP_RW([unversioned requires])
 AT_KEYWORDS([install depends])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -19,7 +18,6 @@ runroot rpmbuild --quiet -bb \
 
 # missing dependency
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
@@ -31,7 +29,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 
 # cross-depending packages
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -42,10 +39,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # 
-RPMTEST_SETUP([unsatisfied versioned require])
+RPMTEST_SETUP_RW([unsatisfied versioned require])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -76,10 +72,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # 
-RPMTEST_SETUP([satisfied versioned require])
+RPMTEST_SETUP_RW([satisfied versioned require])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -100,9 +95,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # 
-RPMTEST_SETUP([versioned conflicts])
+RPMTEST_SETUP_RW([versioned conflicts])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -115,7 +109,6 @@ runroot rpmbuild --quiet -bb \
 
 # versioned conflict in transaction
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -127,7 +120,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # versioned conflict in database
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
@@ -139,10 +131,9 @@ runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([install and verify self-conflicting package])
+RPMTEST_SETUP_RW([install and verify self-conflicting package])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -159,10 +150,9 @@ runroot rpm -V --nofiles deptest-one
 RPMTEST_CLEANUP
 
 # explicit file conflicts
-RPMTEST_SETUP([explicit file conflicts])
+RPMTEST_SETUP_RW([explicit file conflicts])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -196,10 +186,9 @@ error: Failed dependencies:
 RPMTEST_CLEANUP
 # ------------------------------
 # 
-RPMTEST_SETUP([erase to break dependencies])
+RPMTEST_SETUP_RW([erase to break dependencies])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -222,10 +211,9 @@ runroot rpm -e deptest-two
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([erase to break colored file dependency])
+RPMTEST_SETUP_RW([erase to break colored file dependency])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg hello" \
@@ -249,10 +237,9 @@ runroot rpm -e hello.x86_64
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([erase on wrong-colored file dependency])
+RPMTEST_SETUP_RW([erase on wrong-colored file dependency])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg hello" \
@@ -275,10 +262,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([unsatisfied WITH requires])
+RPMTEST_SETUP_RW([unsatisfied WITH requires])
 AT_KEYWORDS([install, boolean])
 
-RPMTEST_INIT
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
 	--define "reqs (deptest-two with flavor = dekstop)" \
@@ -321,9 +307,8 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([satisfied WITH requires])
+RPMTEST_SETUP_RW([satisfied WITH requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -369,9 +354,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([unsatisfied WITHOUT requires])
+RPMTEST_SETUP_RW([unsatisfied WITHOUT requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -385,7 +369,6 @@ runroot rpmbuild --quiet -bb \
 
 # unsatisfied WITHOUT require in transaction
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -397,7 +380,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # unsatisfied WITHOUT require in rpmdb
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 
@@ -410,9 +392,8 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([satisfied WITHOUT requires])
+RPMTEST_SETUP_RW([satisfied WITHOUT requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -448,9 +429,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([AND requires])
+RPMTEST_SETUP_RW([AND requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -464,7 +444,6 @@ for pkg in two three; do
 done
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 # unsatisfied AND require - all missing
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
@@ -476,7 +455,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 
 # unsatisfied AND require - first is missing
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -488,7 +466,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # unsatisfied AND require - second is missing
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -500,7 +477,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied AND require
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -511,9 +487,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([OR requires])
+RPMTEST_SETUP_RW([OR requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -570,9 +545,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([IF requires])
+RPMTEST_SETUP_RW([IF requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -587,7 +561,6 @@ done
 
 # unsatisfied IF require
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -599,7 +572,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied IF require
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -608,9 +580,8 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([IF-ELSE requires])
+RPMTEST_SETUP_RW([IF-ELSE requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -658,9 +629,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([nested AND-OR requires])
+RPMTEST_SETUP_RW([nested AND-OR requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -674,7 +644,6 @@ for pkg in two three; do
 done
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 # unsatisfied nested AND-OR require
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -686,7 +655,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 
 # satisfied nested AND-OR require
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -697,9 +665,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([nested AND-IF requires])
+RPMTEST_SETUP_RW([nested AND-IF requires])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -735,9 +702,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([install to break installed rich dependency])
+RPMTEST_SETUP_RW([install to break installed rich dependency])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -756,7 +722,6 @@ runroot rpmbuild --quiet -bb \
 
 # installed conflict with "or" clause
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
@@ -769,7 +734,6 @@ runroot rpm -U /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 
 # installed requires with "if" clause
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/deptest-four-1.0-1.noarch.rpm
@@ -783,9 +747,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 #
-RPMTEST_SETUP([erase to break installed rich dependency])
+RPMTEST_SETUP_RW([erase to break installed rich dependency])
 AT_KEYWORDS([install, boolean])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -807,7 +770,6 @@ runroot rpmbuild --quiet -bb \
 
 # installed requires with "or" clause
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 runroot rpm -e deptest-three
@@ -820,7 +782,6 @@ runroot rpm -e deptest-three
 
 # installed conflicts with "unless" clause
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-four-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-five-1.0-1.noarch.rpm
 runroot rpm -e deptest-four

--- a/tests/rpmdevel.at
+++ b/tests/rpmdevel.at
@@ -35,9 +35,8 @@ LD_PRELOAD=${ASANLIB} ./trpm
 )
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm plugin development])
+RPMTEST_SETUP_RW([rpm plugin development])
 AT_KEYWORDS([devel])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	/data/SPECS/simple.spec \

--- a/tests/rpme.at
+++ b/tests/rpme.at
@@ -1,7 +1,6 @@
 
-RPMTEST_SETUP([rpm -e and verify files removed])
+RPMTEST_SETUP_RW([rpm -e and verify files removed])
 AT_KEYWORDS([install erase rpmdb])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -25,9 +24,8 @@ missing   d /usr/share/doc/hello-2.0/README
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -e suid hardlink])
+RPMTEST_SETUP_RW([rpm -e suid hardlink])
 AT_KEYWORDS([install erase])
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
 		/data/SPECS/attrtest.spec
@@ -47,9 +45,8 @@ exists
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm reinstall with shared files])
+RPMTEST_SETUP_RW([rpm reinstall with shared files])
 AT_KEYWORDS([install erase update rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 3" \
@@ -90,9 +87,8 @@ runroot rpm -Vv --nodeps --nogroup --nouser hello.i686 hello.x86_64
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -e and shared files removed 1.1])
+RPMTEST_SETUP_RW([rpm -e and shared files removed 1.1])
 AT_KEYWORDS([install erase rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 3" \
@@ -135,9 +131,8 @@ missing     /usr/bin/hello
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -e and shared files removed 1.2])
+RPMTEST_SETUP_RW([rpm -e and shared files removed 1.2])
 AT_KEYWORDS([install erase rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 3" \
@@ -181,9 +176,8 @@ missing   d /usr/share/doc/hello-2.0/README
 
 RPMTEST_CLEANUP
 # Test that removing shared or wrong colored files has no effect
-RPMTEST_SETUP([rpm -e and verify colored files removed 1.1])
+RPMTEST_SETUP_RW([rpm -e and verify colored files removed 1.1])
 AT_KEYWORDS([install erase rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -207,11 +201,9 @@ RPMTEST_CLEANUP
 # XXX This is wrong really, rpm shouldn't let the real provider of
 # a shared file get removed - and unforced action shouldn't result
 # in verify failure.
-RPMTEST_SETUP([rpm -e and verify colored files removed 1.2])
+RPMTEST_SETUP_RW([rpm -e and verify colored files removed 1.2])
 AT_KEYWORDS([install erase rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 3" \
@@ -231,12 +223,10 @@ runroot rpm -Vv --nodeps --nogroup --nouser hello
 RPMTEST_CLEANUP
 
 # Test that shared colored files actually get removed regardless of order 1
-RPMTEST_SETUP([rpm -e and verify colored files removed 2.1])
+RPMTEST_SETUP_RW([rpm -e and verify colored files removed 2.1])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_KEYWORDS([install erase rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 2" \
@@ -256,12 +246,10 @@ missing   d /usr/share/doc/hello-2.0/README
 RPMTEST_CLEANUP
 
 # Test that shared colored files actually get removed regardless of order 2
-RPMTEST_SETUP([rpm -e and verify colored files removed 2.2])
+RPMTEST_SETUP_RW([rpm -e and verify colored files removed 2.2])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_KEYWORDS([install erase rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	--define "_transaction_color 2" \
@@ -280,9 +268,8 @@ missing   d /usr/share/doc/hello-2.0/README
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -e and verify conflicting files removed 1])
+RPMTEST_SETUP_RW([rpm -e and verify conflicting files removed 1])
 AT_KEYWORDS([install erase rpmdb])
-RPMTEST_INIT
 for p in a b; do
     runroot rpmbuild -bb --quiet \
 		--define "pkg ${p}" \
@@ -359,10 +346,9 @@ RPMTEST_CLEANUP
 
 # Test %_netsharedpath erasure. It's a bit weird as we're abusing verify
 # on non-installed package to see if files are there.
-RPMTEST_SETUP([rpm -e and verify netshared files not removed])
+RPMTEST_SETUP_RW([rpm -e and verify netshared files not removed])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
 	/data/RPMS/hello-2.0-1.x86_64.rpm

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -51,9 +51,8 @@ RPMTEST_CHECK_PINNED([rpmlibver])
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([rpm --showrc])
+RPMTEST_SETUP_RW([rpm --showrc])
 AT_KEYWORDS([basic])
-RPMTEST_INIT
 RPMTEST_CHECK([
 mkdir -p ${RPMTEST}/${RPMSYSCONFDIR}
 echo x86_64_v3-Linux > ${RPMTEST}/${RPMSYSCONFDIR}/platform
@@ -431,9 +430,8 @@ runroot_other rpm2archive "${RPMTEST}"/data/SRPMS/hello-1.0-1.src.rpm | tar tzf 
 
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([urlhelper missing])
+RPMTEST_SETUP_RW([urlhelper missing])
 AT_KEYWORDS([urlhelper])
-RPMTEST_INIT
 RPMTEST_CHECK([
 # runroot rpm --define "_urlhelper /not/there" --root /srv/test -qp https://example.com/foo-0.1-1.noarch.rpm
 runroot rpm --define "_urlhelper /not/there" -qp https://www.example.com/foo-1.0-1.x86_64.rpm
@@ -445,9 +443,8 @@ error: open of https://www.example.com/foo-1.0-1.x86_64.rpm failed: No such file
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([urlhelper fails])
+RPMTEST_SETUP_RW([urlhelper fails])
 AT_KEYWORDS([urlhelper])
-RPMTEST_INIT
 
 cat << EOF > "${RPMTEST}"/tmp/fakecurl
 #!/bin/sh

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -46,7 +46,7 @@ RPMTEST_CLEANUP
 # Check that libtool versioning matches expectations, it's easy to screw up.
 RPMTEST_SETUP([rpm library version])
 AT_KEYWORDS([basic])
-AT_SKIP_IF(test -f "${RPMTEST}/${RPMLIBDIR}/librpm.a")
+RPMTEST_SKIP_IF(test -f "${RPMTEST}/${RPMLIBDIR}/librpm.a")
 RPMTEST_CHECK_PINNED([rpmlibver])
 RPMTEST_CLEANUP
 

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -283,7 +283,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U <signed nokey 1>])
 AT_KEYWORDS([install])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -298,7 +298,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U <signed nokey 2>])
 AT_KEYWORDS([install])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -315,7 +315,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U <signed 1>])
 AT_KEYWORDS([install])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -330,7 +330,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U <signed 2>])
 AT_KEYWORDS([install])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -346,7 +346,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U <corrupted signed 1>])
 AT_KEYWORDS([install])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK_UNQUOTED([
 RPMTEST_INIT
 
@@ -373,7 +373,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U <corrupted signed 2>])
 AT_KEYWORDS([install])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -396,7 +396,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U <corrupted signed 3>])
 AT_KEYWORDS([install])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1526,7 +1526,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm -U dev])
 AT_KEYWORDS([install])
-AT_SKIP_IF([$MKNOD_DISABLED])
+RPMTEST_SKIP_IF([$MKNOD_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -18,10 +18,9 @@
 
 AT_BANNER([RPM install tests])
 
-RPMTEST_SETUP([rpm -U <manifest>])
+RPMTEST_SETUP_RW([rpm -U <manifest>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo /data/RPMS/hello-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -32,10 +31,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <manifest glob>])
+RPMTEST_SETUP_RW([rpm -U <manifest glob>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo "/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm" > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -46,10 +44,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <manifest glob fallback>])
+RPMTEST_SETUP_RW([rpm -U <manifest glob fallback>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 cp "${RPMTEST}/data/RPMS/hello-2.0-1.i686.rpm" \
    "${RPMTEST}/tmp/fallback-[[123]].0-1.i686.rpm"
@@ -64,10 +61,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <manifest notfound 1>])
+RPMTEST_SETUP_RW([rpm -U <manifest notfound 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo /data/RPMS/hello-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -79,10 +75,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <manifest notfound 2>])
+RPMTEST_SETUP_RW([rpm -U <manifest notfound 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo /data/RPMS/hello-not-there-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -94,10 +89,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <manifest notfound 3>])
+RPMTEST_SETUP_RW([rpm -U <manifest notfound 3>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo /data/RPMS/hello-not-there-1.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
 echo /data/RPMS/hello-not-there-2.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
@@ -113,10 +107,9 @@ error: open of /data/RPMS/hello-not-there-3.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <manifest notfound 4>])
+RPMTEST_SETUP_RW([rpm -U <manifest notfound 4>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo "/data/RPMS/hello-not-there-*.x86_64.rpm" > ${RPMTEST}/tmp/test.mft
 echo /data/RPMS/hello-not-there-1.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
@@ -132,10 +125,9 @@ error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <notfound>])
+RPMTEST_SETUP_RW([rpm -U <notfound>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-not-there-2.0-1.x86_64.rpm
@@ -146,10 +138,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <notfound 2>])
+RPMTEST_SETUP_RW([rpm -U <notfound 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
@@ -164,10 +155,9 @@ error: open of /data/RPMS/hello-not-there-3.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <unsigned 1>])
+RPMTEST_SETUP_RW([rpm -U <unsigned 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
@@ -177,10 +167,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <unsigned 2>])
+RPMTEST_SETUP_RW([rpm -U <unsigned 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	--define "_pkgverify_level signature" \
@@ -192,10 +181,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <corrupted unsigned 1>])
+RPMTEST_SETUP_RW([rpm -U <corrupted unsigned 1>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -238,10 +226,9 @@ error: hello-2.0-1.x86_64: install failed
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <corrupted unsigned 2>])
+RPMTEST_SETUP_RW([rpm -U <corrupted unsigned 2>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -281,11 +268,10 @@ error: hello-2.0-1.x86_64: install failed
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <signed nokey 1>])
+RPMTEST_SETUP_RW([rpm -U <signed nokey 1>])
 AT_KEYWORDS([install])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-2.0-1.x86_64-signed.rpm
@@ -296,11 +282,10 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <signed nokey 2>])
+RPMTEST_SETUP_RW([rpm -U <signed nokey 2>])
 AT_KEYWORDS([install])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	--define "_pkgverify_level signature" \
@@ -313,11 +298,10 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <signed 1>])
+RPMTEST_SETUP_RW([rpm -U <signed 1>])
 AT_KEYWORDS([install])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -328,11 +312,10 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <signed 2>])
+RPMTEST_SETUP_RW([rpm -U <signed 2>])
 AT_KEYWORDS([install])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -344,11 +327,10 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <corrupted signed 1>])
+RPMTEST_SETUP_RW([rpm -U <corrupted signed 1>])
 AT_KEYWORDS([install])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK_UNQUOTED([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -371,11 +353,10 @@ error: /tmp/hello-2.0-1.x86_64-signed.rpm cannot be installed
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <corrupted signed 2>])
+RPMTEST_SETUP_RW([rpm -U <corrupted signed 2>])
 AT_KEYWORDS([install])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -394,11 +375,10 @@ error: /tmp/hello-2.0-1.x86_64-signed.rpm cannot be installed
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <corrupted signed 3>])
+RPMTEST_SETUP_RW([rpm -U <corrupted signed 3>])
 AT_KEYWORDS([install])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -453,10 +433,9 @@ error: hello-2.0-1.x86_64: install failed
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <glob>])
+RPMTEST_SETUP_RW([rpm -U <glob>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	"/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm"
@@ -466,10 +445,9 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <glob notfound>])
+RPMTEST_SETUP_RW([rpm -U <glob notfound>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	"/data/RPMS/hello-not-there-*.x86_64.rpm" \
@@ -484,10 +462,9 @@ error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file 
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <glob fallback>])
+RPMTEST_SETUP_RW([rpm -U <glob fallback>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 cp "${RPMTEST}/data/RPMS/hello-2.0-1.i686.rpm" \
    "${RPMTEST}/tmp/fallback-[[123]].0-1.i686.rpm"
@@ -502,10 +479,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test tid/time overrides using SOURCE_DATE_EPOCH
-RPMTEST_SETUP([rpm -i <overridden time>])
+RPMTEST_SETUP_RW([rpm -i <overridden time>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64"
 timestamp=97445
@@ -531,10 +507,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test multiple installs using SOURCE_DATE_EPOCH
-RPMTEST_SETUP([rpm -i <overridden time keeps ticking>])
+RPMTEST_SETUP_RW([rpm -i <overridden time keeps ticking>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 timestamp=1445412535
 
@@ -555,10 +530,9 @@ Install Date: Wed Oct 21 07:28:56 2015
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i --nodb])
+RPMTEST_SETUP_RW([rpm -i --nodb])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm \
   -U --nodb /data/RPMS/hlinktest-1.0-1.noarch.rpm
@@ -579,10 +553,9 @@ runroot_other find /foo|sort
 
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i --justdb])
+RPMTEST_SETUP_RW([rpm -i --justdb])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # avoid having to deal with non-existent /foo in the find below
 runroot_other mkdir /foo
@@ -600,7 +573,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpm -U *.src.rpm works
-RPMTEST_SETUP([rpm -U *.src.rpm])
+RPMTEST_SETUP_RW([rpm -U *.src.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 rpm \
@@ -620,7 +593,7 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpm -i *.src.rpm works
-RPMTEST_SETUP([rpm -i *.src.rpm])
+RPMTEST_SETUP_RW([rpm -i *.src.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 rpm \
@@ -640,10 +613,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Check if rpm -i *.src.rpm *.rpm works
-RPMTEST_SETUP([rpm -i *.src.rpm *.rpm])
+RPMTEST_SETUP_RW([rpm -i *.src.rpm *.rpm])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm \
   --define "_topdir /tmp/build" \
@@ -668,10 +640,9 @@ RPMTEST_CLEANUP
 # ------------------------------
 # Various error behavior tests
 #
-RPMTEST_SETUP([rpm -i <nonexistent file>])
+RPMTEST_SETUP_RW([rpm -i <nonexistent file>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   -i no_such_file
 ],
@@ -681,10 +652,9 @@ runroot rpm \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i --nomanifest <garbage text file>])
+RPMTEST_SETUP_RW([rpm -i --nomanifest <garbage text file>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 junk="${RPMTEST}/textfile"
 cat << EOF > "${junk}"
 no_such.file
@@ -700,10 +670,9 @@ runroot rpm \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i <garbage text file])
+RPMTEST_SETUP_RW([rpm -i <garbage text file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 junk="${RPMTEST}/not_an.rpm"
 cat << EOF > "${junk}"
 no_such.file
@@ -721,8 +690,7 @@ error: open of not_pkg.rpm failed: No such file or directory
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([rpm upgrade/downgrade])
-RPMTEST_INIT
+RPMTEST_SETUP_RW([rpm upgrade/downgrade])
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -894,8 +862,7 @@ runroot rpm -q versiontest
 
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm upgrade/downgrade epoch])
-RPMTEST_INIT
+RPMTEST_SETUP_RW([rpm upgrade/downgrade epoch])
 
 runroot rpmbuild --quiet -bb --define "ver 1.0" /data/SPECS/versiontest.spec
 runroot_other cp /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm /tmp/noepoch.rpm
@@ -1031,9 +998,8 @@ runroot rpm -U --replacepkgs /tmp/epoch1.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U obsoleted packages])
+RPMTEST_SETUP_RW([rpm -U obsoleted packages])
 AT_KEYWORDS([install obsolete])
-RPMTEST_INIT
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
 	--define "obs deptest-two <= 1.0" \
@@ -1096,10 +1062,9 @@ deptest-one-1.0-1.noarch
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U with invalid --relocate])
+RPMTEST_SETUP_RW([rpm -U with invalid --relocate])
 AT_KEYWORDS([install relocate])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -1112,10 +1077,9 @@ runroot rpm -U --test --ignoreos --relocate /usr=/opt \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U --badreloc with invalid --relocate])
+RPMTEST_SETUP_RW([rpm -U --badreloc with invalid --relocate])
 AT_KEYWORDS([install relocate])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
@@ -1127,9 +1091,8 @@ runroot rpm -U --test --ignoreos --badreloc --relocate /usr=/opt \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i relocatable package])
+RPMTEST_SETUP_RW([rpm -i relocatable package])
 AT_KEYWORDS([install relocate])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/reloc.spec
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
@@ -1172,9 +1135,8 @@ runroot rpm -U --relocate /opt/bin=/bin \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i relocatable package 2])
+RPMTEST_SETUP_RW([rpm -i relocatable package 2])
 AT_KEYWORDS([install relocate])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/reloc.spec
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
@@ -1207,10 +1169,9 @@ runroot rpm -ql reloc
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i relocatable package 3])
+RPMTEST_SETUP_RW([rpm -i relocatable package 3])
 AT_KEYWORDS([install relocate])
 RPMTEST_USER
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/rootfs.spec
 
@@ -1232,10 +1193,9 @@ runroot_user test ! -d \$PWD/root
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i with/without --excludedocs])
+RPMTEST_SETUP_RW([rpm -i with/without --excludedocs])
 AT_KEYWORDS([install excludedocs])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/testdoc.spec
 
@@ -1265,13 +1225,11 @@ runroot rpm -e testdoc
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i --excludeartifacts])
+RPMTEST_SETUP_RW([rpm -i --excludeartifacts])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 runroot rpmbuild --quiet -bb /data/SPECS/vattrtest.spec
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i --excludeartifacts /build/RPMS/noarch/vattrtest-1.0-1.noarch.rpm
 test -e ${RPMTEST}/opt/vattrtest/a && exit 1
 runroot rpm -e vattrtest
@@ -1283,9 +1241,8 @@ test -e ${RPMTEST}/opt/vattrtest/a || exit 1
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U <suicidal>])
+RPMTEST_SETUP_RW([rpm -U <suicidal>])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 for r in 1 2; do
     runroot rpmbuild -bb --quiet \
@@ -1324,9 +1281,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # hardlink tests
-RPMTEST_SETUP([rpm -i hardlinks])
+RPMTEST_SETUP_RW([rpm -i hardlinks])
 AT_KEYWORDS([build install])
-RPMTEST_INIT
 
 pkg="/data/RPMS/hlinktest-1.0-1.noarch.rpm"
 
@@ -1343,7 +1299,6 @@ dd if=/dev/zero of="${RPMTEST}/tmp/3.rpm" \
    conv=notrunc bs=1 seek=8050 count=6 2> /dev/null
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i --noverify /tmp/1.rpm
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
@@ -1355,7 +1310,6 @@ error: hlinktest-1.0-1.noarch: install failed
 ])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i --noverify /tmp/2.rpm
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
@@ -1367,7 +1321,6 @@ error: hlinktest-1.0-1.noarch: install failed
 ])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i --noverify /tmp/3.rpm 2>&1| sed 's/;.*:/:/g'
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
@@ -1379,7 +1332,6 @@ error: hlinktest-1.0-1.noarch: install failed
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i "${pkg}"
 runroot rpm -q --qf "[[%{filenlinks} %{filenames}\n]]%{longsize}\n" hlinktest
 ls -i "${RPMTEST}"/foo/hello* | awk {'print $1'} | sort -u | wc -l
@@ -1401,7 +1353,6 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i --excludepath=/foo/zzzz "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
@@ -1419,7 +1370,6 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i --excludepath=/foo/aaaa "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
@@ -1437,7 +1387,6 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i --excludepath=/foo/aaaa --excludepath=/foo/zzzz "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
@@ -1455,7 +1404,6 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -i --excludepath=/foo/hello-foo "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
@@ -1473,7 +1421,6 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpmbuild -bb --quiet --with crossdir_links /data/SPECS/hlinktest.spec
 runroot rpm -U /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
 runroot rpm -Vav --nouser --nogroup
@@ -1493,10 +1440,9 @@ runroot rpm -Vav --nouser --nogroup
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U filesystem])
+RPMTEST_SETUP_RW([rpm -U filesystem])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/fs.spec
 runroot rpm -U --ignoreos /build/RPMS/noarch/fs-1.0-1.noarch.rpm
@@ -1509,10 +1455,9 @@ runroot rpm -q --whatprovides /
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U fifo])
+RPMTEST_SETUP_RW([rpm -U fifo])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/fifo.spec
 runroot rpm -U --ignoreos /build/RPMS/noarch/fifo-1.0-1.noarch.rpm
@@ -1524,11 +1469,10 @@ runroot rpm -Vv --nouser --nogroup fifo
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U dev])
+RPMTEST_SETUP_RW([rpm -U dev])
 AT_KEYWORDS([install])
 RPMTEST_SKIP_IF([$MKNOD_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet /data/SPECS/dev.spec
 runroot rpm -U --ignoreos /build/RPMS/noarch/dev-1.0-1.noarch.rpm
@@ -1541,10 +1485,9 @@ runroot rpm -Vv --nouser --nogroup dev
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -U with Obsoletes])
+RPMTEST_SETUP_RW([rpm -U with Obsoletes])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet --define "pkg obsoletes" \
   /data/SPECS/deptest.spec
@@ -1561,10 +1504,9 @@ deptest-test-obsoletes-1.0-1.noarch
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i create user])
+RPMTEST_SETUP_RW([rpm -i create user])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser u myuser 876 - /home/myuser /bin/sh}"\
   /data/SPECS/deptest.spec
@@ -1578,10 +1520,9 @@ runroot rpm -V --root /alt ${VERIFYOPTS} deptest-user
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i create group])
+RPMTEST_SETUP_RW([rpm -i create group])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser g mygroup 678}"\
   /data/SPECS/deptest.spec
@@ -1595,9 +1536,8 @@ runroot rpm -V ${VERIFYOPTS} deptest-user
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -i sysusers])
+RPMTEST_SETUP_RW([rpm -i sysusers])
 AT_KEYWORDS([install build sysusers])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot rpmbuild -bb -D "_use_weak_usergroup_deps 1" --quiet /data/SPECS/klang.spec
@@ -1716,9 +1656,8 @@ klangd
 
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([install on invalid symlinked directory])
+RPMTEST_SETUP_RW([install on invalid symlinked directory])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
           /data/SPECS/replacetest.spec
@@ -1737,9 +1676,8 @@ error: replacetest-1.0-1.noarch: install failed
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([update on invalid symlinked directory])
+RPMTEST_SETUP_RW([update on invalid symlinked directory])
 AT_KEYWORDS([install update symlink])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 for r in 1 2; do
@@ -1777,11 +1715,11 @@ runroot rpm -V --nomtime pamupdate
 [])
 RPMTEST_CLEANUP
 
+# Leave the fs read-only for a reproducible result
 RPMTEST_SETUP([rpm -U diskspace])
 AT_KEYWORDS([install diskspace])
 RPMTEST_CHECK([
 
-# Skip RPMTEST_INIT to leave the fs read-only for a reproducible result
 runroot rpm -U --nodb --test --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 ],

--- a/tests/rpmio.at
+++ b/tests/rpmio.at
@@ -3,11 +3,9 @@
 AT_BANNER([I/O])
 
 # test too unstable for production
-#RPMTEST_SETUP([SIGPIPE from --pipe])
+#RPMTEST_SETUP_RW([SIGPIPE from --pipe])
 #AT_KEYWORDS([signals])
 #RPMTEST_CHECK([
-#RPMDB_CLEAR
-#RPMTEST_INIT
 #
 #runroot rpmbuild --quiet --with manyfiles -bb /data/SPECS/sigpipe.spec
 #runroot rpm -qpl /build/RPMS/noarch/sigpipe-1.0-1.noarch.rpm --pipe "cat" | head -1
@@ -18,10 +16,9 @@ AT_BANNER([I/O])
 #[])
 #RPMTEST_CLEANUP
 
-RPMTEST_SETUP([SIGPIPE from install scriptlet])
+RPMTEST_SETUP_RW([SIGPIPE from install scriptlet])
 AT_KEYWORDS([signals])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/sigpipe.spec
 runroot rpm -U --nodeps /build/RPMS/noarch/sigpipe-1.0-1.noarch.rpm
@@ -34,11 +31,9 @@ RPMTEST_CLEANUP
 # XXX TODO: test for RhBug:471591 too, but needs a simpler reproducer
 
 # test too unstable for production
-#RPMTEST_SETUP([SIGPIPE in build scriptlet])
+#RPMTEST_SETUP_RW([SIGPIPE in build scriptlet])
 #AT_KEYWORDS([signals])
 #RPMTEST_CHECK([
-#RPMDB_CLEAR
-#RPMTEST_INIT
 #
 #run rpmbuild --quiet --with buildpipe -bb "${RPMDATA}/SPECS/sigpipe.spec"
 #],
@@ -50,7 +45,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmlog error handling])
 AT_KEYWORDS([log])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -qpl /data/RPMS/hello-2.0-1.x86_64.rpm > /dev/full
 ],

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -2,9 +2,8 @@
 #
 AT_BANNER([RPM macros])
 
-RPMTEST_SETUP([macro path])
+RPMTEST_SETUP_RW([macro path])
 AT_KEYWORDS([macros])
-RPMTEST_INIT
 
 # .rpmmacros exists, new directory not
 RPMTEST_CHECK([[
@@ -40,9 +39,8 @@ runroot --setenv  XDG_CONFIG_HOME "~/.zzz" rpm --showrc | awk '/^Macro path/{pri
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([macro path: skip editor backups])
+RPMTEST_SETUP_RW([macro path: skip editor backups])
 AT_KEYWORDS([macros])
-RPMTEST_INIT
 RPMTEST_CHECK([
 echo '%this that' > $RPMTEST/$RPM_CONFIGDIR_PATH/macros.d/macros.this
 runroot rpm --eval '%{this}'
@@ -173,10 +171,9 @@ rpm --define 'aaa %\\[%aaa\\]' --eval '%aaa'
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([parametrized macro 1])
+RPMTEST_SETUP_RW([parametrized macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-RPMTEST_INIT
 cat << EOF > mtest
 %bar() bar
 %foo()\\
@@ -355,7 +352,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([uncompress 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-RPMTEST_INIT
 echo xxxxxxxxxxxxxxxxxxxxxxxxx > "some%%ath"
 ${RPM_CONFIGDIR_PATH}/rpmuncompress "some%%ath"
 ],
@@ -404,7 +400,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([uncompress 4])
 AT_KEYWORDS([macros rpmuncompress])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 runroot_other mkdir -p /tmp/1
@@ -451,7 +446,7 @@ runroot_other --chdir /tmp/2 find . | sort
 [ignore])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([getncpus macro])
+RPMTEST_SETUP_RW([getncpus macro])
 AT_KEYWORDS([macros])
 # skip if nproc not available
 RPMTEST_SKIP_IF([test -z "$(nproc 2>/dev/null)"])
@@ -1112,10 +1107,9 @@ error: lua script failed: [[string "<lua>"]]:1: redirect2null not permitted in t
 )
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([lua library path])
+RPMTEST_SETUP_RW([lua library path])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-RPMTEST_INIT
 f=$(rpm --eval "%{_rpmconfigdir}/lua/foo.lua")
 echo "bar = 'graak'" > ${RPMTEST}/${f}
 runroot rpm \
@@ -1129,7 +1123,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([lua auto-print])
 AT_KEYWORDS([macros lua])
-RPMTEST_INIT
 RPMTEST_CHECK([[
 rpm \
     --define 'foo() %{lua:return string.reverse(arg[1])}' \
@@ -1162,7 +1155,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([lua rpm io stream])
 AT_KEYWORDS([macros lua])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --eval '%{lua: local f = rpm.open("zzz", "w+"); f:write("gggg"); print(f:seek("cur")); f:close()}' \
   --eval '%{lua: local f = rpm.open("zzz"); print(f:read()); f:close()}' \
@@ -1521,7 +1513,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmlua])
 AT_KEYWORDS([lua])
-RPMTEST_INIT
 RPMTEST_CHECK([
 rpmlua /data/t1.lua a b
 ],

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -454,7 +454,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([getncpus macro])
 AT_KEYWORDS([macros])
 # skip if nproc not available
-AT_SKIP_IF([test -z "$(nproc 2>/dev/null)"])
+RPMTEST_SKIP_IF([test -z "$(nproc 2>/dev/null)"])
 RPMTEST_CHECK([
 mem=$(expr $(getconf PAGESIZE) \* $(getconf _PHYS_PAGES) / 1024 / 1024)
 expr $(rpm --eval "%{getncpus}") = $(nproc)

--- a/tests/rpmorder.at
+++ b/tests/rpmorder.at
@@ -1,8 +1,7 @@
 AT_BANNER([RPM install/erase ordering])
 
-RPMTEST_SETUP([basic install/erase order 1])
+RPMTEST_SETUP_RW([basic install/erase order 1])
 AT_KEYWORDS([install erase order])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -47,9 +46,8 @@ deptest-three-1.0-1.noarch
 RPMTEST_CLEANUP
 
 # same as above but with mixed weak dependencies
-RPMTEST_SETUP([basic install/erase order 2])
+RPMTEST_SETUP_RW([basic install/erase order 2])
 AT_KEYWORDS([install erase order])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -96,9 +94,8 @@ RPMTEST_CLEANUP
 # same as above but with all weak reverse dependencies
 # these are all considered meta by ordering, so order is simply reverse
 # of the cli
-RPMTEST_SETUP([basic install/erase order 3])
+RPMTEST_SETUP_RW([basic install/erase order 3])
 AT_KEYWORDS([install erase order])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \

--- a/tests/rpmpgp.at
+++ b/tests/rpmpgp.at
@@ -5,7 +5,7 @@ AT_BANNER([RPM OpenPGP parsing])
 # Test OpenPGP parsing
 RPMTEST_SETUP([[Running tests for malformed OpenPGP packages]])
 AT_KEYWORDS([[rpmkeys digest OpenPGP]])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([[
 rpmpgpcheck
 ]],0,)
@@ -14,7 +14,7 @@ RPMTEST_CLEANUP
 # Test pgpPubkeyFingerprint
 RPMTEST_SETUP([[Running tests for computing OpenPGP fingerprints]])
 AT_KEYWORDS([[rpmkeys digest OpenPGP]])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 # Note: the internal OpenPGP parser produces a warning when fed
 # bad data.  Don't force Sequoia to generate the same warning.
 RPMTEST_CHECK([[

--- a/tests/rpmpkgfmt.at
+++ b/tests/rpmpkgfmt.at
@@ -1,6 +1,5 @@
-RPMTEST_SETUP([rpm v4 format])
+RPMTEST_SETUP_RW([rpm v4 format])
 AT_KEYWORDS([rpmformat v4])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 cp /data/misc/rpmdump4.txt expout
@@ -23,9 +22,8 @@ rpm -qp --qf "%{rpmformat}\n" ${RPMTEST}/build/RPMS/4/noarch/attrtest-1.0-1.noar
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm v6 format])
+RPMTEST_SETUP_RW([rpm v6 format])
 AT_KEYWORDS([rpmformat v6])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 cp /data/misc/rpmdump6.txt expout
@@ -50,7 +48,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpm v3 format])
 AT_KEYWORDS([rpmformat install query v3])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -qpl /data/RPMS/hello-1.0-1.x86_64.rpm-v3
 ],

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -219,7 +219,7 @@ myprint(h['arch'])
 
 RPMTEST_SETUP([reading a signed package file])
 AT_KEYWORDS([python])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMPY_CHECK([
 # avoid rpmlog spew with absolute path to package
 sink = open('/dev/null', 'w')

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -444,9 +444,8 @@ ts.run(callback=ncb, data=cbd)
 <class 'NoneType'> 64 6 1 mine]
 )
 
-RPMTEST_SETUP([database iterators])
+RPMTEST_SETUP_RW([database iterators])
 AT_KEYWORDS([python rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -i \
   --justdb --nodeps --ignorearch --ignoreos \
@@ -534,9 +533,8 @@ hi
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([database cookies])
+RPMTEST_SETUP_RW([database cookies])
 AT_KEYWORDS([python rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
 ],
 [0],

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -409,7 +409,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([pgpsig extension query])
 AT_KEYWORDS([query signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 rpm \

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -22,7 +22,6 @@ AT_BANNER([RPM queries])
 RPMTEST_SETUP([rpm --qf -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -q --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
   -p /data/RPMS/hello-2.0-1.i686.rpm
@@ -37,7 +36,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm --qf -p *.src.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -q --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
   -p /data/SRPMS/hello-1.0-1.src.rpm
@@ -52,7 +50,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <glob>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -qp "/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm"
 ],
@@ -66,7 +63,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <glob fallback>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 cp "/data/RPMS/hello-1.0-1.i386.rpm" \
    "/tmp/fallback-[[123]].0-1.i386.rpm"
@@ -83,7 +79,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <notfound>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -qp /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
       /data/RPMS/hello-not-there-2.0-1.x86_64.rpm \
@@ -100,7 +95,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <glob notfound>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -qp "/data/RPMS/hello-not-there-*.x86_64.rpm" \
       /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
@@ -118,7 +112,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -ql -p *.src.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -ql \
   -p /data/SRPMS/hello-1.0-1.src.rpm
@@ -134,7 +127,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -ql multiple *.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -ql \
   /data/SRPMS/hello-1.0-1.src.rpm /data/RPMS/hello-1.0-1.i386.rpm
@@ -152,7 +144,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp --dump])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -qp --dump \
   /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -171,7 +162,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmspec -q])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpmspec \
   -q --qf "%{name}" /data/SPECS/hello.spec
 ],
@@ -184,7 +174,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -ql -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -ql \
   -p /data/RPMS/hello-1.0-1.i386.rpm
@@ -202,7 +191,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -qp <manifest>])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 cat << EOF > query.mft
 /data/RPMS/hello-1.0-1.i386.rpm
 /data/RPMS/hello-1.0-1.ppc64.rpm
@@ -224,7 +212,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpm -q --scripts -p *.i386.rpm])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   -q --scripts \
   -p /data/RPMS/hello-1.0-1.i386.rpm
@@ -242,12 +229,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 # install a package into a local rpmdb
 # * Use --ignorearch because we don't know the arch
-RPMTEST_SETUP([rpm -q on installed package])
+RPMTEST_SETUP_RW([rpm -q on installed package])
 AT_KEYWORDS([rpmdb install query])
 
 RPMTEST_CHECK([
-RPMTEST_INIT
-
 runroot rpm \
   --noscripts --nodeps --ignorearch \
   -i /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -288,10 +273,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # query a package by a file
-RPMTEST_SETUP([rpm -qf])
+RPMTEST_SETUP_RW([rpm -qf])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   --nodeps \
   --ignorearch \
@@ -305,10 +289,9 @@ runroot rpm \
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -qf on non-installed file])
+RPMTEST_SETUP_RW([rpm -qf on non-installed file])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   --nodeps \
   --excludedocs \
@@ -323,10 +306,9 @@ runroot rpm \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm -q --path on non-installed file])
+RPMTEST_SETUP_RW([rpm -q --path on non-installed file])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   --nodeps \
   --excludedocs \
@@ -345,7 +327,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([integer array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%{filemodes}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -362,7 +343,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([formatted filesbypkg query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%-10{=NAME} %{FILENAMES}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -379,7 +359,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([hex formatted integer array extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%5{longfilesizes:hex}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -396,7 +375,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([base64 extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   --queryformat="%{pkgid:base64}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -411,7 +389,6 @@ RPMTEST_SETUP([pgpsig extension query])
 AT_KEYWORDS([query signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
     --queryformat="%{rsaheader:pgpsig}" \
     -qp /data/RPMS/hello-2.0-1.x86_64-signed.rpm
@@ -438,7 +415,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([integer array perms format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   --queryformat="[[%{filemodes:perms}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -455,7 +431,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([string array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%{basenames} ]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -469,7 +444,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([empty string array query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   --queryformat="[[%{basenames}]]" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -483,7 +457,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([empty string array extension array format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%{filenames}]]" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -497,7 +470,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([empty string array extension query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="%{filenames}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -511,7 +483,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([different sizes arrays query 1])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%{basenames} %{changelogname}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -528,7 +499,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([different sizes arrays query 2])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%{name} %{changelogtime}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -543,7 +513,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([different sizes arrays query 3])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%{name} %{basenames}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -558,7 +527,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([different sizes arrays query 4])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="[[%{=name} %{basenames}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -575,7 +543,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([non-existent string tag])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="%{vendor}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -589,7 +556,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([non-existent integer tag query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm \
   --queryformat="%{installcolor}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -603,7 +569,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([conditional queryformat])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="%|name?{%{name}}:{no}| %|installtime?{%{installtime}}:{(not installed)}|" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -617,7 +582,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([invalid tag query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="%{notag}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -632,7 +596,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([invalid data for format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="%{name:depflags}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -646,7 +609,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([invalid format width query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat="%ss{size}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -660,7 +622,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([xml format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm -qp --xml  /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
@@ -960,7 +921,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([json format 1])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm -qp --json  /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
@@ -1196,9 +1156,8 @@ rpm -qp --json  /data/RPMS/hello-2.0-1.x86_64.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([json format 2])
+RPMTEST_SETUP_RW([json format 2])
 AT_KEYWORDS([query])
-RPMTEST_INIT
 runroot rpmbuild --quiet -bb /data/SPECS/weirdnames.spec
 
 RPMTEST_CHECK([
@@ -1219,10 +1178,9 @@ print(len(json.loads(s)))
 RPMTEST_CLEANUP
 
 
-RPMTEST_SETUP([query file attribute filtering])
+RPMTEST_SETUP_RW([query file attribute filtering])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpmbuild -bb --quiet \
   /data/SPECS/vattrtest.spec
 
@@ -1277,7 +1235,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([formatting name humansi, humaniec])
 AT_KEYWORDS([query, humansi, humaniec])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat '%{SIZE:humansi} %{SIZE:humaniec}\n' \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -1300,7 +1257,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([incomplete escape sequence for format query])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 rpm \
   --queryformat='%{NAME}\n\' \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -1314,7 +1270,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([query format iteration])
 AT_KEYWORDS([query])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 rpmspec -q --qf "[[%{*:tagnum}\n]]" --srpm /data/SPECS/mini.spec
@@ -1354,9 +1309,8 @@ Sourcepackage
 RPMTEST_CLEANUP
 
 # my autotest fu fails to deal with trailing whitespace except by trimming it
-RPMTEST_SETUP([file classes query])
+RPMTEST_SETUP_RW([file classes query])
 AT_KEYWORDS([query])
-RPMTEST_INIT
 RPMTEST_CHECK([[
 # v4 packages
 runroot rpmbuild -bb --quiet \

--- a/tests/rpmreplace.at
+++ b/tests/rpmreplace.at
@@ -1,10 +1,9 @@
 
 AT_BANNER([RPM file replacement])
 
-RPMTEST_SETUP([upgrade to/from regular file])
+RPMTEST_SETUP_RW([upgrade to/from regular file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
 
@@ -35,9 +34,8 @@ foo
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade regular file to/from link])
+RPMTEST_SETUP_RW([upgrade regular file to/from link])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -92,10 +90,9 @@ foo
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade broken link to broken link])
+RPMTEST_SETUP_RW([upgrade broken link to broken link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -123,10 +120,9 @@ stuff
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade file link to file link])
+RPMTEST_SETUP_RW([upgrade file link to file link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -154,10 +150,9 @@ goo
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade directory link to directory link])
+RPMTEST_SETUP_RW([upgrade directory link to directory link])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -185,10 +180,9 @@ zoo
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade regular file to directory])
+RPMTEST_SETUP_RW([upgrade regular file to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -214,10 +208,9 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade broken link to directory])
+RPMTEST_SETUP_RW([upgrade broken link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -243,10 +236,9 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade file link to directory])
+RPMTEST_SETUP_RW([upgrade file link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -272,10 +264,9 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade directory link to directory])
+RPMTEST_SETUP_RW([upgrade directory link to directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -301,10 +292,9 @@ runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade empty directory to empty directory])
+RPMTEST_SETUP_RW([upgrade empty directory to empty directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -327,10 +317,9 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade empty directory to regular file])
+RPMTEST_SETUP_RW([upgrade empty directory to regular file])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -354,10 +343,9 @@ test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rp
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade locally symlinked directory])
+RPMTEST_SETUP_RW([upgrade locally symlinked directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -388,10 +376,9 @@ test -L "${tf}" && test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade invalid locally symlinked directory])
+RPMTEST_SETUP_RW([upgrade invalid locally symlinked directory])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -418,9 +405,8 @@ test -d "${tf}"
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade empty directory to broken link])
+RPMTEST_SETUP_RW([upgrade empty directory to broken link])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -462,9 +448,8 @@ test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rp
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade empty directory to file link])
+RPMTEST_SETUP_RW([upgrade empty directory to file link])
 AT_KEYWORDS([install])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -508,10 +493,9 @@ readlink "${tf}"
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([upgrade empty directory to file link with pretrans])
+RPMTEST_SETUP_RW([upgrade empty directory to file link with pretrans])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -2,9 +2,8 @@
 
 AT_BANNER([RPM scriptlets])
 
-RPMTEST_SETUP([basic script failures 1])
+RPMTEST_SETUP_RW([basic script failures 1])
 AT_KEYWORDS([script])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 for v in 1.0 2.0; do
@@ -229,9 +228,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # 
-RPMTEST_SETUP([basic scripts and arguments])
+RPMTEST_SETUP_RW([basic scripts and arguments])
 AT_KEYWORDS([verify script])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb --define "rel 1" /data/SPECS/scripts.spec
@@ -293,9 +291,8 @@ scripts-1.0-2 POSTUNTRANS 0
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([basic trigger scripts: package args])
+RPMTEST_SETUP_RW([basic trigger scripts: package args])
 AT_KEYWORDS([trigger script])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -364,9 +361,8 @@ triggers-1.0-1 TRIGGERUN 0 1
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([basic trigger scripts: runtime args])
+RPMTEST_SETUP_RW([basic trigger scripts: runtime args])
 AT_KEYWORDS([trigger script])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb --define "rel 1" /data/SPECS/scripts.spec
@@ -439,9 +435,8 @@ scripts-1.0-2 POSTUNTRANS 0
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([basic file trigger scripts])
+RPMTEST_SETUP_RW([basic file trigger scripts])
 AT_KEYWORDS([filetrigger script])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -546,9 +541,8 @@ transfiletriggerpostun(/foo*):
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([basic file triggers: prefix args])
+RPMTEST_SETUP_RW([basic file triggers: prefix args])
 AT_KEYWORDS([filetrigger script])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -680,9 +674,8 @@ filetriggerun:
 
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([basic file triggers: runtime args])
+RPMTEST_SETUP_RW([basic file triggers: runtime args])
 AT_KEYWORDS([filetrigger script])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 for v in 1.0 2.0 3.0; do
@@ -772,10 +765,9 @@ runroot rpm -e parallel-trigger
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([script running environment])
+RPMTEST_SETUP_RW([script running environment])
 AT_KEYWORDS([script])
 RPMTEST_SKIP_IF([test ${HAVE_UNSHARE} = 0])
-RPMTEST_INIT
 runroot rpmbuild -bb --quiet \
 	/data/SPECS/fakeshell.spec \
 	/data/SPECS/scriptwrite.spec
@@ -801,9 +793,8 @@ runroot_other test -f /tmp/scriptwrite.log
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([deprecated Lua functions])
+RPMTEST_SETUP_RW([deprecated Lua functions])
 AT_KEYWORDS([script lua])
-RPMTEST_INIT
 
 # binary pre-built on rpm 4.18 should emit no warnings
 RPMTEST_CHECK([

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -774,7 +774,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([script running environment])
 AT_KEYWORDS([script])
-AT_SKIP_IF([test ${HAVE_UNSHARE} = 0])
+RPMTEST_SKIP_IF([test ${HAVE_UNSHARE} = 0])
 RPMTEST_INIT
 runroot rpmbuild -bb --quiet \
 	/data/SPECS/fakeshell.spec \

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -525,7 +525,7 @@ RPMTEST_CLEANUP
 # imported.
 RPMTEST_SETUP([rpmkeys --import rsa (rpmdb)])
 AT_KEYWORDS([rpmkeys import])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -587,7 +587,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys --import rsa (fs)])
 AT_KEYWORDS([rpmkeys import])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -635,7 +635,7 @@ RPMTEST_CLEANUP
 # Check a package signed with a subkey
 RPMTEST_SETUP([rpmkeys --import, signed with a good subkey])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -694,7 +694,7 @@ RPMTEST_CLEANUP
 # Check a package signed with an expired subkey
 RPMTEST_SETUP([rpmkeys --import, signed with an expired subkey])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -767,7 +767,7 @@ RPMTEST_CLEANUP
 # Check a package signed with a revoked subkey
 RPMTEST_SETUP([rpmkeys --import, signed with a revoked subkey])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -834,7 +834,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys --import invalid keys])
 AT_KEYWORDS([rpmkeys import])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 
 # The following certificates include subkeys with errors.  The internal
@@ -889,7 +889,7 @@ RPMTEST_CLEANUP
 # instead of the key's creation time.
 RPMTEST_SETUP([rpmkeys --import different-creation-times])
 AT_KEYWORDS([rpmkeys import])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmkeys \
@@ -947,7 +947,7 @@ RPMTEST_CLEANUP
 # just ignores the invalid components and imports the rest.  This test
 # checks the behavior of the internal parser.
 RPMTEST_SETUP([rpmkeys type confusion])
-AT_SKIP_IF([test x$PGP != xlegacy])
+RPMTEST_SKIP_IF([test x$PGP != xlegacy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -964,7 +964,7 @@ RPMTEST_CLEANUP
 # Test pre-built package verification
 RPMTEST_SETUP([rpmkeys -K <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -983,7 +983,7 @@ RPMTEST_CLEANUP
 # Test pre-built package verification
 RPMTEST_SETUP([rpmkeys -Kv <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1047,7 +1047,7 @@ RPMTEST_CLEANUP
 # Test pre-built corrupted package verification (corrupted signature)
 RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1087,7 +1087,7 @@ RPMTEST_CLEANUP
 # Test pre-built corrupted package verification (corrupted header)
 RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 2.1])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1122,7 +1122,7 @@ RPMTEST_CLEANUP
 # Test pre-built corrupted package verification (corrupted header)
 RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 2.2])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1158,7 +1158,7 @@ RPMTEST_CLEANUP
 # Test pre-built corrupted package verification (corrupted payload)
 RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 3])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1195,7 +1195,7 @@ RPMTEST_CLEANUP
 # Test pre-built corrupted package verification (corrupted payload)
 RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 4])
 AT_KEYWORDS([rpmkeys digest signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT[(
 
@@ -1235,7 +1235,7 @@ RPMTEST_CLEANUP
 # Test --addsign
 RPMTEST_SETUP([rpmsign --addsign])
 AT_KEYWORDS([rpmsign signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/rpm.org-rsa-2048-test.secret
 
@@ -1403,7 +1403,7 @@ RPMTEST_CLEANUP
 # Signing test(s) using Sequoia
 RPMTEST_SETUP([rpmsign --addsign sequoia])
 AT_KEYWORDS([rpmsign sequoia signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 
 RPMTEST_CHECK([
@@ -1464,7 +1464,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmsign --addsign multisig v4])
 AT_KEYWORDS([rpmsign signature multisig v4])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 
 RPMTEST_CHECK([
@@ -1574,7 +1574,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmsign --addsign multisig v6])
 AT_KEYWORDS([rpmsign signature multisig v6])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 
 RPMTEST_CHECK([
@@ -1655,7 +1655,7 @@ RPMTEST_CLEANUP
 # Test --delsign
 RPMTEST_SETUP([rpmsign --delsign])
 AT_KEYWORDS([rpmsign signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -1679,7 +1679,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([without openpgp])
 AT_KEYWORDS([dummy])
-AT_SKIP_IF([test x$PGP != xdummy])
+RPMTEST_SKIP_IF([test x$PGP != xdummy])
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 ],
@@ -1703,7 +1703,7 @@ RPMTEST_CLEANUP
 # Test ed25519 signature creation and verification
 RPMTEST_SETUP([Ed25519 signatures])
 AT_KEYWORDS([rpmsign signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/*.secret
 RPMTEST_CHECK([
@@ -1734,7 +1734,7 @@ RPMTEST_CLEANUP
 # Test NIST p-256 signature creation and verification
 RPMTEST_SETUP([NIST P-256 signatures])
 AT_KEYWORDS([rpmsign signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/*.secret
 RPMTEST_CHECK([
@@ -1765,7 +1765,7 @@ RPMTEST_CLEANUP
 # Test key id collision
 RPMTEST_SETUP([key id collision])
 AT_KEYWORDS([rpmsign signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/keyidcollision1.asc
 RPMTEST_CHECK([
@@ -1802,7 +1802,7 @@ RPMTEST_CLEANUP
 # Test key id collision
 RPMTEST_SETUP([key id collision])
 AT_KEYWORDS([rpmsign signature])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/keyidcollision2.asc
 RPMTEST_CHECK([
@@ -1837,7 +1837,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([ima file signatures])
 AT_KEYWORDS([rpmsign ima signature])
-AT_SKIP_IF([$IMA_DISABLED])
+RPMTEST_SKIP_IF([$IMA_DISABLED])
 
 RPMTEST_INIT
 cp /data/RPMS/hello-2.0-1.x86_64.rpm /tmp/
@@ -1903,7 +1903,7 @@ RPMTEST_CLEANUP
 # we can't do this.
 RPMTEST_SETUP([install ima file signatures])
 AT_KEYWORDS([install ima signature])
-AT_SKIP_IF([$IMA_DISABLED])
+RPMTEST_SKIP_IF([$IMA_DISABLED])
 
 RPMTEST_INIT
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -261,14 +261,16 @@ runroot rpmkeys --list | wc -l
 RPMTEST_CLEANUP
 # ------------------------------
 # Test rpmkeys write errors
-RPMTEST_SETUP([[rpmkeys -K no space left on stdout]])
+RPMTEST_SETUP([rpmkeys -K no space left on stdout])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMTEST_INIT[
 
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i386.rpm >/dev/full
-]],255,,[[Error writing to log: No space left on device
-]])
+],
+[255],
+[],
+[Error writing to log: No space left on device
+])
 RPMTEST_CLEANUP
 
 
@@ -1196,8 +1198,8 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 4])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_CHECK([
-RPMTEST_INIT[(
+RPMTEST_INIT
+RPMTEST_CHECK([[
 
 dorpm () {
     runroot rpmkeys --define '_pkgverify_level digest' \
@@ -1211,7 +1213,7 @@ dorpm -Kv
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 dorpm -K
 dorpm -Kv
-)]],
+]],
 [0],
 [[/data/RPMS/hello-2.0-1.x86_64-corrupted.rpm: digests SIGNATURES NOT OK
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -59,9 +59,8 @@ runroot rpmkeys -Kv /data/RPMS/hello-1.0-1.i386.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys key update and delete (rpmdb)])
+RPMTEST_SETUP_RW([rpmkeys key update and delete (rpmdb)])
 AT_KEYWORDS([rpmkeys signature])
-RPMTEST_INIT
 # currently the default but make it explicit
 echo "%_keyring rpmdb" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 RPMTEST_CHECK([
@@ -133,9 +132,8 @@ runroot rpm -qa gpg-pubkey
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys migrate from keyid to fingerprint (rpmdb)])
+RPMTEST_SETUP_RW([rpmkeys migrate from keyid to fingerprint (rpmdb)])
 AT_KEYWORDS([rpmkeys rpmdb])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpm -q --dbpath /data/misc/ gpg-pubkey
 ],
@@ -160,9 +158,8 @@ runroot rpm -q --dbpath /data/misc/ gpg-pubkey
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys migrate from keyid to fingerprint (fs)])
+RPMTEST_SETUP_RW([rpmkeys migrate from keyid to fingerprint (fs)])
 AT_KEYWORDS([rpmkeys rpmdb])
-RPMTEST_INIT
 echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 krpath="$(rpm --eval %{_keyringpath})"
 
@@ -194,9 +191,8 @@ runroot_other ls ${krpath}
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys key update (fs)])
+RPMTEST_SETUP_RW([rpmkeys key update (fs)])
 AT_KEYWORDS([rpmkeys signature])
-RPMTEST_INIT
 echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -274,9 +270,8 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i38
 RPMTEST_CLEANUP
 
 
-RPMTEST_SETUP([rpmkeys key update (openpgp)])
+RPMTEST_SETUP_RW([rpmkeys key update (openpgp)])
 AT_KEYWORDS([rpmkeys signature])
-RPMTEST_INIT
 echo "%_keyring openpgp" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.keyring
 krpath=$(rpm --eval "%{_keyringpath}")
 
@@ -368,7 +363,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys -Kv <reconstructed> 1])
 AT_KEYWORDS([rpmkeys digest])
-RPMTEST_INIT
 
 cp "${RPMTEST}"/data/misc/hello.intro "${RPMTEST}"/data/misc/hello.payload .
 gzip -cd < hello.payload > hello.uc-payload
@@ -410,9 +404,8 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test corrupted package verification (corrupted md5 hash in signature)
-RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 1])
+RPMTEST_SETUP_RW([rpmkeys -Kv <corrupted unsigned> 1])
 AT_KEYWORDS([rpmkeys digest])
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -444,10 +437,9 @@ runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/${pkg}
 RPMTEST_CLEANUP
 # ------------------------------
 # Test corrupted package verification (corrupted header)
-RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 2])
+RPMTEST_SETUP_RW([rpmkeys -Kv <corrupted unsigned> 2])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -467,10 +459,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test corrupted package verification (corrupted payload)
-RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 3])
+RPMTEST_SETUP_RW([rpmkeys -Kv <corrupted unsigned> 3])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -493,7 +484,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys -Kv <corrupted unsigned> 4])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -509,9 +499,8 @@ runroot rpmkeys -Kv /tmp/${pkg}
 RPMTEST_CLEANUP
 # ------------------------------
 # Reproducably build and verify a package
-RPMTEST_SETUP([rpmkeys -Kv <unsigned> 2])
+RPMTEST_SETUP_RW([rpmkeys -Kv <unsigned> 2])
 AT_KEYWORDS([rpmkeys digest v4 v6])
-RPMTEST_INIT
 RPMTEST_CHECK_PINNED([rpmsigdig])
 RPMTEST_CHECK_PINNED([rpmsigdig6])
 RPMTEST_CLEANUP
@@ -525,11 +514,10 @@ RPMTEST_CLEANUP
 # is because a key's validity depends on the current time.  Thus, the
 # time to check for validity is when the key is used, not when it is
 # imported.
-RPMTEST_SETUP([rpmkeys --import rsa (rpmdb)])
+RPMTEST_SETUP_RW([rpmkeys --import rsa (rpmdb)])
 AT_KEYWORDS([rpmkeys import])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmkeys \
 	--define "_keyring rpmdb" \
@@ -587,11 +575,10 @@ gpg(4344591e1964c5fc) = 4:771b18d3d7baa28734333c424344591e1964c5fc-58e63918
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys --import rsa (fs)])
+RPMTEST_SETUP_RW([rpmkeys --import rsa (fs)])
 AT_KEYWORDS([rpmkeys import])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmkeys \
 	--define "_keyringpath /tmp/kr" \
@@ -635,11 +622,10 @@ RPMTEST_CLEANUP
 
 # -----------------------------------------
 # Check a package signed with a subkey
-RPMTEST_SETUP([rpmkeys --import, signed with a good subkey])
+RPMTEST_SETUP_RW([rpmkeys --import, signed with a good subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm; echo $?
@@ -694,11 +680,10 @@ RPMTEST_CLEANUP
 
 # -----------------------------------------
 # Check a package signed with an expired subkey
-RPMTEST_SETUP([rpmkeys --import, signed with an expired subkey])
+RPMTEST_SETUP_RW([rpmkeys --import, signed with an expired subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm 2>&1; echo $?
@@ -767,11 +752,10 @@ RPMTEST_CLEANUP
 
 # -----------------------------------------
 # Check a package signed with a revoked subkey
-RPMTEST_SETUP([rpmkeys --import, signed with a revoked subkey])
+RPMTEST_SETUP_RW([rpmkeys --import, signed with a revoked subkey])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm; echo $?
@@ -834,10 +818,9 @@ Checking package after importing key, no signature:
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys --import invalid keys])
+RPMTEST_SETUP_RW([rpmkeys --import invalid keys])
 AT_KEYWORDS([rpmkeys import])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 
 # The following certificates include subkeys with errors.  The internal
 # OpenPGP implementation rejects those keys at import time whereas
@@ -889,10 +872,9 @@ RPMTEST_CLEANUP
 # If the key is identified as gpg-pubkey-62837bea-62553ec1, then the
 # implementation is using the binding signature's creation time
 # instead of the key's creation time.
-RPMTEST_SETUP([rpmkeys --import different-creation-times])
+RPMTEST_SETUP_RW([rpmkeys --import different-creation-times])
 AT_KEYWORDS([rpmkeys import])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 RPMTEST_CHECK([
 runroot rpmkeys \
 	--define "_keyring rpmdb" \
@@ -951,7 +933,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys type confusion])
 RPMTEST_SKIP_IF([test x$PGP != xlegacy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmkeys --import /data/keys/type-confusion.asc
 ],
@@ -964,11 +945,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built package verification
-RPMTEST_SETUP([rpmkeys -K <signed> 1])
+RPMTEST_SETUP_RW([rpmkeys -K <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmkeys -K /data/RPMS/hello-2.0-1.x86_64-signed.rpm
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -983,11 +963,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built package verification
-RPMTEST_SETUP([rpmkeys -Kv <signed> 1])
+RPMTEST_SETUP_RW([rpmkeys -Kv <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm; echo $?
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo $?
@@ -1047,11 +1026,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted signature)
-RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 1])
+RPMTEST_SETUP_RW([rpmkeys -Kv <corrupted signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1087,11 +1065,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted header)
-RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 2.1])
+RPMTEST_SETUP_RW([rpmkeys -Kv <corrupted signed> 2.1])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-v3-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1122,11 +1099,10 @@ runroot rpmkeys -Kv /tmp/${pkg}
 RPMTEST_CLEANUP
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted header)
-RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 2.2])
+RPMTEST_SETUP_RW([rpmkeys -Kv <corrupted signed> 2.2])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1158,11 +1134,10 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted payload)
-RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 3])
+RPMTEST_SETUP_RW([rpmkeys -Kv <corrupted signed> 3])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1195,10 +1170,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test pre-built corrupted package verification (corrupted payload)
-RPMTEST_SETUP([rpmkeys -Kv <corrupted signed> 4])
+RPMTEST_SETUP_RW([rpmkeys -Kv <corrupted signed> 4])
 AT_KEYWORDS([rpmkeys digest signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 RPMTEST_CHECK([[
 
 dorpm () {
@@ -1235,10 +1209,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test --addsign
-RPMTEST_SETUP([rpmsign --addsign])
+RPMTEST_SETUP_RW([rpmsign --addsign])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/rpm.org-rsa-2048-test.secret
 
 # rpmsign --addsign --rpmv3 <unsigned>
@@ -1403,10 +1376,9 @@ gpgconf --kill gpg-agent
 RPMTEST_CLEANUP
 
 # Signing test(s) using Sequoia
-RPMTEST_SETUP([rpmsign --addsign sequoia])
+RPMTEST_SETUP_RW([rpmsign --addsign sequoia])
 AT_KEYWORDS([rpmsign sequoia signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 cat << EOF >> ${HOME}/.config/rpm/macros
@@ -1464,10 +1436,9 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmsign --addsign multisig v4])
+RPMTEST_SETUP_RW([rpmsign --addsign multisig v4])
 AT_KEYWORDS([rpmsign signature multisig v4])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 cat << EOF >> ${HOME}/.config/rpm/macros
@@ -1574,10 +1545,9 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmsign --addsign multisig v6])
+RPMTEST_SETUP_RW([rpmsign --addsign multisig v6])
 AT_KEYWORDS([rpmsign signature multisig v6])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 
 RPMTEST_CHECK([
 cat << EOF >> ${HOME}/.config/rpm/macros
@@ -1659,7 +1629,6 @@ RPMTEST_SETUP([rpmsign --delsign])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64-signed.rpm "${RPMTEST}"/tmp/
 echo PRE-DELSIGN
@@ -1703,13 +1672,11 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test ed25519 signature creation and verification
-RPMTEST_SETUP([Ed25519 signatures])
+RPMTEST_SETUP_RW([Ed25519 signatures])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/*.secret
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id B0645AEC757BF69E --digest-algo sha512 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1734,14 +1701,11 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test NIST p-256 signature creation and verification
-RPMTEST_SETUP([NIST P-256 signatures])
+RPMTEST_SETUP_RW([NIST P-256 signatures])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/*.secret
 RPMTEST_CHECK([
-RPMTEST_INIT
-
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 7f1c21f95f65bbe8 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
 echo PRE-IMPORT
@@ -1765,13 +1729,11 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test key id collision
-RPMTEST_SETUP([key id collision])
+RPMTEST_SETUP_RW([key id collision])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/keyidcollision1.asc
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 79cc07f167fee8841829acaa42655a75156b3de0 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1802,13 +1764,11 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # Test key id collision
-RPMTEST_SETUP([key id collision])
+RPMTEST_SETUP_RW([key id collision])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-RPMTEST_INIT
 gpg2 --import ${RPMTEST}/data/keys/keyidcollision2.asc
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 94706f8da571389e8642bdfd42655a75156b3de0 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1837,11 +1797,10 @@ POST-IMPORT
 gpgconf --kill gpg-agent
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([ima file signatures])
+RPMTEST_SETUP_RW([ima file signatures])
 AT_KEYWORDS([rpmsign ima signature])
 RPMTEST_SKIP_IF([$IMA_DISABLED])
 
-RPMTEST_INIT
 cp /data/RPMS/hello-2.0-1.x86_64.rpm /tmp/
 gpg2 --import /data/keys/rpm.org-rsa-2048-test.secret
 rpmsign --key-id 4344591E1964C5FC --addsign --signfiles --fskpath=/data/keys/privkey.pem /tmp/hello-2.0-1.x86_64.rpm
@@ -1903,11 +1862,9 @@ RPMTEST_CLEANUP
 # The installation should succeed in all cases, but whether setting the
 # IMA signature succeeds depends on container privileges - in rootless
 # we can't do this.
-RPMTEST_SETUP([install ima file signatures])
+RPMTEST_SETUP_RW([install ima file signatures])
 AT_KEYWORDS([install ima signature])
 RPMTEST_SKIP_IF([$IMA_DISABLED])
-
-RPMTEST_INIT
 
 cat << EOF > expout
 # file: /usr/share/example1

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -289,7 +289,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmspec --parse])
 AT_KEYWORDS([rpmspec])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # ensure the macros expand to expected values
 # debug packages disabled for simplicity, we're not testing for that here

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -93,7 +93,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([directory replaced with an invalid directory symlink])
 AT_KEYWORDS([verify])
-AT_SKIP_IF([test `id -u` != 0 ])
+RPMTEST_SKIP_IF([test `id -u` != 0 ])
 RPMTEST_CHECK([
 RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
@@ -575,7 +575,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([verify empty/no capabilities 1])
 AT_KEYWORDS([verify])
-AT_SKIP_IF([$CAP_DISABLED])
+RPMTEST_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -594,7 +594,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([verify empty/no capabilities 2])
 AT_KEYWORDS([verify])
-AT_SKIP_IF([$CAP_DISABLED])
+RPMTEST_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
 RPMTEST_INIT
 

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -4,10 +4,9 @@ AT_BANNER([RPM verification])
 
 # ------------------------------
 # 
-RPMTEST_SETUP([dependency problems])
+RPMTEST_SETUP_RW([dependency problems])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -27,10 +26,9 @@ RPMTEST_CLEANUP
 # Test file verify when no errors expected.
 # Ignore dependencies here as we're not testing for them, and
 # --nogroup --nouser is required when running tests as non-root.
-RPMTEST_SETUP([files with no problems])
+RPMTEST_SETUP_RW([files with no problems])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -42,10 +40,9 @@ runroot rpm -Va --nodeps ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 # Test file verify when no errors expected in verbose mode.
-RPMTEST_SETUP([files with no problems in verbose mode])
+RPMTEST_SETUP_RW([files with no problems in verbose mode])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -62,10 +59,9 @@ runroot rpm -Vva --nodeps ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 # Test file verify when no errors expected in verbose mode.
-RPMTEST_SETUP([directory replaced with a directory symlink])
+RPMTEST_SETUP_RW([directory replaced with a directory symlink])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -91,11 +87,10 @@ runroot rpm -Vv replacetest
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([directory replaced with an invalid directory symlink])
+RPMTEST_SETUP_RW([directory replaced with an invalid directory symlink])
 AT_KEYWORDS([verify])
 RPMTEST_SKIP_IF([test `id -u` != 0 ])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
@@ -121,10 +116,9 @@ runroot rpm -Vv replacetest
 RPMTEST_CLEANUP
 
 # Test file verify after mutilating the files a bit.
-RPMTEST_SETUP([verify from db, with problems present])
+RPMTEST_SETUP_RW([verify from db, with problems present])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -142,10 +136,9 @@ missing   d /usr/share/doc/hello-2.0/FAQ
 RPMTEST_CLEANUP
 
 # Test file verify from original package after mutilating the files a bit.
-RPMTEST_SETUP([verify from package, with problems present])
+RPMTEST_SETUP_RW([verify from package, with problems present])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -162,10 +155,9 @@ missing   d /usr/share/doc/hello-2.0/FAQ
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([verify file attribute filtering])
+RPMTEST_SETUP_RW([verify file attribute filtering])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild -bb --quiet \
   /data/SPECS/vattrtest.spec
@@ -221,9 +213,8 @@ done
 RPMTEST_CLEANUP
 
 # Test verify script success & failure behavior
-RPMTEST_SETUP([verifyscript])
+RPMTEST_SETUP_RW([verifyscript])
 AT_KEYWORDS([verify])
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/verifyscript.spec
 runroot rpm -U --nodeps /build/RPMS/noarch/verifyscript-1.0-1.noarch.rpm
@@ -248,10 +239,9 @@ RPMTEST_CLEANUP
 
 # ------------------------------
 # shared file timestamp behavior
-RPMTEST_SETUP([shared file timestamp behavior])
+RPMTEST_SETUP_RW([shared file timestamp behavior])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 # create packages sharing a file but with different timestamp
 for p in "one" "two"; do
@@ -274,9 +264,8 @@ runroot rpm -Va ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 # ------------------------------
-RPMTEST_SETUP([minimize writes (files)])
+RPMTEST_SETUP_RW([minimize writes (files)])
 AT_KEYWORDS([upgrade verify min_writes])
-RPMTEST_INIT
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -399,14 +388,12 @@ fox
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([minimize writes (hardlinks)])
+RPMTEST_SETUP_RW([minimize writes (hardlinks)])
 AT_KEYWORDS([upgrade verify min_writes])
-RPMTEST_INIT
 for v in "0" "1"; do
     runroot rpmbuild --quiet -bb --define "ver ${v}" /data/SPECS/hlbreak.spec
 done
 RPMTEST_CHECK([
-RPMTEST_INIT
 runroot rpm -U --define "_minimize_writes 1" /build/RPMS/noarch/hlbreak-0-0.noarch.rpm
 runroot rpm -Vav ${VERIFYOPTS}
 runroot rpm -U --define "_minimize_writes 1" /build/RPMS/noarch/hlbreak-1-0.noarch.rpm
@@ -421,9 +408,8 @@ runroot rpm -Vav ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 
-RPMTEST_SETUP([minimize writes (symlinks)])
+RPMTEST_SETUP_RW([minimize writes (symlinks)])
 AT_KEYWORDS([upgrade verify min_writes])
-RPMTEST_INIT
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -539,10 +525,9 @@ fox
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([minimize writes (SUID files)])
+RPMTEST_SETUP_RW([minimize writes (SUID files)])
 AT_KEYWORDS([upgrade verify min_writes])
 RPMTEST_CHECK([
-RPMTEST_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
 
@@ -573,11 +558,10 @@ runroot rpm -V ${VERIFYOPTS} replacetest
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([verify empty/no capabilities 1])
+RPMTEST_SETUP_RW([verify empty/no capabilities 1])
 AT_KEYWORDS([verify])
 RPMTEST_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --nocaps --ignoreos \
 	/data/RPMS/capstest-1.0-1.noarch.rpm
@@ -592,11 +576,10 @@ runroot rpm -Va ${VERIFYOPTS}
 RPMTEST_CLEANUP
 
 
-RPMTEST_SETUP([verify empty/no capabilities 2])
+RPMTEST_SETUP_RW([verify empty/no capabilities 2])
 AT_KEYWORDS([verify])
 RPMTEST_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --nocaps --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -608,10 +591,9 @@ runroot rpm -Va ${VERIFYOPTS} --nodeps | grep "/bin/hello"
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpm --restore])
+RPMTEST_SETUP_RW([rpm --restore])
 AT_KEYWORDS([verify restore])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -628,10 +610,9 @@ runroot rpm -Va --nodeps ${VERIFYOPTS}
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([test for %verify in %files])
+RPMTEST_SETUP_RW([test for %verify in %files])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/verifyfiles.spec
 runroot rpm -i /build/RPMS/noarch/verifyfiles-1.0-1.noarch.rpm

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -218,7 +218,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys -K <signed 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 
@@ -292,7 +292,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP([rpmkeys -K <signed 3> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
-AT_SKIP_IF([test x$PGP = xdummy])
+RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 RPMTEST_INIT
 

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -3,7 +3,6 @@ AT_BANNER([RPM signature/digest verifylevel])
 RPMTEST_SETUP([rpmkeys -K <unsigned 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 for lvl in none digest signature all; do
     echo "LEVEL ${lvl}"
@@ -75,7 +74,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmkeys -K <unsigned 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 nomd5="0x20000"
 nopld="0x10000"
@@ -144,10 +142,9 @@ nohdr
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys -K <signed 1> verifylevel])
+RPMTEST_SETUP_RW([rpmkeys -K <signed 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 for lvl in none digest signature all; do
     echo "LEVEL ${lvl}"
@@ -216,11 +213,10 @@ LEVEL all
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys -K <signed 2> verifylevel])
+RPMTEST_SETUP_RW([rpmkeys -K <signed 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 for lvl in none digest signature all; do
@@ -290,11 +286,10 @@ LEVEL all
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP([rpmkeys -K <signed 3> verifylevel])
+RPMTEST_SETUP_RW([rpmkeys -K <signed 3> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
-RPMTEST_INIT
 
 nomd5="0x20000"
 nopld="0x10000"


### PR DESCRIPTION
See commits for details, but the main deal here is to reduce the boilerplate needed for tests and nudge test-authors towards not using (expensive) mutable snapshots unnecessarily.