### PR TITLE
Bump CI runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The newer environment would be welcome if we can use it now that our sudo usage is gone.

Related to: #3377