### PR TITLE
Add new tag and algorithm ID's and descriptions from RFC-9580

### DIFF
--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -56,7 +56,7 @@ typedef enum pgpTag_e {
     PGPTAG_USER_ID		= 13, /*!< User ID */
     PGPTAG_PUBLIC_SUBKEY	= 14, /*!< Public Subkey */
     PGPTAG_COMMENT_OLD		= 16, /*!< Comment (from OpenPGP draft) */
-    PGPTAG_PHOTOID		= 17, /*!< PGP's photo ID */
+    PGPTAG_USER_ATTRIBUTE	= 17, /*!< User Attribute packet */
     PGPTAG_ENCRYPTED_MDC	= 18, /*!< Integrity protected encrypted data */
     PGPTAG_MDC			= 19, /*!< Manipulaion detection code packet */
     PGPTAG_PRIVATE_60		= 60, /*!< Private or Experimental Values */
@@ -64,6 +64,8 @@ typedef enum pgpTag_e {
     PGPTAG_PRIVATE_62		= 62, /*!< Private or Experimental Values */
     PGPTAG_CONTROL		= 63  /*!< Control (GPG) */
 } pgpTag;
+
+#define PGPTAG_PHOTOID PGPTAG_USER_ATTRIBUTE /* legacy name */
 
 /** \ingroup rpmpgp
  * 5.2.1. Signature Types

--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -59,6 +59,7 @@ typedef enum pgpTag_e {
     PGPTAG_USER_ATTRIBUTE	= 17, /*!< User Attribute packet */
     PGPTAG_ENCRYPTED_MDC	= 18, /*!< Integrity protected encrypted data */
     PGPTAG_MDC			= 19, /*!< Manipulaion detection code packet */
+    PGPTAG_PADDING		= 21, /*!< Padding packet */
     PGPTAG_PRIVATE_60		= 60, /*!< Private or Experimental Values */
     PGPTAG_COMMENT		= 61, /*!< Comment */
     PGPTAG_PRIVATE_62		= 62, /*!< Private or Experimental Values */
@@ -88,7 +89,8 @@ typedef enum pgpSigType_e {
     PGPSIGTYPE_KEY_REVOKE	 = 0x20, /*!< Key revocation */
     PGPSIGTYPE_SUBKEY_REVOKE	 = 0x28, /*!< Subkey revocation */
     PGPSIGTYPE_CERT_REVOKE	 = 0x30, /*!< Certification revocation */
-    PGPSIGTYPE_TIMESTAMP	 = 0x40  /*!< Timestamp */
+    PGPSIGTYPE_TIMESTAMP	 = 0x40, /*!< Timestamp */
+    PGPSIGTYPE_THIRD_PARTY	 = 0x50, /*!< Third-Party Confirmation */
 } pgpSigType;
 
 /** \ingroup rpmpgp
@@ -104,7 +106,11 @@ typedef enum pgpPubkeyAlgo_e {
     PGPPUBKEYALGO_ECDSA		= 19,	/*!< ECDSA */
     PGPPUBKEYALGO_ELGAMAL	= 20,	/*!< Elgamal */
     PGPPUBKEYALGO_DH		= 21,	/*!< Diffie-Hellman (X9.42) */
-    PGPPUBKEYALGO_EDDSA		= 22	/*!< EdDSA */
+    PGPPUBKEYALGO_EDDSA		= 22,	/*!< EdDSA */
+    PGPPUBKEYALGO_X25519	= 25,	/*!< X25519 */
+    PGPPUBKEYALGO_X448		= 26,	/*!< X448 */
+    PGPPUBKEYALGO_ED25519	= 27,	/*!< Ed25519 */
+    PGPPUBKEYALGO_ED448		= 28,	/*!< Ed448 */
 } pgpPubkeyAlgo;
 
 /** \ingroup rpmpgp
@@ -122,6 +128,9 @@ typedef enum pgpSymkeyAlgo_e {
     PGPSYMKEYALGO_AES_192	=  8,	/*!< AES(192-bit key) */
     PGPSYMKEYALGO_AES_256	=  9,	/*!< AES(256-bit key) */
     PGPSYMKEYALGO_TWOFISH	= 10,	/*!< TWOFISH(256-bit key) */
+    PGPSYMKEYALGO_CAMELLIA_128	= 11,	/*!< Camellia with 128-bit */
+    PGPSYMKEYALGO_CAMELLIA_192	= 12,	/*!< Camellia with 192-bit */
+    PGPSYMKEYALGO_CAMELLIA_256	= 13,	/*!< Camellia with 256-bit */
     PGPSYMKEYALGO_NOENCRYPT	= 110	/*!< no encryption */
 } pgpSymkeyAlgo;
 
