### PR TITLE
Support automatic signing on build when %_openpgp_autosign_id is set

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(librpmbuild
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_libraries(librpmbuild PUBLIC librpmio librpm)
+target_link_libraries(librpmbuild PUBLIC librpmio librpm librpmsign)
 target_link_libraries(librpmbuild PRIVATE
 	libmisc
 	PkgConfig::POPT

--- a/tests/data/macros.testenv
+++ b/tests/data/macros.testenv
@@ -4,3 +4,4 @@
 %_tmppath %{getenv:RPMTEST}/var/tmp
 %_dbpath /var/lib/rpm-testsuite
 %_keyring openpgp
+%_keyringpath /var/lib/rpm-keyring

--- a/tests/local.at
+++ b/tests/local.at
@@ -29,6 +29,10 @@ rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`
 runroot rpm --initdb
 ])
 
+m4_define([RPMKEYRING_RESET],[
+rm -rf "${RPMTEST}"`rpm --eval '%_keyringpath'`
+])
+
 m4_define([RPMPY_RUN],[[
 cat << EOF > test.py
 # coding=utf-8

--- a/tests/pinned/common/buildrepr.sh
+++ b/tests/pinned/common/buildrepr.sh
@@ -8,5 +8,6 @@ runroot rpmbuild -ba --quiet \
 	--define "source_date_epoch_from_changelog 1" \
 	--define "build_mtime_policy clamp_to_source_date_epoch" \
 	--define "_use_weak_usergroup_deps 0" \
+	--define "_openpgp_autosign_id %{nil}" \
 	/data/SPECS/attrtest.spec
 

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -1172,7 +1172,7 @@ import json
 s = open('stdout').read()
 print(len(json.loads(s)))
 ],
-[58
+[59
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -161,8 +161,10 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmkeys migrate from keyid to fingerprint (fs)])
 AT_KEYWORDS([rpmkeys rpmdb])
+# use a keyring specific to this test
+krpath=${PWD}/kr
 echo "%_keyring fs" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.testenv
-krpath="$(rpm --eval %{_keyringpath})"
+echo "%_keyringpath ${krpath}" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.testenv
 
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -273,8 +275,10 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmkeys key update (openpgp)])
 AT_KEYWORDS([rpmkeys signature])
+# use a keyring specific to this test
+krpath=${PWD}/kr
 echo "%_keyring openpgp" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.testenv
-krpath=$(rpm --eval "%{_keyringpath}")
+echo "%_keyringpath ${krpath}" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.testenv
 
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -1213,11 +1217,12 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([rpmsign --addsign])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
+echo "%_openpgp_sign gpg" >> $RPMTEST/root/.config/rpm/macros
 gpg2 --import ${RPMTEST}/data/keys/rpm.org-rsa-2048-test.secret
 
 # rpmsign --addsign --rpmv3 <unsigned>
 RPMTEST_CHECK([
-RPMDB_RESET
+RPMKEYRING_RESET
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 4344591E1964C5FC --rpmv3 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1246,7 +1251,7 @@ POST-DELSIGN
 
 # rpmsign --addsign <unsigned>
 RPMTEST_CHECK([
-RPMDB_RESET
+RPMKEYRING_RESET
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
@@ -1273,7 +1278,7 @@ POST-DELSIGN
 
 # test --delsign restores the old package bit-per-bit
 RPMTEST_CHECK([
-RPMDB_RESET
+RPMKEYRING_RESET
 
 ORIG="/data/RPMS/hello-2.0-1.x86_64.rpm"
 NEW="/tmp/hello-2.0-1.x86_64.rpm"
@@ -1309,7 +1314,7 @@ error: /gnus/not/here exec failed (1)
 
 # rpmsign --addsign <signed>
 RPMTEST_CHECK([
-RPMDB_RESET
+RPMKEYRING_RESET
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64-signed.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64-signed.rpm 2>&1 |grep -q "already contains identical signature, skipping"
@@ -1322,7 +1327,7 @@ runroot rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign /tmp/he
 # This is behaves counter-intuitively / is buggy if md5 verification is
 # disabled, see https://github.com/rpm-software-management/rpm/issues/3291
 RPMTEST_CHECK([
-RPMDB_RESET
+RPMKEYRING_RESET
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1349,7 +1354,7 @@ runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/hello-2.0-1.x86_64.rpm
 
 # rpmsign --addsign corrupted payload
 RPMTEST_CHECK([
-RPMDB_RESET
+RPMKEYRING_RESET
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -1564,10 +1569,10 @@ runroot rpmkeys --import /data/keys/*.pub
 [ignore])
 
 RPMTEST_CHECK([
+# automatically signed now
 runroot rpmbuild -bb --quiet \
 	--define "_rpmformat 6" \
 	/data/SPECS/attrtest.spec
-runroot rpmsign --addsign /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm
 ],
 [0],
 [],
@@ -1676,6 +1681,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([Ed25519 signatures])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
+echo "%_openpgp_sign gpg" >> $RPMTEST/root/.config/rpm/macros
 gpg2 --import ${RPMTEST}/data/keys/*.secret
 RPMTEST_CHECK([
 
@@ -1705,6 +1711,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([NIST P-256 signatures])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
+echo "%_openpgp_sign gpg" >> $RPMTEST/root/.config/rpm/macros
 gpg2 --import ${RPMTEST}/data/keys/*.secret
 RPMTEST_CHECK([
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
@@ -1733,6 +1740,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([key id collision])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
+echo "%_openpgp_sign gpg" >> $RPMTEST/root/.config/rpm/macros
 gpg2 --import ${RPMTEST}/data/keys/keyidcollision1.asc
 RPMTEST_CHECK([
 
@@ -1768,6 +1776,8 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([key id collision])
 AT_KEYWORDS([rpmsign signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
+
+echo "%_openpgp_sign gpg" >> $RPMTEST/root/.config/rpm/macros
 gpg2 --import ${RPMTEST}/data/keys/keyidcollision2.asc
 RPMTEST_CHECK([
 
@@ -1803,6 +1813,7 @@ AT_KEYWORDS([rpmsign ima signature])
 RPMTEST_SKIP_IF([$IMA_DISABLED])
 
 cp /data/RPMS/hello-2.0-1.x86_64.rpm /tmp/
+echo "%_openpgp_sign gpg" >> $RPMTEST/root/.config/rpm/macros
 gpg2 --import /data/keys/rpm.org-rsa-2048-test.secret
 rpmsign --key-id 4344591E1964C5FC --addsign --signfiles --fskpath=/data/keys/privkey.pem /tmp/hello-2.0-1.x86_64.rpm
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -18,10 +18,36 @@ cp /data/macros.testenv @CMAKE_INSTALL_FULL_SYSCONFDIR@/rpm/
 # setup an empty db that all tests are pointed to by default
 rpmdb --initdb
 
+# set up new-style XDG config directory
+rpmhome=/root/.config/rpm
+mkdir -p ${rpmhome}
+
+# setup default signing id + key
+sqemail="rpmbuild-user@$(uname -n)"
+sqhome=${rpmhome}/sq
+sqkey=$(sq key generate \
+   --batch \
+   --quiet \
+   --own-key \
+   --without-password \
+   --can-sign \
+   --cannot-authenticate \
+   --cannot-encrypt \
+   --email ${sqemail} \
+      2>&1 | awk '/Fingerprint/{print $2}')
+
+cat << EOF > ${rpmhome}/macros
+%_openpgp_autosign_id ${sqkey}
+%_openpgp_sign sq
+EOF
+
+# import the signing key by default
+sq cert export \
+    --cert-email "${sqemail}" > /root/rpm-key.asc
+rpmkeys --import /root/rpm-key.asc
+
 # gpg-connect-agent is very, very unhappy if this doesn't exist
 mkdir -p /root/.gnupg
 chmod 700 /root/.gnupg
 
-# set up new-style XDG config directory
-mkdir -p /root/.config/rpm
 


### PR DESCRIPTION
This is obviously only an enabler for automatic signing. The other half of the equation is automatically setting it up, but that's another ticket (#3522). This lets us at least manually enable automatic signing in the test-suite, which in turn is a pre-requisite for enabling enforcing signature checking by default (#1573).

Set up auto-signing inside the test-suite throughout, using a freshly generated key for each run. With the exception of the reproducibility tests where this would be harmful.

This is a rather primitive thing in this state - ideally the signing would happen in parallel, but as the signing code relies heavily on macro manipulation, that's a much bigger task for some other time. Also I think we'd rather use an rpm specific keyring for the automatic signing,  but that requires further changes to how the signing macros work.

Fixes: #2678
