### PR TITLE
Fix buildsys specific %prep section not accepted

### DIFF
--- a/build/parseSpec.cc
+++ b/build/parseSpec.cc
@@ -987,7 +987,7 @@ int checkBuildsystem(rpmSpec spec, const char *name)
 }
 
 static rpmRC parseBuildsysSect(rpmSpec spec, const char *prefix,
-				struct sectname_s *sc, FD_t fd)
+				struct sectname_s *sc, FD_t fd, int *foundp)
 {
     rpmRC rc = RPMRC_OK;
 
@@ -1015,6 +1015,7 @@ static rpmRC parseBuildsysSect(rpmSpec spec, const char *prefix,
 	    }
 	    free(buf);
 	    free(args);
+	    *foundp = 1;
 	}
 	free(mn);
     }
@@ -1038,9 +1039,10 @@ static rpmRC parseBuildsystem(rpmSpec spec)
 	}
 
 	for (struct sectname_s *sc = sectList; !rc && sc->name; sc++) {
-	    rc = parseBuildsysSect(spec, buildsystem, sc, fd);
-	    if (!rc && spec->sections[sc->section] == NULL)
-		rc = parseBuildsysSect(spec, "default", sc, fd);
+	    int found = 0;
+	    rc = parseBuildsysSect(spec, buildsystem, sc, fd, &found);
+	    if (!rc && !found)
+		rc = parseBuildsysSect(spec, "default", sc, fd, &found);
 	}
 
 	if (!rc)

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -118,6 +118,17 @@ runroot rpm -qpl --noartifact /build/RPMS/*/amhello-1.0-1.*.rpm
 [ignore])
 
 RPMTEST_CHECK([
+runroot rpmspec -P \
+	--define "buildsystem_autotools_prep() echo PREP" \
+	/data/SPECS/amhello.spec | grep PREP
+
+],
+[0],
+[echo PREP
+],
+[])
+
+RPMTEST_CHECK([
 # re-tar the source to a different name
 tar xf /data/SOURCES/amhello-1.0.tar.gz
 mv amhello-1.0 amhello-1.0-prerelease


### PR DESCRIPTION
%prep is special in the buildsystem in that it ships with a global default. And since we didn't have a specific test for *that*, of course it's broken, sigh.

The logic in parseBuildsystem() is faulty in that it assumes parseBuildsysSect() populates the relevant spec struct section, but that only happens at a later point. So we need to track whether a buildsys section was found through other means. Add a secondary return code to do just that, and a test to ensure it actually works.

Fixes: #3635