### PR TITLE
Make built-in macros usable before explicit initialization

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -38,6 +38,18 @@ runroot --setenv  XDG_CONFIG_HOME "~/.zzz" rpm --showrc | awk '/^Macro path/{pri
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([macros in macro path])
+AT_KEYWORDS([macros])
+RPMTEST_CHECK([
+echo "%somewhere /some/where" > /tmp/somewhere
+SOMENV=/tmp/somewhere rpm --macros "%{getenv:SOMENV}" --eval "%somewhere"
+],
+[0],
+[/some/where
+],
+[])
+RPMTEST_CLEANUP
+
 # ------------------------------
 RPMTEST_SETUP_RW([macro path: skip editor backups])
 AT_KEYWORDS([macros])


### PR DESCRIPTION
Macro initialization is about loading macro configuration, but built-ins should always work as they are, well, built-ins. Initialize built-ins in the macro context constructor so they're usable in any macro context at any time.

Note that we now need to pay attention to avoid copying the built-ins, and make sure they're still there after clearing the macros. Avoiding deleting them in the first place sounds neater but is messier in practise and unlikely to make the damnest of differences in performance.

Fixes: #3638