### PR TITLE
fix bad copypaste

### DIFF
--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -488,9 +488,9 @@ static int sinfoCmp(const void *a, const void *b)
 	rc = sb->type - sa->type;
     /* strongest (in the "newer is better" sense) algos first */
     if (rc == 0)
-	rc = sb->sigalgo - sb->sigalgo;
+	rc = sb->sigalgo - sa->sigalgo;
     if (rc == 0)
-	rc = sb->hashalgo - sb->hashalgo;
+	rc = sb->hashalgo - sa->hashalgo;
     /* last resort, these only makes sense from consistency POV */
     if (rc == 0)
 	rc = sb->id - sa->id;


### PR DESCRIPTION
Comparator function sinfoCmp tried to compare sigalgo and hashalgo, but the result was always 0 due to sb being used in both operands.