### PR TITLE
Python tests: Check that ds.Count emits deprecation warning

### DIFF
--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -618,11 +618,21 @@ R rtld(GNU_HASH)]
 )
 
 RPMPY_TEST([dependency sets 2],[
+import warnings
 h = ts.hdrFromFdno('${RPMDATA}/RPMS/hello-2.0-1.i686.rpm')
 ds = rpm.ds(h, 'provides')
-myprint('%d %d' % (ds.Instance(), ds.Count()))
+
+# ds.Count() is a deprecated alias for len(ds).
+# Ensure warnings are always emitted and check that one was emitted correctly.
+with warnings.catch_warnings(record=True) as warns:
+    warnings.simplefilter("always")
+    count = ds.Count()
+assert len(warns) == 1
+assert warns[0].category == PendingDeprecationWarning
+
+myprint('%d %d %d' % (ds.Instance(), count, len(ds)))
 ],
-[0 2
+[0 2 2
 ],
 [])
 


### PR DESCRIPTION
This test failed when Python is set to show all warnings, e.g. with -Xdev option for debugging.

```
--- /dev/null	2025-02-06 08:39:24.294002404 +0000
+++ /srv/rpmtests.dir/at-groups/124/stderr	2025-02-13 12:36:33.848737564 +0000
@@ -0,0 +1 @@
+<sys>:0: PendingDeprecationWarning: use len(ds) instead
124. rpmpython.at:620: 124. dependency sets 2 (rpmpython.at:620): FAILED (rpmpython.at:620)
```

Also, it looks like `myprint` in Python tests isn't necessary anymore - it was needed in Python 2 era (Python's native `print` function has already been used in `archscore` test); but I haven't touched it here - if desired, I can send another patch with a rename of all the other tests.