### PR TITLE
Add new "%{trim: ...}" string operation

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -124,7 +124,8 @@ various common operations.
 | `%{sub:...}`     | expand to substring (see Lua `string.sub()`) | 4.19.0
 | `%{upper:...}`   | uppercase a string | 4.19.0
 | `%{shescape:...}`| single quote with escapes for use in shell | 4.18.0
-| `%{shrink:...}`  | trim leading and trailing whitespace, reduce intermediate whitespace to a single space | 4.14.0
+| `%{shrink:...}`  | delete newline symbols, trim leading and trailing whitespace, and reduce intermediate whitespace to a single space | 4.14.0
+| `%{trim:...}`    | keep newline symbols, trim leading and trailing whitespace in each line |
 
 ### File and path operations
 

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -1239,6 +1239,31 @@ static char *doShrink(const char *arg)
     return buf;
 }
 
+/*
+ * Trim the body by removing all leading and trailing
+ * whitespaces on every line
+ */
+static char *doTrim(const char *arg)
+{
+    char *b, *p, *i, c, iter_c;
+    char *buf = b = p = xstrdup(arg);
+    int was_newline = 1;
+    int will_newline = 0;
+    while ((c = *p++) != 0) {
+        if(risblank(c) && (was_newline || will_newline))
+            continue;
+        was_newline = iseol(c);
+        i = p;
+
+        while ((iter_c = *i++) != 0 && risblank(iter_c));
+        will_newline = iseol(iter_c) || (iter_c == 0);
+
+        *b++ = c;
+    }
+    *b = 0;
+    return buf;
+}
+
 static void doFoo(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 {
     char *buf = NULL;
@@ -1252,6 +1277,8 @@ static void doFoo(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 	b = dirname(buf);
     } else if (rstreq("shrink", me->name)) {
 	b = buf = doShrink(argv[1]);
+    } else if (rstreq("trim", me->name)) {
+        b = buf = doTrim(argv[1]);
     } else if (rstreq("quote", me->name)) {
 	if (mb->flags & RPMEXPAND_KEEP_QUOTED) {
 	    b = buf = unsplitQuoted(argv + 1, " ");
@@ -1348,6 +1375,7 @@ static struct builtins_s {
     { "sub",		doString,	1,	0 },
     { "suffix",		doFoo,		1,	0 },
     { "trace",		doTrace,	0,	0 },
+    { "trim",		doFoo,		1,	0 },
     { "u2p",		doFoo,		1,	0 },
     { "shescape",	doShescape,	1,	0 },
     { "uncompress",	doUncompress,	1,	0 },

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -486,6 +486,23 @@ rpm \
 ])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP([trim macro])
+AT_KEYWORDS([macros])
+RPMTEST_CHECK([
+rpm \
+    --eval "%{trim: 
+    h e 
+  l  
+    l   o  }"
+],
+[0],
+[
+h e
+l
+l   o
+])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP([suffix macro])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
@@ -573,6 +590,9 @@ rpm --eval "%{dump:foo}"
 rpm --eval "%{shrink:%%%%}"
 rpm --eval "%{shrink %%%%}"
 rpm --eval "%shrink %%%%"
+rpm --eval "%{trim:%%%%}"
+rpm --eval "%{trim %%%%}"
+rpm --eval "%trim %%%%"
 rpm --eval "%verbose foo"
 ],
 [0],
@@ -598,6 +618,9 @@ foobar
 
 bar
 bar baz\baz
+%%
+%%
+%%
 %%
 %%
 %%


### PR DESCRIPTION
It trims the body by removing all leading and trailing whitespaces from each line of the string

The new operation can be useful for writing human-readable, multi-line macros. For example, the macros from [ghc-rpm-macros-extra](https://src.fedoraproject.org/rpms/ghc-rpm-macros/blob/rawhide/f/macros.ghc-extra) can be rewritten as follows.

From
<details><summary>Before</summary>

```
%ghc_lib_subpackage(c:dl:mx)\
%define pkgname %{?2:%{1}}%{!?2:%{lua:\
local pv = rpm.expand("%1")\
local _, _, name = string.find(pv, "^([%a%d-]+)-")\
print(name)\
}}\
%define pkgver %{?2}%{!?2:%{lua:\
local pv = rpm.expand("%1")\
print(string.sub(pv, string.find(pv, "[%d.]+$")))\
}}\
%global ghc_subpackages_list %{?ghc_subpackages_list} %{pkgname}-%{pkgver}\
%{!-x:%{?1:%global ghc_packages_list %{?ghc_packages_list} %{pkgname}-%{pkgver}}}\
%define basepkg %{ghc_prefix}-%{pkgname}\
%if 0%{!-m:1}\
%package -n %{basepkg}\
Summary:        Haskell %{pkgname} library\
%{?1:Version:        %{pkgver}}\
%{-l:License:        %{-l*}}\
Url:            https://hackage.haskell.org/package/%{pkgname}\
%{?ghc_pkg_obsoletes:Obsoletes:      %(echo "%{ghc_pkg_obsoletes}" | sed -e "s/\\(%{ghc_prefix}-[^, ]*\\)-devel/\\1/g")}\
%{?ghc_obsoletes_name:Obsoletes:        %{ghc_obsoletes_name}-%{pkgname} < %{pkgver}-%{release}}\
\
%description -n %{basepkg}\
This package provides the Haskell %{pkgname} library.\
\
%endif\
%package -n %{basepkg}-devel\
Summary:        Haskell %{pkgname} library development files\
%{?1:Version:        %{pkgver}}\
%{-l:License:        %{-l*}}\
Provides:       %{basepkg}-static = %{pkgver}-%{release}\
Provides:       %{basepkg}-static%{?_isa} = %{pkgver}-%{release}\
Requires:       %{ghc_prefix}-compiler = %{ghc_version}%{?ghc_version_override:-%{release}}\
%if 0%{!-m:1}\
Requires:       %{ghc_prefix}-%{pkgname}%{?_isa} = %{pkgver}-%{release}\
%endif\
%{?ghc_pkg_c_deps:Requires:       %{ghc_pkg_c_deps}}\
%{-c:Requires:       %{-c*}}\
%{?ghc_obsoletes_name:Obsoletes:        %{ghc_obsoletes_name}-%{pkgname}-devel < %{pkgver}-%{release}}\
%{?ghc_pkg_obsoletes:Obsoletes:      %{ghc_pkg_obsoletes}}\
\
%description -n %{basepkg}-devel\
This package provides the Haskell %{pkgname} library development files.\
\
%if 0%{!-m:1}\
%if %{with haddock}\
%package -n %{basepkg}-doc\
Summary:        Haskell %{pkgname} library documentation\
%{?1:Version:        %{pkgver}}\
%{-l:License:        %{-l*}}\
BuildArch:      noarch\
Requires:       %{ghc_prefix}-filesystem\
%{?ghc_obsoletes_name:Obsoletes:        %{ghc_obsoletes_name}-%{pkgname}-doc < %{pkgver}-%{release}}\
Supplements:    (%{basepkg}-devel and %{ghc_prefix}-doc)\
\
%description -n %{basepkg}-doc\
This package provides the Haskell %{pkgname} library documentation.\
%endif\
\
%if %{with ghc_prof}\
%package -n %{basepkg}-prof\
Summary:        Haskell %{pkgname} profiling library\
%{?1:Version:        %{pkgver}}\
%{-l:License:        %{-l*}}\
Requires:       %{ghc_prefix}-%{pkgname}-devel%{?_isa} = %{pkgver}-%{release}\
%{?ghc_obsoletes_name:Obsoletes:        %{ghc_obsoletes_name}-%{pkgname}-prof < %{pkgver}-%{release}}\
Supplements:    (%{basepkg}-devel and %{ghc_prefix}-prof)\
\
%description -n %{basepkg}-prof\
This package provides the Haskell %{pkgname} profiling library.\
%endif\
\
%files -n %{basepkg} -f %{!-d:%{pkgname}-%{pkgver}/}%{basepkg}.files\
\
%endif\
%files -n %{basepkg}-devel -f %{!-d:%{pkgname}-%{pkgver}/}%{basepkg}-devel.files\
%if 0%{!-m:1}\
\
%if %{with haddock}\
%files -n %{basepkg}-doc -f %{!-d:%{pkgname}-%{pkgver}/}%{basepkg}-doc.files\
%endif\
\
%if %{with ghc_prof}\
%files -n %{basepkg}-prof -f %{!-d:%{pkgname}-%{pkgver}/}%{basepkg}-prof.files\
%endif\
%endif\
%{nil}
```

</details> 

To

<details>
  <summary>After</summary>
  
```
%ghc_lib_subpackage(c:dl:mx) %{trim:
    %define pkgname %{?2:%{1}}%{!?2:%{lua:
        local pv = rpm.expand("%1")
        local _, _, name = string.find(pv, "^([%a%d-]+)-")
        print(name)
    }}

    %define pkgver %{?2}%{!?2:%{lua:
        local pv = rpm.expand("%1")
        print(string.sub(pv, string.find(pv, "[%d.]+$")))
    }}

    %global ghc_subpackages_list %{?ghc_subpackages_list} %{pkgname}-%{pkgver}
    %{!-x:%{?1:%global ghc_packages_list %{?ghc_packages_list} %{pkgname}-%{pkgver}}}
    %define basepkg %{ghc_prefix}-%{pkgname}

    %if 0%{!-m:1}
        %package -n %{basepkg}
        Summary:        Haskell %{pkgname} library
        %{?1:Version:        %{pkgver}}
        %{-l:License:        %{-l*}}
        Url:            https://hackage.haskell.org/package/%{pkgname}
        %{?ghc_pkg_obsoletes:Obsoletes:      %(echo "%{ghc_pkg_obsoletes}" | sed -e "s/\\(%{ghc_prefix}-[^, ]*\\)-devel/\\1/g")}
        %{?ghc_obsoletes_name:Obsoletes:        %{ghc_obsoletes_name}-%{pkgname} < %{pkgver}-%{release}}

        %description -n %{basepkg}
        This package provides the Haskell %{pkgname} library.

    %endif
    %package -n %{basepkg}-devel

    Summary:        Haskell %{pkgname} library development files

    %{?1:Version:        %{pkgver}}
    %{-l:License:        %{-l*}}

    Provides:       %{basepkg}-static = %{pkgver}-%{release}
    Provides:       %{basepkg}-static%{?_isa} = %{pkgver}-%{release}
    Requires:       %{ghc_prefix}-compiler = %{ghc_version}%{?ghc_version_override:-%{release}}

    %if 0%{!-m:1}
        Requires:       %{ghc_prefix}-%{pkgname}%{?_isa} = %{pkgver}-%{release}
    %endif

    %{?ghc_pkg_c_deps:Requires:       %{ghc_pkg_c_deps}}
    %{-c:Requires:       %{-c*}}
    %{?ghc_obsoletes_name:Obsoletes:        %{ghc_obsoletes_name}-%{pkgname}-devel < %{pkgver}-%{release}}
    %{?ghc_pkg_obsoletes:Obsoletes:      %{ghc_pkg_obsoletes}}

    %description -n %{basepkg}-devel
    This package provides the Haskell %{pkgname} library development files.

    %if 0%{!-m:1}
        %if %{with haddock}\
            %package -n %{basepkg}-doc
            Summary:        Haskell %{pkgname} library documentation
            %{?1:Version:        %{pkgver}}
            %{-l:License:        %{-l*}}
            BuildArch:      noarch

            Requires:       %{ghc_prefix}-filesystem
            %{?ghc_obsoletes_name:Obsoletes:        %{ghc_obsoletes_name}-%{pkgname}-doc < %{pkgver}-%{release}}
            Supplements:    (%{basepkg}-devel and %{ghc_prefix}-doc)

            %description -n %{basepkg}-doc
            This package provides the Haskell %{pkgname} library documentation.
        %endif

        %if %{with ghc_prof}
            %package -n %{basepkg}-prof
            Summary:        Haskell %{pkgname} profiling library

            %{?1:Version:        %{pkgver}}
            %{-l:License:        %{-l*}}

            Requires:       %{ghc_prefix}-%{pkgname}-devel%{?_isa} = %{pkgver}-%{release}
            %{?ghc_obsoletes_name:Obsoletes:        %{ghc_obsoletes_name}-%{pkgname}-prof < %{pkgver}-%{release}}
            Supplements:    (%{basepkg}-devel and %{ghc_prefix}-prof)

            %description -n %{basepkg}-prof
            This package provides the Haskell %{pkgname} profiling library.
        %endif

        %files -n %{basepkg} -f %{!-d:%{pkgname}-%{pkgver}/}%{basepkg}.files

    %endif

    %files -n %{basepkg}-devel -f %{!-d:%{pkgname}-%{pkgver}/}%{basepkg}-devel.files
    %if 0%{!-m:1}
        %if %{with haddock}
            %files -n %{basepkg}-doc -f %{!-d:%{pkgname}-%{pkgver}/}%{basepkg}-doc.files
        %endif

        %if %{with ghc_prof}
            %files -n %{basepkg}-prof -f %{!-d:%{pkgname}-%{pkgver}/}%{basepkg}-prof.files
        %endif
    %endif
}
```
  
</details>

This macro serves as an example of something quite large and complex, which is not immediately easy to read or understand. Logical indentation and flexible line breaks greatly enhance the readability. 

We can't use the %{expand: ...} construct here because, the %package directives won't be processed correctly (leading spaces matter in their context).
