### PR TITLE
Fix regression on buildarchtranslate overrides

### DIFF
--- a/lib/rpmrc.cc
+++ b/lib/rpmrc.cc
@@ -332,7 +332,7 @@ static rpmRC addDefault(defaultsTable & table, char * line,
 	return RPMRC_FAIL;
     }
 
-    table.insert({name, defName});
+    table[name] = defName;
 
     return RPMRC_OK;
 }

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -77,6 +77,19 @@ optflags              : -O2 -g -march=x86-64-v3
 ])
 
 RPMTEST_CHECK([
+cat << EOF > ${RPMTEST}/root/.config/rpm/rpmrc
+buildarchtranslate: x86_64_v3: noarch
+EOF
+
+runroot rpm --showrc | head -2
+],
+[0],
+[ARCHITECTURE AND OS:
+build arch            : noarch
+],
+[])
+
+RPMTEST_CHECK([
 echo ppc64le-Linux > ${RPMTEST}/${RPMSYSCONFDIR}/platform
 runroot rpm --showrc | head -17 | sed '/backend/d'
 ],


### PR DESCRIPTION
Commit 7be4b79581a451f750242485ec1923ca96df9e5b didn't account for the fact that there can be multiple source values for the same key, and that order matters: to honor the default < vendor < host < user override system, we need to use the last, not the first value we encounter. And .insert() on an STL map only inserts if the they doesn't already exist. Oops. Add a test as well.

Fixes: #3582