### PR TITLE
Add %{xdg:...} macro for evaluating XDG base directory paths

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -136,6 +136,7 @@ various common operations.
 | `%{suffix:...}`     | expand to suffix part of a file name |
 | `%{url2path:...}`   | convert url to a local path |
 | `%{uncompress:...}` | expand to a command for outputting argument file to stdout, uncompressing as needed |
+| `%{xdg:...}`        | XDG base directory for `config`, `data` or `state`a | 6.0.0
 
 ### Environment info
 

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -9,6 +9,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include <stack>
 
@@ -1314,6 +1315,28 @@ static void doRpmver(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *pars
     rpmMacroBufAppendStr(mb, VERSION);
 }
 
+const static std::unordered_map<std::string,std::pair<std::string,std::string>> xdgvars = {
+    { "config",	{ "XDG_CONFIG_HOME",	".config" } },
+    { "data",	{ "XDG_DATA_HOME",	".local/share" } },
+    { "state",	{ "XDG_STATE_HOME",	".local/state" } },
+};
+
+static void doXdg(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
+{
+    auto res = xdgvars.find(argv[1]);
+    if (res == xdgvars.end()) {
+	rpmMacroBufErr(mb, 1, "%s: invalid argument: %s\n", argv[0], argv[1]);
+	return;
+    }
+    auto const & vars = res->second;
+    auto mctx = rpm::macros();
+    auto [ rc, xenv ] = mctx.expand({"%{getenv:", vars.first, "}"});
+    if (rc || xenv.empty())
+	xenv = mctx.expand({"%{getenv:HOME}/", vars.second}).second;
+
+    rpmMacroBufAppendStr(mb, xenv.c_str());
+}
+
 static struct builtins_s {
     const char * name;
     macroFunc func;
@@ -1358,6 +1381,7 @@ static struct builtins_s {
     { "url2path",	doFoo,		1,	0 },
     { "verbose",	doVerbose,	-1,	ME_PARSE },
     { "warn",		doOutput,	1,	0 },
+    { "xdg",		doXdg,		1,	0 },
     { NULL,		NULL,		0 }
 };
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -533,6 +533,39 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP([xdg macro])
+AT_KEYWORDS([macros])
+RPMTEST_CHECK([
+rpm \
+    --eval "%{xdg:config}" \
+    --eval "%{xdg:data}" \
+    --eval "%{xdg:state}"
+],
+[0],
+[/root/.config
+/root/.local/share
+/root/.local/state
+],
+[])
+
+RPMTEST_CHECK([
+XDG_CONFIG_HOME=/some/where
+XDG_DATA_HOME=/other/place
+XDG_STATE_HOME=/other/state
+export XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME
+rpm \
+    --eval "%{xdg:config}" \
+    --eval "%{xdg:data}" \
+    --eval "%{xdg:state}"
+],
+[0],
+[/some/where
+/other/place
+/other/state
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP([macrobody macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([


### PR DESCRIPTION
We need to manage XDG paths in our base path anyhow, and presumably more XDG related needs are coming, so why not...