### PR TITLE
Implement rpmkeys --rebuild

### DIFF
--- a/docs/man/rpmkeys.8.scd
+++ b/docs/man/rpmkeys.8.scd
@@ -22,6 +22,8 @@ The general forms of *rpm*(8) digital signature commands are
 
 *rpmkeys* {*-K*|*--checksig*} _PACKAGE_FILE_ ...
 
+*rpmkeys* {*--rebuild*} [*--from* _BACKEND_]
+
 The *--checksig* option checks all the digests and signatures
 contained in _PACKAGE_FILE_ to ensure the integrity and origin of the
 package. Note that signatures are now verified whenever a package is
@@ -56,6 +58,19 @@ as Sequoia or GnuPG. For example:
 Erase the key(s) designated by _FINGERPRINT_. For example:
 
 *rpmkeys* *--erase 771b18d3d7baa28734333c424344591e1964c5fc*
+
+Rebuild the key storage:
+
+*rpmkeys* *--rebuild*
+
+Recreate the public key storage. Update to the latest format and drop
+unreadable keys.
+
+*--from* _BACKEND_
+
+Use the keys from _BACKEND_ as content to build the configured
+backend.  Valid values for _BACKEND_ are *rpmdb*, *fs*, *openpgp*.
+This can be used to convert from one key storage to another.
 
 # SEE ALSO
 

--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -754,6 +754,14 @@ rpmtsi rpmtsiInit(rpmts ts);
  */
 rpmte rpmtsiNext(rpmtsi tsi, rpmElementTypes types);
 
+/** \ingroup rpmts
+ * Rebuild key store using current settings and fill it with keys form keyring
+ * @param txn		transaction handle
+ * @param from		backend to get the keys from
+ * @return		RPMRC_OK on success
+ */
+rpmRC rpmtsRebuildKeystore(rpmtxn txn, const char * from);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/keystore.cc
+++ b/lib/keystore.cc
@@ -24,6 +24,20 @@
 using std::string;
 using namespace rpm;
 
+keystore *rpm::getKeystore(const char * krtype)
+{
+    keystore * keystore = NULL;
+    if (rstreq(krtype, "fs")) {
+	keystore = new keystore_fs();
+    } else if (rstreq(krtype, "rpmdb")) {
+	keystore = new keystore_rpmdb();
+    } else if (rstreq(krtype, "openpgp")) {
+	keystore = new keystore_openpgp_cert_d();
+    }
+    return keystore;
+}
+
+
 static int makePubkeyHeader(rpmts ts, rpmPubkey key, Header * hdrp);
 
 static rpmRC load_keys_from_glob(rpmtxn txn, rpmKeyring keyring, string glob)

--- a/lib/keystore.cc
+++ b/lib/keystore.cc
@@ -257,6 +257,10 @@ rpmRC keystore_rpmdb::load_keys(rpmtxn txn, rpmKeyring keyring)
     rpmdbMatchIterator mi;
 
     rpmlog(RPMLOG_DEBUG, "loading keyring from rpmdb\n");
+    rpmts ts = rpmtxnTs(txn);
+    if (rpmtsGetDBMode(ts) == -1 && rpmtsOpenDB(ts, O_RDONLY))
+        return RPMRC_FAIL;
+
     mi = rpmtsInitIterator(rpmtxnTs(txn), RPMDBI_NAME, "gpg-pubkey", 0);
     while ((h = rpmdbNextIterator(mi)) != NULL) {
 	struct rpmtd_s pubkeys;
@@ -329,6 +333,9 @@ rpmRC keystore_rpmdb::import_key(rpmtxn txn, rpmPubkey key, int replace, rpmFlag
 {
     Header h = NULL;
     rpmRC rc = RPMRC_FAIL;
+    rpmts ts = rpmtxnTs(txn);
+    if (rpmtsOpenDB(ts, (O_RDWR|O_CREAT)))
+	return RPMRC_FAIL;
 
     if (makePubkeyHeader(rpmtxnTs(txn), key, &h) != 0)
 	return rc;

--- a/lib/keystore.hh
+++ b/lib/keystore.hh
@@ -13,6 +13,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring) = 0;
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0) = 0;
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key) = 0;
+    virtual rpmRC delete_store(rpmtxn txn) = 0;
 
     virtual ~keystore() = default;
 };
