### PR TITLE
Fix empty password field in passwd/group causing entry to be ignored

### DIFF
--- a/lib/rpmug.cc
+++ b/lib/rpmug.cc
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <errno.h>
+#include <rpm/argv.h>
 #include <rpm/rpmlog.h>
 #include <rpm/rpmstring.h>
 #include <rpm/rpmmacro.h>
@@ -68,12 +69,11 @@ static int lookup_field(const char *path, const char *val, int vcol, int rcol,
     while ((str = fgets(buf, sizeof(buf), f)) != NULL) {
 	int nf = vcol > rcol ? vcol : rcol;
 	const char *fields[nf + 1];
-	char *tok, *save = NULL;
 	int col = -1;
 
-	while ((tok = strtok_r(str, ":", &save)) != NULL) {
-	    fields[++col] = tok;
-	    str = NULL;
+	ARGV_t tokens = argvSplitString(str, ":", ARGV_NONE);
+	for (ARGV_const_t tok = tokens; tok && *tok; tok++) {
+	    fields[++col] = *tok;
 	    if (col >= nf)
 		break;
 	}
@@ -84,6 +84,7 @@ static int lookup_field(const char *path, const char *val, int vcol, int rcol,
 		rc = 0;
 	    }
 	}
+	argvFree(tokens);
     }
 
     fclose(f);

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1639,6 +1639,14 @@ runroot rpm -V ${VERIFYOPTS} klang-client klang-common
 [ignore])
 
 RPMTEST_CHECK([
+runroot sed -i -e "s/:x:/::/g" /etc/group
+runroot rpm -V ${VERIFYOPTS} klang-client klang-common
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
 runroot rpm -U /build/RPMS/noarch/klang-server-1.0-1.noarch.rpm
 runroot grep ^klangd /etc/passwd | cut -f1 -d:
 runroot chage -l klangd | grep "Account expires" | cut -f2 -d:


### PR DESCRIPTION
strtok() only handles non-empty tokens. Says so on the first line of the description on the man page. Doh. So use our own argv splitting, this is actually more handy anyhow.

Fixes: #3594