@@ -199,6 +208,8 @@ typedef enum pgpSubType_e {
     PGPSUBTYPE_FEATURES		=  30, /*!< feature flags (gpg) */
     PGPSUBTYPE_EMBEDDED_SIG	=  32, /*!< embedded signature (gpg) */
     PGPSUBTYPE_ISSUER_FINGERPRINT= 33, /*!< issuer fingerprint */
+    PGPSUBTYPE_INTREC_FINGERPRINT= 35, /*!< intended recipient fingerprint */
+    PGPSUBTYPE_PFERER_AEAD	= 39,  /*!<  preferred AEAD ciphercuites */
 
     PGPSUBTYPE_INTERNAL_100	= 100, /*!< internal or user-defined */
     PGPSUBTYPE_INTERNAL_101	= 101, /*!< internal or user-defined */

--- a/rpmio/rpmpgpval.hh
+++ b/rpmio/rpmpgpval.hh
@@ -23,6 +23,7 @@ static struct pgpValTbl_s const pgpSigTypeTbl[] = {
     { PGPSIGTYPE_SUBKEY_REVOKE,	"Subkey revocation signature" },
     { PGPSIGTYPE_CERT_REVOKE,	"Certification revocation signature" },
     { PGPSIGTYPE_TIMESTAMP,	"Timestamp signature" },
+    { PGPSIGTYPE_THIRD_PARTY,	"Third-Party Confirmation signature" },
     { -1,			"Unknown signature type" },
 };
 
@@ -37,6 +38,10 @@ static struct pgpValTbl_s const pgpPubkeyTbl[] = {
     { PGPPUBKEYALGO_ELGAMAL,	"Elgamal" },
     { PGPPUBKEYALGO_DH,		"Diffie-Hellman (X9.42)" },
     { PGPPUBKEYALGO_EDDSA,	"EdDSA" },
+    { PGPPUBKEYALGO_X25519,	"X25519" },
+    { PGPPUBKEYALGO_X448,	"X448" },
+    { PGPPUBKEYALGO_ED25519,	"Ed25519" },
+    { PGPPUBKEYALGO_ED448,	"Ed448" },
     { -1,			"Unknown public key algorithm" },
 };
 
@@ -52,6 +57,9 @@ static struct pgpValTbl_s const pgpSymkeyTbl[] = {
     { PGPSYMKEYALGO_AES_192,	"AES(192-bit key)" },
     { PGPSYMKEYALGO_AES_256,	"AES(256-bit key)" },
     { PGPSYMKEYALGO_TWOFISH,	"TWOFISH(256-bit key)" },
+    { PGPSYMKEYALGO_CAMELLIA_128,"Camellia(128-bit key)" },
+    { PGPSYMKEYALGO_CAMELLIA_192,"Camellia(192-bit key)" },
+    { PGPSYMKEYALGO_CAMELLIA_256,"Camellia(256-bit key)" },
     { PGPSYMKEYALGO_NOENCRYPT,	"no encryption" },
     { -1,			"Unknown symmetric key algorithm" },
 };
@@ -75,6 +83,8 @@ static struct pgpValTbl_s const pgpHashTbl[] = {
     { PGPHASHALGO_SHA384,	"SHA384" },
     { PGPHASHALGO_SHA512,	"SHA512" },
     { PGPHASHALGO_SHA224,	"SHA224" },
+    { PGPHASHALGO_SHA3_256,	"SHA3-256" },
+    { PGPHASHALGO_SHA3_512,	"SHA3-512" },
     { -1,			"Unknown hash algorithm" },
 };
 
@@ -108,6 +118,8 @@ static struct pgpValTbl_s const pgpSubTypeTbl[] = {
     { PGPSUBTYPE_FEATURES,	"features" },
     { PGPSUBTYPE_EMBEDDED_SIG,	"embedded signature" },
     { PGPSUBTYPE_ISSUER_FINGERPRINT,"issuer fingerprint" },
+    { PGPSUBTYPE_INTREC_FINGERPRINT,"intended recipient fingerprint" },
+    { PGPSUBTYPE_PFERER_AEAD,	"preferred AEAD ciphersuites" },
 
     { PGPSUBTYPE_INTERNAL_100,	"internal subpkt type 100" },
     { PGPSUBTYPE_INTERNAL_101,	"internal subpkt type 101" },
@@ -142,6 +154,7 @@ static struct pgpValTbl_s const pgpTagTbl[] = {
     { PGPTAG_USER_ATTRIBUTE,	"User Attribute" },
     { PGPTAG_ENCRYPTED_MDC,	"Integrity protected encrypted data" },
     { PGPTAG_MDC,		"Manipulaion detection code packet" },
+    { PGPTAG_PADDING,		"Padding" },
     { PGPTAG_PRIVATE_60,	"Private #60" },
     { PGPTAG_COMMENT,		"Comment" },
     { PGPTAG_PRIVATE_62,	"Private #62" },

--- a/rpmio/rpmpgpval.hh
+++ b/rpmio/rpmpgpval.hh
@@ -139,7 +139,7 @@ static struct pgpValTbl_s const pgpTagTbl[] = {
     { PGPTAG_USER_ID,		"User ID" },
     { PGPTAG_PUBLIC_SUBKEY,	"Public Subkey" },
     { PGPTAG_COMMENT_OLD,	"Comment (from OpenPGP draft)" },
-    { PGPTAG_PHOTOID,		"PGP's photo ID" },
+    { PGPTAG_USER_ATTRIBUTE,	"User Attribute" },
     { PGPTAG_ENCRYPTED_MDC,	"Integrity protected encrypted data" },
     { PGPTAG_MDC,		"Manipulaion detection code packet" },
     { PGPTAG_PRIVATE_60,	"Private #60" },


### PR DESCRIPTION
While most of the details are handled by rpm-sequoia, rpm needs to know at least the algorithm id's. Add the other tags while at it, it's not much anyhow.

Also add the SHA3 description texts that were missing from 9344367edf654fb41a136793b68cea9abb892fb9

There's no way to test this stuff at this point though, we need to wait until sequoia-pgp 2.0 and a compatible rpm-sequoia. OTOH some implementations might need these symbols in place.

Fixes: #3631