@@ -22,7 +23,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
-
+    virtual rpmRC delete_store(rpmtxn txn);
 private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, const std::string & newname = "");
 };
@@ -32,7 +33,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
-
+    virtual rpmRC delete_store(rpmtxn txn);
 private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, unsigned int newinstance = 0);
 };
@@ -42,6 +43,7 @@ public:
     virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
     virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
+    virtual rpmRC delete_store(rpmtxn txn);
 };
 
 RPM_GNUC_INTERNAL

--- a/lib/keystore.hh
+++ b/lib/keystore.hh
@@ -44,6 +44,9 @@ public:
     virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
 };
 
+RPM_GNUC_INTERNAL
+keystore *getKeystore(const char * krtype);
+
 }; /* namespace */
 
 #endif /* _KEYSTORE_H */

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2001,3 +2001,199 @@ rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" hello-2.0-1.x86_64-badima.rpm
 ],
 [])
 RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([keyring rebuild rpmdb])
+AT_KEYWORDS([rpmkeys signature])
+RPMTEST_INIT
+
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub \
+		 /data/keys/rpm.org-ed25519-test.pub
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub \
+		 /data/keys/alice.asc
+runroot rpmkeys \
+        --define "_keyring openpgp" \
+        --import /data/keys/rpm.org-rsa-2048-add-subkey.asc
+runroot rpm -i --noverify /data/RPMS/foo-1.0-1.noarch.rpm
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring rpmdb" --rebuild --from=wrongname
+]],
+[2],
+[],
+[error: unknown keyring type: wrongname
+])
+
+RPMTEST_CHECK([[
+runroot rpm -q foo
+runroot rpmkeys --define "_keyring rpmdb" --list
+runroot rpmkeys --define "_keyring rpmdb" --rebuild
+runroot rpm -q foo
+runroot rpmkeys --define "_keyring rpmdb" --list
+]],
+[0],
+[foo-1.0-1.noarch
+771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+foo-1.0-1.noarch
+771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring rpmdb" --rebuild --from=fs
+runroot rpmkeys --define "_keyring rpmdb" --list
+echo ----------
+runroot rpmkeys --define "_keyring openpgp" --list
+runroot rpmkeys --define "_keyring fs" --list
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
+----------
+],
+[])
+RPMTEST_CLEANUP
+
+
+RPMTEST_SETUP_RW([keyring rebuild fs])
+AT_KEYWORDS([rpmkeys signature])
+RPMTEST_INIT
+
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub \
+		 /data/keys/rpm.org-ed25519-test.pub \
+		 /data/keys/rpm.org-rsa-2048-add-subkey.asc
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub \
+		 /data/keys/alice.asc
+runroot rpm -i --noverify /data/RPMS/foo-1.0-1.noarch.rpm
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring fs" --list
+runroot rpmkeys --define "_keyring fs" --rebuild
+echo "==============================================="
+runroot rpmkeys --define "_keyring fs" --list
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
+===============================================
+771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
+],
+[ignore])
+
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring fs" --rebuild --from rpmdb
+runroot rpmkeys --define "_keyring fs" --list
+echo "==============================================="
+runroot rpmkeys --define "_keyring rpmdb" --list
+runroot rpmkeys --define "_keyring openpgp" --list
+runroot rpmkeys --define "_keyring fs" -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm | grep "Header OpenPGP"
+runroot rpm -q foo
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+===============================================
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+foo-1.0-1.noarch
+],
+[ignore])
+
+
+runroot rpmkeys \
+        --define "_keyring openpgp" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub \
+		 /data/keys/rpm.org-ed25519-test.pub \
+		 /data/keys/rpm.org-rsa-2048-add-subkey.asc
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring fs" --rebuild --from openpgp
+runroot rpmkeys --define "_keyring fs" --list
+echo "==============================================="
+runroot rpmkeys --define "_keyring openpgp" --list
+runroot rpmkeys --define "_keyring fs" -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm | grep "Header OpenPGP"
+runroot rpm -q foo
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+===============================================
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+foo-1.0-1.noarch
+],
+[ignore])
+RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([keyring rebuild openpgp])
+AT_KEYWORDS([rpmkeys signature])
+RPMTEST_INIT
+
+runroot rpmkeys \
+        --define "_keyring rpmdb" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub \
+		 /data/keys/rpm.org-ed25519-test.pub
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub \
+		 /data/keys/rpm.org-rsa-2048-add-subkey.asc \
+		 /data/keys/alice.asc
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring openpgp" --list | cut -c43-55
+runroot rpmkeys --define "_keyring openpgp" --rebuild
+runroot rpmkeys --define "_keyring openpgp" --list | cut -c43-55
+runroot rpmkeys --define "_keyring fs" --list
+]],
+[0],
+[rpmbuild-user
+rpmbuild-user
+],
+[])
+
+runroot rpmkeys \
+        --define "_keyring fs" \
+        --import /data/keys/rpm.org-rsa-2048-test.pub \
+		 /data/keys/rpm.org-rsa-2048-add-subkey.asc \
+		 /data/keys/alice.asc
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring fs" --list
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring openpgp" --rebuild --from fs
+runroot rpmkeys --define "_keyring openpgp" --list
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+b6542f92f30650c36b6f41bcb3a771bfeb04e625 Alice <alice@example.org> public key
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpmkeys --define "_keyring fs" --list
+runroot rpmkeys --define "_keyring rpmdb" --list
+runroot rpmkeys --define "_keyring openpgp" -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm | grep "Header OpenPGP"
+]],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+152bb32fd9ca982797e835cfb0645aec757bf69e rpm.org ed25519 testkey <ed25519@rpm.org> public key
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+],
+[ignore])
+RPMTEST_CLEANUP

