### PR TITLE
Enable enforcing signature checking by default

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -693,7 +693,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 # signature	require valid signature(s)
 # digest	require valid digest(s)
 # none		traditional rpm behavior, nothing required
-%_pkgverify_level digest
+%_pkgverify_level all
 
 # Disabler flags for package verification (similar to vsflags)
 # Set to 0x0 for full compatibility with v4 packages.

--- a/tests/pinned/common/rpmsigdig.sh
+++ b/tests/pinned/common/rpmsigdig.sh
@@ -2,4 +2,4 @@
 for v in SHA256HEADER SHA1HEADER SIGMD5 PAYLOADDIGEST PAYLOADDIGESTALT PAYLOADSIZE PAYLOADSIZEALT; do
     runroot rpm -q --qf "${v}: %{${v}}\n" ${pkg}
 done
-runroot rpmkeys -Kv ${pkg}
+runroot rpmkeys -Kv --nosignature ${pkg}

--- a/tests/rpmconflict.at
+++ b/tests/rpmconflict.at
@@ -108,7 +108,7 @@ RPMTEST_SETUP_RW([multilib elf conflict, prefer 64bit 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.i686.rpm \
@@ -128,12 +128,12 @@ RPMTEST_SETUP_RW([multilib elf conflict, prefer 64bit 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.i686.rpm
 runroot rpm -q --qf "[[%{filestates:fstate},]]\n" hello.i686
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -153,12 +153,12 @@ RPMTEST_SETUP_RW([multilib elf conflict, prefer 64bit 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.x86_64.rpm
 runroot rpm -q --qf "[[%{filestates:fstate},]]\n" hello.x86_64
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.i686.rpm
@@ -178,7 +178,7 @@ RPMTEST_SETUP_RW([multilib elf conflict, prefer 32bit 1])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 1" \
   /data/RPMS/hello-2.0-1.i686.rpm \
@@ -198,12 +198,12 @@ RPMTEST_SETUP_RW([multilib elf conflict, prefer 32bit 2])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 1" \
   /data/RPMS/hello-2.0-1.i686.rpm 
 runroot rpm -q --qf "[[%{filestates:fstate},]]\n" hello.i686
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 1" \
   /data/RPMS/hello-2.0-1.x86_64.rpm 
@@ -223,12 +223,12 @@ RPMTEST_SETUP_RW([multilib elf conflict, prefer 32bit 3])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 1" \
   /data/RPMS/hello-2.0-1.x86_64.rpm 
 runroot rpm -q --qf "[[%{filestates:fstate},]]\n" hello.x86_64
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 1" \
   /data/RPMS/hello-2.0-1.i686.rpm 
@@ -250,7 +250,7 @@ RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.x86_64.rpm \
@@ -269,12 +269,12 @@ RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.x86_64.rpm
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /build/RPMS/noarch/hello-script-1.0-1.noarch.rpm
@@ -292,12 +292,12 @@ RPMTEST_CHECK([
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /build/RPMS/noarch/hello-script-1.0-1.noarch.rpm
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.x86_64.rpm

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -92,7 +92,7 @@ test -s rdonly.list
 
 RPMTEST_CHECK([
 RPMTEST_SNAPSHOT_MOUNT
-runroot rpm -U /data/RPMS/hlinktest-1.0-1.noarch.rpm
+runroot rpm -U --nosignature /data/RPMS/hlinktest-1.0-1.noarch.rpm
 ],
 [0],
 [],
@@ -355,6 +355,7 @@ AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
 
 runroot rpm -i \
+  --nosignature \
   /data/RPMS/foo-1.0-1.noarch.rpm
 
 runroot rpm -q foo
@@ -373,6 +374,7 @@ AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
 
 runroot rpm -i \
+  --nosignature \
   /data/RPMS/foo-1.0-1.noarch.rpm
 
 runroot rpm -q foo-
@@ -389,7 +391,7 @@ AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
 
 for i in 1 2 3; do
-    runroot rpm -i /data/RPMS/foo-1.0-1.noarch.rpm
+    runroot rpm -i --nosignature /data/RPMS/foo-1.0-1.noarch.rpm
     runroot rpm -q --qf "%{dbinstance} %{name}\n" foo
     runroot rpm -e foo
 done
@@ -408,6 +410,7 @@ AT_KEYWORDS([rpmdb query])
 RPMTEST_CHECK([
 
 runroot rpm -i \
+  --nosignature \
   /data/RPMS/foo-1.0-1.noarch.rpm
 
 ],
@@ -441,6 +444,7 @@ AT_KEYWORDS([rpmdb install])
 RPMTEST_CHECK([
 
 runroot rpm -i \
+  --nosignature \
   /data/RPMS/foo-1.0-1.noarch.rpm
 ],
 [0])
@@ -456,8 +460,8 @@ RPMTEST_CHECK([
 
 tpkg="/data/RPMS/foo-1.0-1.noarch.rpm"
 
-runroot rpm -i "${tpkg}" && 
-  runroot rpm -U --replacepkgs "${tpkg}" &&
+runroot rpm -i --nosignature "${tpkg}" &&
+  runroot rpm -U --replacepkgs --nosignature "${tpkg}" &&
   runroot rpm -qa
 ],
 [0],
@@ -476,8 +480,9 @@ RPMTEST_CHECK([
 
 tpkg="/data/RPMS/hello-2.0-1.i686.rpm"
 
-runroot rpm -U --nodeps --ignorearch "${tpkg}" && 
-  runroot rpm -U --nodeps --ignorearch --nodocs --replacepkgs "${tpkg}" &&
+runroot rpm -U --nodeps --ignorearch --nosignature "${tpkg}" &&
+  runroot rpm -U --nodeps --ignorearch --nodocs --nosignature \
+	--replacepkgs "${tpkg}" &&
   runroot rpm -e hello
 test -d "${RPMTEST}"/usr/share/doc/hello-2.0
 ],
@@ -494,8 +499,8 @@ AT_KEYWORDS([rpmdb install])
 RPMTEST_CHECK([
 tpkg="/data/RPMS/hello-2.0-1.i686.rpm"
 
-runroot rpm -U --nodeps --ignorearch "${tpkg}" && 
-  runroot rpm --reinstall --nodeps --ignorearch --nodocs "${tpkg}" &&
+runroot rpm -U --nodeps --ignorearch --nosignature "${tpkg}" &&
+  runroot rpm --reinstall --nodeps --ignorearch --nodocs --nosignature "${tpkg}" &&
   runroot rpm -e hello
 test -d "${RPMTEST}"/usr/share/doc/hello-2.0
 ],
@@ -513,14 +518,14 @@ AT_KEYWORDS([rpmdb install])
 
 RPMTEST_CHECK([
 runroot rpm -i \
-  --noscripts --nodeps --ignorearch --noverify \
+  --noscripts --nodeps --ignorearch --noverify --nosignature \
   /data/RPMS/hello-1.0-1.i386.rpm
 ],
 [0])
 
 RPMTEST_CHECK([
 runroot rpm -i \
-  --noscripts --nodeps --ignorearch --noverify \
+  --noscripts --nodeps --ignorearch --noverify --nosignature \
   /data/RPMS/hello-1.0-1.ppc64.rpm
 ],
 [1],
@@ -530,7 +535,8 @@ runroot rpm -i \
 
 RPMTEST_CHECK([
 runroot rpm -i \
-  --noscripts --nodeps --ignorearch --noverify --relocate=/usr=/check \
+  --noscripts --nodeps --ignorearch --noverify --nosignature \
+  --relocate=/usr=/check \
   /data/RPMS/hello-1.0-1.ppc64.rpm
 ],
 [0])
@@ -553,10 +559,10 @@ AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
 RPMDB_RESET
 
-runroot rpm -U --noscripts --nodeps --ignorearch --noverify \
+runroot rpm -U --noscripts --nodeps --ignorearch --noverify --nosignature \
   /data/RPMS/hello-1.0-1.i386.rpm
 runroot rpm -qa --qf "%{nevra} %{dbinstance}\n"
-runroot rpm -U --noscripts --nodeps --ignorearch \
+runroot rpm -U --noscripts --nodeps --ignorearch --nosignature \
   /data/RPMS/hello-2.0-1.i686.rpm
 runroot rpm -qa --qf "%{nevra} %{dbinstance}\n"
 runroot rpmdb --rebuilddb
@@ -672,9 +678,10 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([rpmdb vacuum])
 AT_KEYWORDS([install rpmdb sqlite])
 RPMTEST_CHECK([
-runroot rpm -U --noscripts --nodeps --ignorearch --noverify \
+runroot rpm -U --noscripts --nodeps --ignorearch --noverify --nosignature \
   /data/RPMS/hello-1.0-1.i386.rpm
-runroot rpm -D "_sqlite_vacuum_kb 1" -vv -U --noscripts --nodeps --ignorearch \
+runroot rpm -D "_sqlite_vacuum_kb 1" \
+  -vv -U --noscripts --nodeps --ignorearch --nosignature \
   /data/RPMS/hello-2.0-1.i686.rpm 2>&1 | grep VACUUM
 ],
 [0],

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -220,7 +220,7 @@ runroot rpmbuild --quiet -bb \
 	--define "reqs /usr/bin/hello" \
 	  /data/SPECS/deptest.spec
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.i686.rpm \
@@ -246,7 +246,7 @@ runroot rpmbuild --quiet -bb \
 	--define "reqs /usr/bin/hello" \
 	  /data/SPECS/deptest.spec
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.i686.rpm \

--- a/tests/rpme.at
+++ b/tests/rpme.at
@@ -3,7 +3,7 @@ RPMTEST_SETUP_RW([rpm -e and verify files removed])
 AT_KEYWORDS([install erase rpmdb])
 
 RPMTEST_CHECK([
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 runroot rpm -Vv --nodeps --nogroup --nouser hello
 runroot rpm -e hello
@@ -48,14 +48,14 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([rpm reinstall with shared files])
 AT_KEYWORDS([install erase update rpmdb])
 RPMTEST_CHECK([
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.x86_64.rpm \
 	/data/RPMS/hello-2.0-1.i686.rpm
 runroot rpm -Vv --nodeps --nogroup --nouser hello.i686 hello.x86_64
 
-runroot rpm --reinstall --ignoreos --ignorearch --nodeps \
+runroot rpm --reinstall --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.x86_64.rpm \
@@ -90,14 +90,14 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([rpm -e and shared files removed 1.1])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	--nodocs \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 runroot rpm -Vv --nodeps --nogroup --nouser hello
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -134,14 +134,14 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([rpm -e and shared files removed 1.2])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	--nodocs \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 runroot rpm -Vv --nodeps --nogroup --nouser hello
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.i686.rpm
@@ -180,7 +180,7 @@ RPMTEST_SETUP_RW([rpm -e and verify colored files removed 1.1])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.i686.rpm /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -205,7 +205,7 @@ RPMTEST_SETUP_RW([rpm -e and verify colored files removed 1.2])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 3" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.i686.rpm /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -228,7 +228,7 @@ AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 2" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.i686.rpm /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -251,7 +251,7 @@ AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	--define "_transaction_color 2" \
 	--define "_prefer_color 2" \
 	/data/RPMS/hello-2.0-1.i686.rpm /data/RPMS/hello-2.0-1.x86_64.rpm
@@ -350,7 +350,7 @@ RPMTEST_SETUP_RW([rpm -e and verify netshared files not removed])
 AT_KEYWORDS([install erase rpmdb])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignoreos --ignorearch --nodeps \
+runroot rpm -U --ignoreos --ignorearch --nodeps --nosignature \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 runroot rpm -e \
 	--define "_netsharedpath /usr/share" \

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1513,6 +1513,7 @@ RPMTEST_CHECK([
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser u myuser 876 - /home/myuser /bin/sh}"\
   /data/SPECS/deptest.spec
+runroot rpmkeys --import --root /alt /root/rpm-key.asc
 runroot rpm -U --root /alt /build/RPMS/noarch/deptest-user-1.0-1.noarch.rpm 2> /dev/null
 runroot tail -1 /alt/etc/passwd
 runroot rpm -V --root /alt ${VERIFYOPTS} deptest-user

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -23,7 +23,7 @@ AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
 echo /data/RPMS/hello-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
-runroot rpm -U --ignorearch --ignoreos --nodeps \
+runroot rpm -U --ignorearch --ignoreos --nodeps --nosignature \
 	/tmp/test.mft
 ],
 [0],
@@ -36,7 +36,7 @@ AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
 echo "/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm" > ${RPMTEST}/tmp/test.mft
-runroot rpm -U --ignorearch --ignoreos --nodeps \
+runroot rpm -U --ignorearch --ignoreos --nodeps --nosignature \
 	/tmp/test.mft
 ],
 [0],
@@ -53,7 +53,7 @@ cp "${RPMTEST}/data/RPMS/hello-2.0-1.i686.rpm" \
 
 echo "/tmp/fallback-[[123]].0-1.i686.rpm" > ${RPMTEST}/tmp/test.mft
 
-runroot rpm -U --ignorearch --ignoreos --nodeps \
+runroot rpm -U --ignorearch --ignoreos --nodeps --nosignature \
 	/tmp/test.mft
 ],
 [0],
@@ -157,9 +157,9 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpm -U <unsigned 1>])
 AT_KEYWORDS([install])
-RPMTEST_CHECK([
 
-runroot rpm -U --ignorearch --ignoreos --nodeps \
+RPMTEST_CHECK([
+runroot rpm -U --ignorearch --ignoreos --nodeps --nosignature \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
@@ -274,6 +274,7 @@ RPMTEST_SKIP_IF([test x$PGP = xdummy])
 RPMTEST_CHECK([
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
+	--define "_pkgverify_level digest" \
 	/data/RPMS/hello-2.0-1.x86_64-signed.rpm
 ],
 [0],
@@ -437,7 +438,7 @@ RPMTEST_SETUP_RW([rpm -U <glob>])
 AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
-runroot rpm -U --ignorearch --ignoreos --nodeps \
+runroot rpm -U --ignorearch --ignoreos --nodeps --nosignature \
 	"/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm"
 ],
 [0],
@@ -469,7 +470,7 @@ RPMTEST_CHECK([
 cp "${RPMTEST}/data/RPMS/hello-2.0-1.i686.rpm" \
    "${RPMTEST}/tmp/fallback-[[123]].0-1.i686.rpm"
 
-runroot rpm -U --ignorearch --ignoreos --nodeps \
+runroot rpm -U --ignorearch --ignoreos --nodeps --nosignature \
 	"/tmp/fallback-[[123]].0-1.i686.rpm"
 ],
 [0],
@@ -486,10 +487,10 @@ RPMTEST_CHECK([
 pkg="hello-2.0-1.x86_64"
 timestamp=97445
 
-runroot rpm -i --ignorearch --ignoreos --nodeps \
+runroot rpm -i --ignorearch --ignoreos --nodeps --nosignature \
 	/data/RPMS/foo-1.0-1.noarch.rpm
 runroot --setenv SOURCE_DATE_EPOCH $timestamp \
-	rpm -i --ignorearch --ignoreos --nodeps \
+	rpm -i --ignorearch --ignoreos --nodeps --nosignature \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 runroot rpm -q --tid $timestamp
 runroot rpm -qi $pkg | grep "Install Date"
@@ -514,7 +515,7 @@ RPMTEST_CHECK([
 timestamp=1445412535
 
 runroot --setenv SOURCE_DATE_EPOCH $timestamp \
-	rpm -i --ignorearch --ignoreos --nodeps \
+	rpm -i --ignorearch --ignoreos --nodeps --nosignature \
 	/data/RPMS/foo-1.0-1.noarch.rpm /data/RPMS/hello-2.0-1.x86_64.rpm
 runroot rpm -q --tid $timestamp
 for pkg in `runroot rpm -q --tid $timestamp`; do
@@ -535,7 +536,7 @@ AT_KEYWORDS([install])
 RPMTEST_CHECK([
 
 runroot rpm \
-  -U --nodb /data/RPMS/hlinktest-1.0-1.noarch.rpm
+  -U --nodb --nosignature /data/RPMS/hlinktest-1.0-1.noarch.rpm
 runroot rpm -qa
 runroot find /foo|sort
 ],
@@ -560,7 +561,7 @@ RPMTEST_CHECK([
 # avoid having to deal with non-existent /foo in the find below
 runroot mkdir /foo
 runroot rpm \
-  -U --justdb /data/RPMS/hlinktest-1.0-1.noarch.rpm
+  -U --justdb --nosignature /data/RPMS/hlinktest-1.0-1.noarch.rpm
 runroot rpm -qa
 runroot find /foo|sort
 ],
@@ -619,7 +620,7 @@ RPMTEST_CHECK([
 
 runroot rpm \
   --define "_topdir /tmp/build" \
-  --ignorearch --ignoreos --nodeps \
+  --ignorearch --ignoreos --nodeps --nosignature \
   -i /data/SRPMS/hello-1.0-1.src.rpm \
      /data/RPMS/hello-2.0-1.x86_64.rpm
 runroot rpm -q hello; echo
@@ -1301,7 +1302,7 @@ dd if=/dev/zero of="${RPMTEST}/tmp/3.rpm" \
    conv=notrunc bs=1 seek=8050 count=6 2> /dev/null
 
 RPMTEST_CHECK([
-runroot rpm -i --noverify /tmp/1.rpm
+runroot rpm -i --noverify --nosignature /tmp/1.rpm
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
 ],
@@ -1312,7 +1313,7 @@ error: hlinktest-1.0-1.noarch: install failed
 ])
 
 RPMTEST_CHECK([
-runroot rpm -i --noverify /tmp/2.rpm
+runroot rpm -i --noverify --nosignature /tmp/2.rpm
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
 ],
@@ -1323,7 +1324,7 @@ error: hlinktest-1.0-1.noarch: install failed
 ])
 
 RPMTEST_CHECK([
-runroot rpm -i --noverify /tmp/3.rpm 2>&1| sed 's/;.*:/:/g'
+runroot rpm -i --noverify --nosignature /tmp/3.rpm 2>&1| sed 's/;.*:/:/g'
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
 ],
@@ -1334,7 +1335,7 @@ error: hlinktest-1.0-1.noarch: install failed
 [])
 
 RPMTEST_CHECK([
-runroot rpm -i "${pkg}"
+runroot rpm -i --nosignature "${pkg}"
 runroot rpm -q --qf "[[%{filenlinks} %{filenames}\n]]%{longsize}\n" hlinktest
 ls -i "${RPMTEST}"/foo/hello* | awk {'print $1'} | sort -u | wc -l
 runroot rpm -e hlinktest
@@ -1355,7 +1356,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-runroot rpm -i --excludepath=/foo/zzzz "${pkg}"
+runroot rpm -i --excludepath=/foo/zzzz --nosignature "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
 ],
@@ -1372,7 +1373,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-runroot rpm -i --excludepath=/foo/aaaa "${pkg}"
+runroot rpm -i --excludepath=/foo/aaaa --nosignature "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
 ],
@@ -1389,7 +1390,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-runroot rpm -i --excludepath=/foo/aaaa --excludepath=/foo/zzzz "${pkg}"
+runroot rpm -i --excludepath=/foo/aaaa --excludepath=/foo/zzzz --nosignature "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
 ],
@@ -1406,7 +1407,7 @@ runroot rpm -e hlinktest
 [])
 
 RPMTEST_CHECK([
-runroot rpm -i --excludepath=/foo/hello-foo "${pkg}"
+runroot rpm -i --excludepath=/foo/hello-foo --nosignature "${pkg}"
 runroot rpm -Vv --nogroup --nouser hlinktest
 runroot rpm -e hlinktest
 ],
@@ -1722,7 +1723,7 @@ RPMTEST_SETUP([rpm -U diskspace])
 AT_KEYWORDS([install diskspace])
 RPMTEST_CHECK([
 
-runroot rpm -U --nodb --test --ignorearch --ignoreos --nodeps \
+runroot rpm -U --nodb --test --ignorearch --ignoreos --nodeps --nosignature \
 	/data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [1],

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -201,6 +201,7 @@ myprint('%s %s %s' % (hex(dlv), hex(olv), hex(nlv)))
 )
 
 RPMPY_TEST([vfylevel API],[
+ts.setVfyLevel(rpm.RPMSIG_DIGEST_TYPE)
 dlv = ts.getVfyLevel()
 olv = ts.setVfyLevel(rpm.RPMSIG_SIGNATURE_TYPE|rpm.RPMSIG_DIGEST_TYPE)
 nlv = ts.getVfyLevel()

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -449,7 +449,7 @@ RPMTEST_SETUP_RW([database iterators])
 AT_KEYWORDS([python rpmdb])
 RPMTEST_CHECK([
 runroot rpm -i \
-  --justdb --nodeps --ignorearch --ignoreos \
+  --justdb --nodeps --ignorearch --ignoreos --nosignature \
   /data/RPMS/foo-1.0-1.noarch.rpm \
   /data/RPMS/hello-2.0-1.i686.rpm
 ],
@@ -558,7 +558,7 @@ with open("dbcookie", "w+") as dbcookie_file:
 
 RPMTEST_CHECK([
 runroot rpm -i \
-  --justdb --nodeps --ignorearch --ignoreos \
+  --justdb --nodeps --ignorearch --ignoreos --nosignature \
   /data/RPMS/foo-1.0-1.noarch.rpm \
   /data/RPMS/hello-2.0-1.i686.rpm \
 ],
@@ -581,7 +581,7 @@ with open("dbcookie", "w+") as dbcookie_file:
 
 RPMTEST_CHECK([
 runroot rpm -i \
-  --justdb --nodeps --ignorearch --ignoreos \
+  --justdb --nodeps --ignorearch --ignoreos --nosignature \
   --define "_transaction_color 3" \
   --define "_prefer_color 2" \
   /data/RPMS/hello-2.0-1.x86_64.rpm

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -234,7 +234,7 @@ AT_KEYWORDS([rpmdb install query])
 
 RPMTEST_CHECK([
 runroot rpm \
-  --noscripts --nodeps --ignorearch \
+  --noscripts --nodeps --ignorearch --nosignature \
   -i /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0])
@@ -279,6 +279,7 @@ RPMTEST_CHECK([
 runroot rpm \
   --nodeps \
   --ignorearch \
+  --nosignature \
   -i /data/RPMS/hello-2.0-1.i686.rpm
 runroot rpm \
   -qf /usr/bin/hello
@@ -296,6 +297,7 @@ runroot rpm \
   --nodeps \
   --excludedocs \
   --ignorearch \
+  --nosignature \
   -i /data/RPMS/hello-2.0-1.i686.rpm
 runroot rpm \
   -qf /usr/share/doc/hello-2.0/FAQ
@@ -313,6 +315,7 @@ runroot rpm \
   --nodeps \
   --excludedocs \
   --ignorearch \
+  --nosignature \
   -i /data/RPMS/hello-2.0-1.i686.rpm
 runroot rpm \
   -q --path /usr/share/doc/hello-2.0/FAQ

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -799,7 +799,7 @@ AT_KEYWORDS([script lua])
 # binary pre-built on rpm 4.18 should emit no warnings
 RPMTEST_CHECK([
 RPMDB_RESET
-runroot rpm -U /data/RPMS/luafork-1.0-1.noarch.rpm
+runroot rpm -U --nosignature /data/RPMS/luafork-1.0-1.noarch.rpm
 ],
 [0],
 [child

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -38,6 +38,21 @@ AT_KEYWORDS([rpmkeys digest])
 RPMTEST_CHECK([
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
+[1],
+[/data/RPMS/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys -Kv --nosignature /data/RPMS/hello-2.0-1.x86_64.rpm
+],
 [0],
 [/data/RPMS/hello-2.0-1.x86_64.rpm:
     Header SHA256 digest: OK
@@ -46,7 +61,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm
 [])
 
 RPMTEST_CHECK([
-runroot rpmkeys -Kv /data/RPMS/hello-1.0-1.i386.rpm
+runroot rpmkeys -Kv --nosignature /data/RPMS/hello-1.0-1.i386.rpm
 ],
 [1],
 [/data/RPMS/hello-1.0-1.i386.rpm:
@@ -70,8 +85,12 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [1],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
     Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 ],
 [])
 
@@ -204,8 +223,12 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [1],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
     Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 ],
 [])
 
@@ -287,8 +310,12 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [1],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
     Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 ],
 [])
 
@@ -986,15 +1013,21 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo
 [0],
 [/data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
     Header OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
     Legacy OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
     Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Legacy OpenPGP DSA signature: NOTFOUND
 1
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
@@ -1047,14 +1080,17 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
+    Header OpenPGP signature: NOTFOUND
 RPMOUTPUT_LEGACY([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
 RPMOUTPUT_SEQUOIA([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
 RPMOUTPUT_SEQUOIA([  Failed to parse Signature Packet])dnl
 RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-conformant OpenPGP implementation, see <https://github.com/rpm-software-management/rpm/issues/2351>.])dnl
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
     Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Legacy OpenPGP DSA signature: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
 RPMOUTPUT_LEGACY([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
 RPMOUTPUT_SEQUOIA([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
@@ -1087,17 +1123,23 @@ runroot rpmkeys -Kv /tmp/${pkg}
 [1],
 [/tmp/hello-2.0-1.x86_64-v3-signed.rpm:
     Header OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
     Legacy OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Legacy OpenPGP DSA signature: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-v3-signed.rpm:
     Header OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
     Legacy OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Legacy OpenPGP DSA signature: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -1121,17 +1163,23 @@ runroot rpmkeys -Kv /tmp/${pkg}
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
     Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Legacy OpenPGP DSA signature: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
     Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Legacy OpenPGP DSA signature: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -1156,10 +1204,13 @@ runroot rpmkeys -Kv /tmp/${pkg}
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
     Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Legacy OpenPGP DSA signature: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
@@ -1345,9 +1396,14 @@ runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
     Legacy MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
 ],
 [])
@@ -1372,9 +1428,14 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
     Payload SHA256 ALT digest: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -1436,8 +1497,12 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
     Header OpenPGP V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOKEY
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 ],
 [])
 RPMTEST_CLEANUP
@@ -1542,10 +1607,15 @@ RPMTEST_CHECK([
 runroot rpmsign --delsign /tmp/hello-2.0-1.x86_64.rpm &> /dev/null
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
-[0],
+[1],
 [/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
 ],
 [])
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1227,13 +1227,13 @@ RPMKEYRING_RESET
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 4344591E1964C5FC --rpmv3 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
 echo PRE-IMPORT
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 echo POST-IMPORT
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 runroot rpmsign --delsign /tmp/hello-2.0-1.x86_64.rpm
 echo POST-DELSIGN
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 ],
 [0],
 [PRE-IMPORT
@@ -1256,13 +1256,13 @@ RPMKEYRING_RESET
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 4344591E1964C5FC --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
 echo PRE-IMPORT
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 echo POST-IMPORT
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 runroot rpmsign --delsign /tmp/hello-2.0-1.x86_64.rpm
 echo POST-DELSIGN
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 ],
 [0],
 [PRE-IMPORT
@@ -1404,14 +1404,14 @@ cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 echo SIGN
 runroot rpmsign --addsign -v /tmp/hello-2.0-1.x86_64.rpm
 echo PRE-IMPORT
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 echo POST-IMPORT
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 echo DELSIGN
 runroot rpmsign --delsign -v /tmp/hello-2.0-1.x86_64.rpm
 echo POST-DELSIGN
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 ],
 [0],
 [SIGN
@@ -1638,10 +1638,10 @@ RPMTEST_CHECK([
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64-signed.rpm "${RPMTEST}"/tmp/
 echo PRE-DELSIGN
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64-signed.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64-signed.rpm|grep -vE '(digest|signature):'
 echo POST-DELSIGN
 runroot rpmsign --delsign /tmp/hello-2.0-1.x86_64-signed.rpm
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64-signed.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64-signed.rpm|grep -vE '(digest|signature):'
 ],
 [0],
 [PRE-DELSIGN
@@ -1688,10 +1688,10 @@ RPMTEST_CHECK([
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id B0645AEC757BF69E --digest-algo sha512 --addsign /tmp/hello-2.0-1.x86_64.rpm
 echo PRE-IMPORT
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 echo POST-IMPORT
 runroot rpmkeys --import /data/keys/rpm.org-ed25519-test.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 ],
 [0],
 [PRE-IMPORT
@@ -1717,10 +1717,10 @@ RPMTEST_CHECK([
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 7f1c21f95f65bbe8 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
 echo PRE-IMPORT
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 echo POST-IMPORT
 runroot rpmkeys --import /data/keys/rpm.org-nistp256-test.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 ],
 [0],
 [PRE-IMPORT
@@ -1747,12 +1747,12 @@ RPMTEST_CHECK([
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 79cc07f167fee8841829acaa42655a75156b3de0 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
 echo PRE-IMPORT
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 echo POST-IMPORT
 runroot rpmkeys --import /data/keys/keyidcollision2.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 runroot rpmkeys --import /data/keys/keyidcollision1.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 ],
 [0],
 [PRE-IMPORT
@@ -1784,12 +1784,12 @@ RPMTEST_CHECK([
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 runroot rpmsign --key-id 94706f8da571389e8642bdfd42655a75156b3de0 --digest-algo sha256 --addsign /tmp/hello-2.0-1.x86_64.rpm
 echo PRE-IMPORT
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 echo POST-IMPORT
 runroot rpmkeys --import /data/keys/keyidcollision1.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 runroot rpmkeys --import /data/keys/keyidcollision2.pub
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -vE '(digest|signature):'
 ],
 [0],
 [PRE-IMPORT

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -375,7 +375,7 @@ cat hello.intro hello.payload > "${RPMTEST}"/tmp/hello-c.rpm
 cat hello.intro hello.uc-payload > "${RPMTEST}"/tmp/hello-uc.rpm
 
 RPMTEST_CHECK([
-runroot rpmkeys -Kv /tmp/hello-c.rpm
+runroot rpmkeys -Kv --nosignature /tmp/hello-c.rpm
 ],
 [0],
 [/tmp/hello-c.rpm:
@@ -385,7 +385,7 @@ runroot rpmkeys -Kv /tmp/hello-c.rpm
 [])
 
 RPMTEST_CHECK([
-runroot rpmkeys -Kv /tmp/hello-uc.rpm
+runroot rpmkeys -Kv --nosignature /tmp/hello-uc.rpm
 ],
 [0],
 [/tmp/hello-uc.rpm:
@@ -395,7 +395,7 @@ runroot rpmkeys -Kv /tmp/hello-uc.rpm
 [])
 
 RPMTEST_CHECK([
-runroot rpmkeys --define "_pkgverify_flags 0" -Kv /tmp/hello-uc.rpm
+runroot rpmkeys --define "_pkgverify_flags 0" -Kv --nosignature /tmp/hello-uc.rpm
 ],
 [1],
 [/tmp/hello-uc.rpm:
@@ -419,7 +419,7 @@ dd if=/dev/zero of="${RPMTEST}"/tmp/${pkg} \
    conv=notrunc bs=1 seek=333 count=4 2> /dev/null
 
 RPMTEST_CHECK([
-runroot rpmkeys -Kv /tmp/${pkg}
+runroot rpmkeys -Kv --nosignature /tmp/${pkg}
 ],
 [0],
 [/tmp/hello-2.0-1.x86_64.rpm:
@@ -429,7 +429,7 @@ runroot rpmkeys -Kv /tmp/${pkg}
 [])
 
 RPMTEST_CHECK([
-runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/${pkg}
+runroot rpmkeys -Kv --nosignature --define "_pkgverify_flags 0" /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
@@ -450,7 +450,7 @@ pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
 dd if=/dev/zero of="${RPMTEST}"/tmp/${pkg} \
    conv=notrunc bs=1 seek=5555 count=6 2> /dev/null
-runroot rpmkeys -Kv /tmp/${pkg}
+runroot rpmkeys -Kv --nosignature /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
@@ -472,7 +472,7 @@ pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
 dd if=/dev/zero of="${RPMTEST}"/tmp/${pkg} \
    conv=notrunc bs=1 seek=7777 count=6 2> /dev/null
-runroot rpmkeys -Kv /tmp/${pkg}
+runroot rpmkeys -Kv --nosignature /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
@@ -494,7 +494,7 @@ pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
 dd if=/dev/zero of="${RPMTEST}"/tmp/${pkg} \
    conv=notrunc bs=1 seek=4750 count=4 2> /dev/null
-runroot rpmkeys -Kv /tmp/${pkg}
+runroot rpmkeys -Kv --nosignature /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
@@ -1891,7 +1891,7 @@ if ! setfattr -n security.ima -v 0sAwIEpZglVABIMEYCIQDlEXva+nO6rrHx3EbsqkaYGmLUF
 fi
 
 RPMTEST_CHECK([
-runroot rpm -U /data/RPMS/imatest-1.0-1.fc34.noarch.rpm
+runroot rpm -U --nosignature /data/RPMS/imatest-1.0-1.fc34.noarch.rpm
 runroot getfattr --absolute-names -d -m security.ima /usr/share/example1
 ],
 [0],

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -30,7 +30,7 @@ RPMTEST_SETUP_RW([files with no problems])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 
-runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
+runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos --nosignature \
 	/data/RPMS/hello-2.0-1.i686.rpm
 runroot rpm -Va --nodeps ${VERIFYOPTS}
 ],
@@ -44,7 +44,7 @@ RPMTEST_SETUP_RW([files with no problems in verbose mode])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 
-runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
+runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos --nosignature \
 	/data/RPMS/hello-2.0-1.i686.rpm
 runroot rpm -Vva --nodeps ${VERIFYOPTS}
 ],
@@ -120,7 +120,7 @@ RPMTEST_SETUP_RW([verify from db, with problems present])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 
-runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
+runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos --nosignature \
 	/data/RPMS/hello-2.0-1.i686.rpm
 rm -f "${RPMTEST}"/usr/share/doc/hello-2.0/FAQ
 chmod u-x "${RPMTEST}"/usr/bin/hello
@@ -140,7 +140,7 @@ RPMTEST_SETUP_RW([verify from package, with problems present])
 AT_KEYWORDS([verify])
 RPMTEST_CHECK([
 
-runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
+runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos --nosignature \
 	/data/RPMS/hello-2.0-1.i686.rpm
 rm -f "${RPMTEST}"/usr/share/doc/hello-2.0/FAQ
 chmod u-x "${RPMTEST}"/usr/bin/hello
@@ -563,7 +563,7 @@ AT_KEYWORDS([verify])
 RPMTEST_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
 
-runroot rpm -U --nocaps --ignoreos \
+runroot rpm -U --nocaps --ignoreos --nosignature \
 	/data/RPMS/capstest-1.0-1.noarch.rpm
 
 runroot rpm -Va ${VERIFYOPTS}
@@ -581,7 +581,7 @@ AT_KEYWORDS([verify])
 RPMTEST_SKIP_IF([$CAP_DISABLED])
 RPMTEST_CHECK([
 
-runroot rpm -U --nocaps --nodeps --noscripts --ignorearch --ignoreos \
+runroot rpm -U --nocaps --nodeps --noscripts --ignorearch --ignoreos --nosignature \
 	/data/RPMS/hello-2.0-1.i686.rpm
 
 runroot rpm -Va ${VERIFYOPTS} --nodeps | grep "/bin/hello"
@@ -595,7 +595,7 @@ RPMTEST_SETUP_RW([rpm --restore])
 AT_KEYWORDS([verify restore])
 RPMTEST_CHECK([
 
-runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
+runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos --nosignature \
 	/data/RPMS/hello-2.0-1.i686.rpm
 runroot touch /usr/share/doc/hello-2.0/FAQ
 runroot chmod a-x /usr/bin/hello


### PR DESCRIPTION
This is all about tediously revising various tests to avoid certain assumptions, and the rest is updating test results to match the new expectations. Some --nosignature disablers added on tests where we know it's unsigned and the extra output from signature checking is not relevant for the tests.

Fixes: #1573
