### PR TITLE
spec.md: fix changelog toc item to point to the anchor

### DIFF
--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -33,7 +33,7 @@ Spec files describe how software is build and packaged.
   * [→ Scriptlet Expansion](scriptlet_expansion.md)
 * [%files section](#files-section)
   * [→ Users and Groups](users_and_groups.md)
-* [%changelog section](changelog-section)
+* [%changelog section](#changelog-section)
 
 ## Generic syntax
 


### PR DESCRIPTION
While the section does not contain any content, it is better to link to an empty section instead of a nonexisting file