### PR TITLE
Generate release tarballs via GitHub Actions

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -1,0 +1,46 @@
+# Builds & attaches release artifacts to a newly published release.
+name: Release artifacts
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  # Generates dist tarball(s) and a checksum file to go with.
+  #
+  # A full build is needed here since we currently bundle some build artifacts
+  # with the tarball (man pages, HTML manuals and .po files) so make use of the
+  # test image as it already contains all the build dependencies.
+  #
+  dist:
+    runs-on: ubuntu-24.04
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG_NAME: ${{ github.event.release.tag_name }}
+      DIST_EXT: tar.bz2
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          podman build --target base --tag rpm -f tests/Dockerfile .
+
+      - name: Create dist tarball(s)
+        run: |
+          mkdir _build
+          podman run -v $PWD:/srv:z --workdir /srv/_build --rm rpm sh -c \
+            "cmake -DWITH_DOXYGEN=ON .. && make dist"
+
+      - name: Create checksum file
+        working-directory: _build
+        run: |
+          sha512sum --tag *.$DIST_EXT > CHECKSUM
+          cat CHECKSUM
+
+      - name: Upload dist tarball(s) & checksum file
+        working-directory: _build
+        run: |
+          gh release upload $TAG_NAME *.$DIST_EXT CHECKSUM


### PR DESCRIPTION
We want the official tarballs to be made in a hermetic environment (i.e. not on a developer's workstation) and have a stable checksum, and GitHub releases alone would only give us the former as the automatic download links aren't guaranteed to be stable [1].

Thus, define a workflow that runs when a GitHub release is published, makes a tarball, an accompanying checksum file, and attaches both to that release as additional assets.  This is also what GitHub recommends [1] if stability is desired.

Note that this YAML file needs to be on the branch we're releasing from, and we currently don't release from master, so the file doesn't have any effect there.  Yet, we want to keep a "canonical" version of the file on master and only cherry pick it (and any future changes) onto the stable branches.  Plus, we may find a use for it on master in the future, too.

[1] https://github.blog/open-source/git/update-on-the-future-stability-of-source-code-archives-and-hashes/

Fixes: #2702