### PR TITLE
Having no keys imported is not an error

### DIFF
--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -134,9 +134,8 @@ RPMTEST_CHECK([
 runroot rpmkeys --delete 1964c5fc
 runroot rpmkeys --list
 ],
-[1],
-[package gpg-pubkey is not installed
-],
+[0],
+[],
 [])
 RPMTEST_CLEANUP
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -29,6 +29,39 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i38
 [])
 RPMTEST_CLEANUP
 
+AT_SETUP([rpmkeys key update and delete (rpmdb)])
+AT_KEYWORDS([rpmkeys signature])
+RPMDB_INIT
+# currently the default but make it explicit
+# root's .rpmmacros used to keep this build prefix independent
+echo "%_keyring rpmdb" >> "${RPMTEST}"/root/.rpmmacros
+runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+
+RPMTEST_CHECK([
+runroot rpmkeys --delete abcd gimmekey 1111aaaa2222bbbb
+],
+[3],
+[],
+[error: package gpg-pubkey-abcd is not installed
+error: package gpg-pubkey-gimmekey is not installed
+error: package gpg-pubkey-1111aaaa2222bbbb is not installed
+])
+
+RPMTEST_CHECK([
+runroot rpmkeys --delete 1964c5fc
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys --list
+],
+[0],
+[],
+[])
+RPMTEST_CLEANUP
+
 # ------------------------------
 # Test rpmkeys write errors
 AT_SETUP([[rpmkeys -K no space left on stdout]])

--- a/tools/rpmkeys.c
+++ b/tools/rpmkeys.c
@@ -98,12 +98,13 @@ int main(int argc, char *argv[])
     case MODE_LISTKEY:
     {
 	ARGV_t query = NULL;
+	QVA_t qva = &rpmQVKArgs;
 	if (args != NULL) {
 	    query = gpgkeyargs(args);
 	} else {
+	    qva->qva_source |= RPMQV_ALL;
 	    argvAdd(&query, "gpg-pubkey");
 	}
-	QVA_t qva = &rpmQVKArgs;
 	rstrcat(&qva->qva_queryFormat, "%{version}-%{release}: %{summary}\n");
 	ec = rpmcliQuery(ts, &rpmQVKArgs, (ARGV_const_t) query);
 	query = argvFree(query);


### PR DESCRIPTION
...any more than "ls" in an empty directory is.

"Backport" of d666883624c5f2905c0bc70112895c33605ca264

Resolves: 3556