### PR TITLE
Move test-suite dbpath setup to macros.testenv too

### DIFF
--- a/tests/data/macros.testenv
+++ b/tests/data/macros.testenv
@@ -2,3 +2,4 @@
 %_buildhost testhost
 %_topdir %{getenv:RPMTEST}/build
 %_tmppath %{getenv:RPMTEST}/var/tmp
+%_dbpath /var/lib/rpm-testsuite

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -7,14 +7,11 @@ export DESTDIR=${1:-/}
 mkdir -p $DESTDIR/build
 ln -sf ../data/SOURCES $DESTDIR/build/
 
-# setup an empty db that all tests are pointed to by default
-dbpath="/var/lib/rpm-testsuite"
-mkdir -p $DESTDIR/$dbpath
-echo "%_dbpath $dbpath" > $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/macros.db
-rpmdb --dbpath $DESTDIR/$dbpath --initdb
-
 # system-wide config to match our test environment
 cp /data/macros.testenv $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/
+
+# setup an empty db that all tests are pointed to by default
+rpmdb --dbpath $DESTDIR/$(rpm --eval "%{_dbpath}") --initdb
 
 # gpg-connect-agent is very, very unhappy if this doesn't exist
 mkdir -p $DESTDIR/root/.gnupg


### PR DESCRIPTION
Somehow missed this opportunity in add3e0676b17840d088de221fee3bf9a721dbe92. With this and 78c21f4ed1e03cbf876247b1dcc6d4542d94d0c9, we really now have a central place to configure system-wide macros in a prefix independent manner.