### PR TITLE
Multi-arch ELF dependency generation (v6 packages)

### DIFF
--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -1,5 +1,6 @@
-%__elf_provides		%{_rpmconfigdir}/elfdeps --provides --multifile
-%__elf_requires		%{_rpmconfigdir}/elfdeps --requires --multifile
+%__elf_depstyle		%[ %_rpmformat >=6 ? "--multiarch" : "--biarch" ]
+%__elf_provides		%{_rpmconfigdir}/elfdeps --provides --multifile %{__elf_depstyle}
+%__elf_requires		%{_rpmconfigdir}/elfdeps --requires --multifile %{__elf_depstyle}
 %__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
 %__elf_exclude_path	^/lib/modules/.*\\.ko?(\\.[[:alnum:]]*)$
 %__elf_protocol		multifile

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1385,14 +1385,14 @@ shebang = 0.1-1
 [])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP_RW([elf dependencies])
-AT_KEYWORDS([build])
+RPMTEST_SETUP_RW([elf biarch dependencies])
+AT_KEYWORDS([build elfdeps])
 
 RPMTEST_CHECK([
 runroot chmod a-x /data/misc/libhello.so
-runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R /data/misc/libhello.so
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --biarch /data/misc/libhello.so
 runroot chmod a+x /data/misc/libhello.so
-runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R /data/misc/libhello.so
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --biarch /data/misc/libhello.so
 ],
 [0],
 [libc.so.6(GLIBC_2.2.5)(64bit)
@@ -1406,9 +1406,9 @@ rtld(GNU_HASH)
 
 RPMTEST_CHECK([
 runroot chmod a-x /data/misc/libhello.so
-runroot ${RPM_CONFIGDIR_PATH}/elfdeps -P /data/misc/libhello.so
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -P --biarch /data/misc/libhello.so
 runroot chmod a+x /data/misc/libhello.so
-runroot ${RPM_CONFIGDIR_PATH}/elfdeps -P /data/misc/libhello.so
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -P --biarch /data/misc/libhello.so
 ],
 [0],
 [libhello.so()(64bit)
@@ -1418,9 +1418,9 @@ libhello.so()(64bit)
 
 RPMTEST_CHECK([
 runroot chmod a-x /data/misc/helloexe
-runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R /data/misc/helloexe
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --biarch /data/misc/helloexe
 runroot chmod a+x /data/misc/helloexe
-runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R /data/misc/helloexe
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --biarch /data/misc/helloexe
 ],
 [0],
 [libc.so.6(GLIBC_2.2.5)(64bit)
@@ -1432,9 +1432,9 @@ rtld(GNU_HASH)
 
 RPMTEST_CHECK([
 runroot chmod a-x /data/misc/hellopie
-runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R /data/misc/hellopie
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --biarch /data/misc/hellopie
 runroot chmod a+x /data/misc/hellopie
-runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R /data/misc/hellopie
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --biarch /data/misc/hellopie
 ],
 [0],
 [libc.so.6(GLIBC_2.2.5)(64bit)
@@ -1445,6 +1445,89 @@ rtld(GNU_HASH)
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([elf multiarch dependencies])
+AT_KEYWORDS([build elfdeps])
+
+RPMTEST_CHECK([
+runroot chmod a-x /data/misc/libhello.so
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --multiarch /data/misc/libhello.so
+runroot chmod a+x /data/misc/libhello.so
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --multiarch /data/misc/libhello.so
+],
+[0],
+[libc.so.6(GLIBC_2.2.5)(x86-64l)
+libc.so.6()(x86-64l)
+rtld(GNU_HASH)
+libc.so.6(GLIBC_2.2.5)(x86-64l)
+libc.so.6()(x86-64l)
+rtld(GNU_HASH)
+],
+[])
+
+RPMTEST_CHECK([
+runroot chmod a-x /data/misc/libhello.so
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -P --multiarch /data/misc/libhello.so
+runroot chmod a+x /data/misc/libhello.so
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -P --multiarch /data/misc/libhello.so
+],
+[0],
+[libhello.so()(x86-64l)
+libhello.so()(x86-64l)
+],
+[])
+
+RPMTEST_CHECK([
+runroot chmod a-x /data/misc/helloexe
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --multiarch /data/misc/helloexe
+runroot chmod a+x /data/misc/helloexe
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --multiarch /data/misc/helloexe
+],
+[0],
+[libc.so.6(GLIBC_2.2.5)(x86-64l)
+libhello.so()(x86-64l)
+libc.so.6()(x86-64l)
+rtld(GNU_HASH)
+],
+[])
+
+RPMTEST_CHECK([
+runroot chmod a-x /data/misc/hellopie
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --multiarch /data/misc/hellopie
+runroot chmod a+x /data/misc/hellopie
+runroot ${RPM_CONFIGDIR_PATH}/elfdeps -R --multiarch /data/misc/hellopie
+],
+[0],
+[libc.so.6(GLIBC_2.2.5)(x86-64l)
+libhello.so()(x86-64l)
+libc.so.6()(x86-64l)
+rtld(GNU_HASH)
+],
+[])
+
+# amusingly our ppc64 package actually contains a 32bit binary
+RPMTEST_CHECK([
+for arch in ppc64 i386; do
+    pkg="hello-1.0-1.${arch}.rpm"
+    echo ${pkg}:
+    rpm2cpio /data/RPMS/${pkg} \
+		| cpio -i --quiet --to-stdout ./usr/local/bin/hello > ${arch}.bin
+    chmod a+x ${arch}.bin
+    ${RPM_CONFIGDIR_PATH}/elfdeps -R --multiarch ${arch}.bin
+done
+],
+[0],
+[hello-1.0-1.ppc64.rpm:
+libc.so.6(GLIBC_2.0)(ppc-32b)
+libc.so.6()(ppc-32b)
+rtld(GNU_HASH)
+hello-1.0-1.i386.rpm:
+libc.so.6(GLIBC_2.0)(x86-32l)
+libc.so.6()(x86-32l)
+rtld(GNU_HASH)
+],
+[])
+
+RPMTEST_CLEANUP
 # ------------------------------
 # Test spec query functionality
 RPMTEST_SETUP_RW([rpmspec query 1])


### PR DESCRIPTION
Traditional rpm dependencies have only supported biarch style installations between 64bit and "something else", traditionally of course 32bit. This has been denoted with (64bit) markers at the end of ELF dependency tokens for some 64bit architectures and for others not, and lets a dependency token of a completely different architecture satisfy that of another. This is inconsistent and limiting at best.

Add a new multiarch mode for elfdeps where each ELF dependency token carries an ABI identifier consisting of the base architecture, it's bitness and endiananess, optionally followed by arch-specific flags. v4 packages continue to use the traditional biarch dependencies, for v6 packages we use the new multiarch style. It's possible to generate
both for transition-period compatibility though.

The last patch is the where the real interest is, the earlier ones are just preliminaries to make this all nicer by converting it to use C++ facilities. There are no docs and the exact format is subject to change, but posting a draft PR to allow experimenting and hopefully inviting a wider community discussion on this.

Fixes: #2197