### PR TITLE
Check architecture before building

### DIFF
--- a/build/parsePreamble.cc
+++ b/build/parsePreamble.cc
@@ -1331,6 +1331,11 @@ int parsePreamble(rpmSpec spec, int initialPackage, enum parseStages stage)
 			    "%{dirname:%{buildroot}}", RMIL_GLOBAL, 0);
     }
 
+    /* XXX Skip valid arch check if not building binary package */
+    if (!(spec->flags & RPMSPEC_ANYARCH) && checkForValidArchitectures(spec)) {
+	goto exit;
+    }
+
     /* if we get down here nextPart has been set to non-error */
     res = nextPart;
 

--- a/build/parseSpec.cc
+++ b/build/parseSpec.cc
@@ -1354,11 +1354,6 @@ static rpmRC finalizeSpec(rpmSpec spec)
     char *os = rpmExpand("%{_target_os}", NULL);
     char *optflags = rpmExpand("%{optflags}", NULL);
 
-    /* XXX Skip valid arch check if not building binary package */
-    if (!(spec->flags & RPMSPEC_ANYARCH) && checkForValidArchitectures(spec)) {
-	goto exit;
-    }
-
     fillOutMainPackage(spec->packages->header);
     /* Define group tag to something when group is undefined in main package*/
     if (!headerIsEntry(spec->packages->header, RPMTAG_GROUP)) {

--- a/tests/data/SPECS/test-exclusivearch.spec
+++ b/tests/data/SPECS/test-exclusivearch.spec
@@ -1,0 +1,24 @@
+Summary:	test
+Name:		test
+Version:	1
+Release:	1
+License:	GPL
+Group:		Applications/System
+%ifarch x86_64
+ExclusiveArch:	aarch64
+%else
+ExclusiveArch:	x86_64
+%endif
+
+
+%description
+test
+
+%prep
+echo prep
+
+%build
+echo build
+
+%install
+echo install

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -780,6 +780,19 @@ runroot rpmbuild -bp --quiet /data/SPECS/hello-patch.spec
 ])
 RPMTEST_CLEANUP
 
+
+RPMTEST_SETUP_RW([rpmbuild ExclusiveArch])
+AT_KEYWORDS([build])
+RPMTEST_CHECK([
+runroot rpmbuild \
+	-bb /data/SPECS/test-exclusivearch.spec 2> >(grep "Architecture is not included" | cut -d: -f-2 ) 1> >(grep "^install$")
+],
+[1],
+[error: Architecture is not included
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([rpmbuild scriptlet -f])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([


### PR DESCRIPTION
fd32a43 moved the architecture check after building. This decision needs to me made beforehand to not build on unsupported architectures. 1296ea9 also made it impossible to change the supported / excluded architectures later.

Move this particular check back and add a test case using ExclusiveArch

Resolves: #3569