--- a/tools/rpmkeys.cc
+++ b/tools/rpmkeys.cc
@@ -15,10 +15,12 @@ enum modes {
     MODE_DELKEY		= (1 << 2),
     MODE_LISTKEY	= (1 << 3),
     MODE_EXPORTKEY	= (1 << 4),
+    MODE_REBUILD	= (1 << 5),
 };
 
 static int mode = 0;
 static int test = 0;
+static char * from = NULL;
 
 static struct poptOption keyOptsTable[] = {
     { "checksig", 'K', (POPT_ARG_VAL|POPT_ARGFLAG_OR), &mode, MODE_CHECKSIG,
@@ -35,6 +37,10 @@ static struct poptOption keyOptsTable[] = {
 	N_("Erase keys from RPM keyring"), NULL },
     { "list", 'l', (POPT_ARG_VAL|POPT_ARGFLAG_OR), &mode, MODE_LISTKEY,
 	N_("list keys from RPM keyring"), NULL },
+    { "rebuild", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR), &mode, MODE_REBUILD,
+	N_("rebuild the keyring - convert to current backend"), NULL },
+    { "from", '\0', POPT_ARG_STRING, &from, 0,
+	N_("get keys from this backend when rebuilding current backend"), NULL },
     POPT_TABLEEND
 };
 
@@ -149,7 +155,8 @@ int main(int argc, char *argv[])
 
     args = (ARGV_const_t) poptGetArgs(optCon);
 
-    if (args == NULL && mode != MODE_LISTKEY && mode != MODE_EXPORTKEY)
+    if (args == NULL && mode != MODE_LISTKEY && mode != MODE_EXPORTKEY &&
+		mode != MODE_REBUILD)
 	argerror(_("no arguments given"));
 
     ts = rpmtsCreate();
@@ -181,6 +188,16 @@ int main(int argc, char *argv[])
     case MODE_LISTKEY:
     {
 	ec = matchingKeys(ts, args, printKey);
+	break;
+    }
+    case MODE_REBUILD:
+    {
+
+	rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
+	if (txn) {
+	    ec = rpmtsRebuildKeystore(txn, from);
+	    rpmtxnEnd(txn);
+	}
 	break;
     }
     default:


### PR DESCRIPTION
This rebuilds the public key storage.

The keys from a previously used key store can be added --from KEYSTORE
Keys are stored in the latest format.

Resolves: #3347



Simplified implementation of #3474. Currently does not do key verification. That's something we might want to consider to do an key loading instead of the actual rebuild.