### PR TITLE
Use stderr for %dump

### DIFF
--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -2048,6 +2048,7 @@ int macros::define(const std::string & macro, int level)
 
 void macros::dump(FILE *fp)
 {
+    if (fp == NULL) fp = stderr;
     fprintf(fp, "========================\n");
     for (auto & entry : mc->tab) {
 	auto const & me = entry.second.top();

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -333,6 +333,19 @@ arg
 ])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP([macro %dump])
+AT_KEYWORDS([macros])
+RPMTEST_CHECK([
+rpm --eval "%dump" 2>&1 | head -3
+],
+[0],
+[[========================
+-20: P	<builtin>
+-20: S	<builtin>
+]],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP([uncompress macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([


### PR DESCRIPTION
439a601439 dropped the code using stderr if no file descriptor is passed. The %dump macro code doesn't pass a file descriptor ever. This led to a segfault.

Omit test case as it spits out a long list of macros that are susceptible the change.

Resolves: #3588