### PR TITLE
Ensure tests/setup.sh is only ever run inside the test-image

### DIFF
--- a/tests/mktree.common
+++ b/tests/mktree.common
@@ -20,4 +20,6 @@ make_install()
     mkdir -p $DESTDIR/$script_dir
     cp rpmtests atlocal mktree.common setup.sh $DESTDIR/$script_dir/
     cp @CMAKE_CURRENT_SOURCE_DIR@/rpmtests.sh $DESTDIR/$script_dir/
+
+    touch $DESTDIR/.rpmtestsuite
 }

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,22 +1,21 @@
 #!/bin/bash
 
-# Setup the environment inside the test-image
-# DESTDIR is only for testing purposes, inside the image it's always /
-export DESTDIR=${1:-/}
+# Setup the environment in the test-image.
+# Runs INSIDE the image, with our newly built rpm in the path.
 
-mkdir -p $DESTDIR/build
-ln -sf ../data/SOURCES $DESTDIR/build/
+mkdir -p /build
+ln -sf ../data/SOURCES /build/
 
 # system-wide config to match our test environment
-cp /data/macros.testenv $DESTDIR/@CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/
+cp /data/macros.testenv @CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/
 
 # setup an empty db that all tests are pointed to by default
-rpmdb --dbpath $DESTDIR/$(rpm --eval "%{_dbpath}") --initdb
+rpmdb --initdb
 
 # gpg-connect-agent is very, very unhappy if this doesn't exist
-mkdir -p $DESTDIR/root/.gnupg
-chmod 700 $DESTDIR/root/.gnupg
+mkdir -p /root/.gnupg
+chmod 700 /root/.gnupg
 
 # set up new-style XDG config directory
-mkdir -p $DESTDIR/root/.config/rpm
+mkdir -p /root/.config/rpm
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -3,6 +3,12 @@
 # Setup the environment in the test-image.
 # Runs INSIDE the image, with our newly built rpm in the path.
 
+# Make sure nobody runs this accidentally outside the environment
+if [ ! -f /.rpmtestsuite ]; then
+    echo "Not inside rpm test-suite image"
+    exit 99
+fi
+
 mkdir -p /build
 ln -sf ../data/SOURCES /build/
 


### PR DESCRIPTION
This can do dangerous stuff, its better not to even pretend it can be run from outside the image. Add a safeguard and drop the pretense of $DESTDIR support. Makes it much nicer too.