### PR TITLE
Fix missing GITHUB_TOKEN permission setting

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -5,6 +5,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  # Permit the modification of releases
+  contents: write
+
 jobs:
   # Generates dist tarball(s) and a checksum file to go with.
   #


### PR DESCRIPTION
Commit 3ff9f13b4644145083ded06b26cd874fe507f5cc didn't specify any permissions for the GITHUB_TOKEN so it used the project's default read-only permissions, preventing the "gh release upload" command from working.  Fix by specifying the right permissions (for modifying releases, see [1]).

[1] https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token