### PR TITLE
Fix RPM version introducing u! in docs

### DIFF
--- a/docs/manual/users_and_groups.md
+++ b/docs/manual/users_and_groups.md
@@ -41,8 +41,8 @@ to weaken these into recommends-dependencies by setting
 
 ## Limitations
 
-At this time, rpm only supports the `u`, `g`, (since RPM 4.20) `m`
-and (since RPM 6.0) the `u!` directives of sysusers.d format and
+At this time, rpm only supports the `u`, `g`, (since RPM 4.20.0) `m`
+and (since RPM 4.20.1) the `u!` directives of sysusers.d format and
 ignores others. If other directives are needed, the package will need
 to call systemd-sysusers with the correct arguments manually.
 


### PR DESCRIPTION
This flag was actually backported to 4.20.1.