### PR TITLE
Remove AUTHORS sections from man pages

### DIFF
--- a/docs/man/gendiff.1.md
+++ b/docs/man/gendiff.1.md
@@ -48,8 +48,3 @@ SEE ALSO
 ========
 
 **diff**(1), **patch**(1)
-
-AUTHOR
-======
-
-    Marc Ewing <marc@redhat.com>

--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -1075,10 +1075,3 @@ aliases it\'s impossible to guarantee that what\'s described in the
 manual matches what\'s available.
 
 **http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
-
-AUTHORS
-=======
-
-    Marc Ewing <marc@redhat.com>
-    Jeff Johnson <jbj@redhat.com>
-    Erik Troan <ewt@redhat.com>

--- a/docs/man/rpm2archive.8.md
+++ b/docs/man/rpm2archive.8.md
@@ -54,8 +54,3 @@ SEE ALSO
 ========
 
 **rpm2cpio**(8), **rpm**(8)
-
-AUTHOR
-======
-
-    Florian Festi <ffesti@redhat.com>

--- a/docs/man/rpm2cpio.8.md
+++ b/docs/man/rpm2cpio.8.md
@@ -32,8 +32,3 @@ SEE ALSO
 ========
 
 **rpm**(8) **rpm2archive**(8)
-
-AUTHOR
-======
-
-    Erik Troan <ewt@redhat.com>

--- a/docs/man/rpmbuild.8.md
+++ b/docs/man/rpmbuild.8.md
@@ -348,10 +348,3 @@ aliases it\'s impossible to guarantee that what\'s described in the
 manual matches what\'s available.
 
 **http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
-
-AUTHORS
-=======
-
-    Marc Ewing <marc@redhat.com>
-    Jeff Johnson <jbj@redhat.com>
-    Erik Troan <ewt@redhat.com>

--- a/docs/man/rpmdb.8.md
+++ b/docs/man/rpmdb.8.md
@@ -49,11 +49,3 @@ aliases it\'s impossible to guarantee that what\'s described in the
 manual matches what\'s available.
 
 **http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
-
-AUTHORS
-=======
-
-    Marc Ewing <marc@redhat.com>
-    Jeff Johnson <jbj@redhat.com>
-    Erik Troan <ewt@redhat.com>
-    Panu Matilainen <pmatilai@redhat.com>

--- a/docs/man/rpmdeps.8.md
+++ b/docs/man/rpmdeps.8.md
@@ -66,8 +66,3 @@ SEE ALSO
 ========
 
 **rpm**(8), **rpmbuild**(8)
-
-AUTHORS
-=======
-
-Jeff Johnson \<jbj\@redhat.com\>

--- a/docs/man/rpmgraph.8.md
+++ b/docs/man/rpmgraph.8.md
@@ -41,8 +41,3 @@ SEE ALSO
 **dot**(1), **dotty**(1)
 
 **http://www.graphviz.org/ \<URL:http://www.graphviz.org/\>**
-
-AUTHORS
-=======
-
-Jeff Johnson \<jbj\@redhat.com\>

--- a/docs/man/rpmkeys.8.md
+++ b/docs/man/rpmkeys.8.md
@@ -75,11 +75,3 @@ aliases it\'s impossible to guarantee that what\'s described in the
 manual matches what\'s available.
 
 **http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
-
-AUTHORS
-=======
-
-    Marc Ewing <marc@redhat.com>
-    Jeff Johnson <jbj@redhat.com>
-    Erik Troan <ewt@redhat.com>
-    Panu Matilainen <pmatilai@redhat.com>

--- a/docs/man/rpmlua.8.md
+++ b/docs/man/rpmlua.8.md
@@ -60,8 +60,3 @@ SEE ALSO
 **lua**(1), **popt**(3), **getopt**(3), **rpm**(8)
 
 **http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
-
-AUTHORS
-=======
-
-    Panu Matilainen <pmatilai@redhat.com>

--- a/docs/man/rpmsign.8.md
+++ b/docs/man/rpmsign.8.md
@@ -177,13 +177,3 @@ aliases it\'s impossible to guarantee that what\'s described in the
 manual matches what\'s available.
 
 **http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
-
-AUTHORS
-=======
-
-    Marc Ewing <marc@redhat.com>
-    Jeff Johnson <jbj@redhat.com>
-    Erik Troan <ewt@redhat.com>
-    Panu Matilainen <pmatilai@redhat.com>
-    Fionnuala Gunter <fin@linux.vnet.ibm.com>
-    Jes Sorensen <jsorensen@fb.com>

--- a/docs/man/rpmsort.8.md
+++ b/docs/man/rpmsort.8.md
@@ -30,9 +30,3 @@ EXAMPLES
 ***$ echo -e \'rpm-4.18.0-3.fc38.x86_64\\nrpm-4.18.0-1.fc38.x86_64\' | rpmsort \
 rpm-4.18.0-1.fc38.x86_64 \
 rpm-4.18.0-3.fc38.x86_64***
-
-AUTHORS
-=======
-
-    Peter Jones <pjones@redhat.com>
-	Robbie Harwood <rharwood@redhat.com>

--- a/docs/man/rpmspec.8.md
+++ b/docs/man/rpmspec.8.md
@@ -152,11 +152,3 @@ aliases it\'s impossible to guarantee that what\'s described in the
 manual matches what\'s available.
 
 **http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
-
-AUTHORS
-=======
-
-    Marc Ewing <marc@redhat.com>
-    Jeff Johnson <jbj@redhat.com>
-    Erik Troan <ewt@redhat.com>
-    Panu Matilainen <pmatilai@redhat.com>


### PR DESCRIPTION
Contact info 20-30 years out of date is useful to exactly nobody. Historians are better served by digging up the info from git anyhow.