### PR TITLE
Use runuser instead of sudo for test-suite user changes

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -156,7 +156,7 @@ as well as the existing tests.  Below are the specifics of RPM's test-suite:
 * Use `RPMTEST_USER` to create a regular UNIX user in a mutable snapshot
     * The username is stored in the `$RPMUSER` environment variable
     * To run a binary as `$RPMUSER` inside the snapshot, use `runroot_user`
-      (this calls `sudo(8)` underneath)
+      (this calls `runuser(1)` underneath)
     * You can create a custom user (or users) by supplying a list of usernames
       to the macro, e.g. `RPMTEST_USER([user1, user2])`.  Then, use
       `runroot_user -n <name>` to run a binary as a specific user

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -139,7 +139,7 @@ runroot_user()
             shift 2
         ;;
     esac
-    runroot --new-session sudo -iu $RPMUSER "$@"
+    runroot --new-session /sbin/runuser -u $RPMUSER -- "$@"
 }
 
 snapshot prune rpmtests.dir/*/tree

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -99,9 +99,7 @@ runroot rpm -U /data/RPMS/hlinktest-1.0-1.noarch.rpm
 [])
 
 RPMTEST_CHECK([
-# Need to pass the dbpath explicitly since we're not going through run/runroot
-dbpath=$(rpm --eval "%_dbpath")
-runroot /sbin/runuser -u nobody -- rpmdb --dbpath ${dbpath} --exportdb > hdr.list
+runroot_user -n nobody rpmdb --exportdb > hdr.list
 ],
 [0],
 [],

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1175,9 +1175,11 @@ RPMTEST_USER
 
 runroot rpmbuild --quiet -bb /data/SPECS/rootfs.spec
 
+USERDIR=/tmp/mydir
+
 RPMTEST_CHECK([
 runroot_user \
-  rpm -U --prefix \$PWD/root --dbpath \$PWD/rpmdb \
+  rpm -U --prefix ${USERDIR}/root --dbpath ${USERDIR}/rpmdb \
   /build/RPMS/noarch/rootfs-1.0-1.noarch.rpm
 ],
 [0],
@@ -1185,8 +1187,8 @@ runroot_user \
 [])
 
 RPMTEST_CHECK([
-runroot_user rpm -e --dbpath \$PWD/rpmdb rootfs
-runroot_user test ! -d \$PWD/root
+runroot_user rpm -e --dbpath ${USERDIR}/rpmdb rootfs
+runroot_user test ! -d ${USERDIR}/root
 ],
 [0],
 [],


### PR DESCRIPTION
We don't need or want any of the sudo fanciness and privilege elevation here: we're already root inside the container and just want to run things as a different user. runuser is more than adequate for this purpose.

One such peculiarity is that apparently sudo re-expands its command, so \$PWD got evaluated to the PWD of the new shell. runuser does no such thing, but we can just as well hardcode a directory, $PWD is nothing special in this case.

Consolidate the lone runuser rpmdb export test to use runroot_user too now that it can.