### PR TITLE
Add an easy autosigning setup script

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -2,7 +2,7 @@ set(core
 	gendiff.1 rpm2cpio.1 rpm2archive.1
 	rpm.8 rpmbuild.1 rpmdb.8 rpmkeys.8 rpmsign.1 rpmspec.1
 	rpmdeps.1 rpmgraph.1 rpmlua.1 rpm-common.8 rpmsort.1
-	rpm-macrofile.5
+	rpm-macrofile.5 rpm-setup-autosign.1
 )
 set(extra
 	rpm-plugins.8 rpm-plugin-prioreset.8 rpm-plugin-syslog.8

--- a/docs/man/rpm-setup-autosign.1.scd
+++ b/docs/man/rpm-setup-autosign.1.scd
@@ -1,0 +1,45 @@
+RPM-SETUP-AUTOSIGN(1)
+
+# NAME
+*rpm-setup-autosign* - Set up automatic signing for rpmbuild
+
+# SYNOPSIS
+*rpm-setup-autosign* [options]
+
+# DESCRIPTION
+*rpm-setup-autosign* is used to set up automatic signing from *rpmbuild*(1).
+It generates a user- and host-specific, passwordless OpenPGP key,
+configures *rpmbuild*(1) to use that key and exports the public key
+(aka certificate) for importing to the persistent *rpm*(8) keyring.
+
+The purpose of automatic signing is to make testing local builds
+painless. For distributing packages, it's recommended to use a separate
+signing account that cannot be compromised by a build.
+
+# OPTIONS
+*-p* <*gpg*|*sq*>,
+*--prog* <*gpg*|*sq*>
+	Specify the signing program to use: GnuPG or Sequoia PGP's sq.
+
+# CONFIGURATION
+On successful completion, one or more of the following macros will be
+configured in the user's macro configuration file.
+See *rpm-config*(5) for details:
+- *%\_openpgp_autosign_id*
+- *%\_openpgp_sign*
+
+# EXIT STATUS
+On success, 0 is returned, a non-zero failure code otherwise.
+
+# FILES
+_~/.config/rpm/rpmbuild-\*.asc_
+_~/.config/rpm/macros_
+
+# EXAMPLES
+*/usr/lib/rpm/rpm-setup-autosign -p sq*
+	Set up *rpmbuild*(1) autosigning using Sequoia-sq.
+
+# SEE ALSO
+*rpm*(8) *rpmsign*(1) *rpmbuild*(1)
+
+*http://www.rpm.org/*

--- a/docs/man/rpmbuild.1.scd
+++ b/docs/man/rpmbuild.1.scd
@@ -201,7 +201,8 @@ See *rpm-common*(8)
 # SEE ALSO
 
 *gendiff*(1), *popt*(3), *rpm*(8), *rpm-common*(8),
-*rpm2cpio*(1), *rpmkeys*(8), *rpmspec*(1), *rpmsign*(1)
+*rpm2cpio*(1), *rpmkeys*(8), *rpmspec*(1), *rpmsign*(1),
+*rpm-setup-autosign*(1)
 
 *rpmbuild --help* - as rpm supports customizing the options via popt
 aliases it's impossible to guarantee that what's described in the

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -11,7 +11,7 @@ install(PROGRAMS
 	rpm_macros_provides.sh
 	rpmdb_dump rpmdb_load
 	rpm2cpio.sh tgpg
-	sysusers.sh
+	sysusers.sh rpm-setup-autosign
 	DESTINATION ${RPM_CONFIGDIR}
 )
 install(FILES

--- a/scripts/rpm-setup-autosign
+++ b/scripts/rpm-setup-autosign
@@ -1,0 +1,139 @@
+#!/bin/bash -e
+
+rpmhome=$(rpm --eval "%{xdg:config}/rpm")
+macros="macros"
+# if oldstyle config exists, then use that instead
+if [[ ! -d "${rpmhome}" && ( -f ~/.rpmmacros || -f ~/.rpmrc) ]]; then
+    rpmhome="${HOME}"
+    macros=".rpmmacros"
+fi
+mkdir -p "${rpmhome}"
+
+email="rpmbuild-${USER}@$(uname -n)"
+keypath="${rpmhome}/${email}.asc"
+
+function log()
+{
+    echo -e $* 1>&2
+}
+
+function error()
+{
+    log $*
+    exit 1
+}
+
+function progpath()
+{
+    which ${1} 2> /dev/null
+}
+
+function setup_autosign()
+{
+    log "Setting up ${1} autosigning in ${rpmhome}/${macros}"
+    echo "# Added by rpm-setup-autosign" >> ${rpmhome}/${macros}
+    echo "%_openpgp_sign ${1}" >> ${rpmhome}/${macros}
+    echo "%_openpgp_autosign_id ${2}" >> ${rpmhome}/${macros}
+}
+
+function genkey_sq()
+{
+    log "Generating key ${email}"
+    local keyfp=$(sq key generate \
+                     --batch \
+                     --quiet \
+                     --own-key \
+                     --without-password \
+                     --can-sign \
+                     --cannot-authenticate \
+                     --cannot-encrypt \
+                     --email "${email}" \
+                   2>&1 | awk '/Fingerprint/{print $2}')
+
+    log "Exporting public key (certificate) to ${keypath}"
+    sq cert export --cert "${keyfp}" > ${keypath}
+
+    setup_autosign sq ${keyfp}
+}
+
+function genkey_gpg()
+{
+    log "Generating key ${email}"
+    gpg \
+        --batch \
+        --quiet \
+        --passphrase "" \
+        --quick-generate-key "<${email}>" \
+        "default" "sign"
+
+    log "Exporting public key (certificate) to ${keypath}"
+    gpg --export --armor "${email}" > ${keypath}
+
+    setup_autosign gpg "${email}"
+}
+
+if [ -z "${USER}" ]; then
+    error "USER environment variable not set"
+fi
+
+if [ -f "${keypath}" ]; then
+    error "File ${keypath} already exists, script already run?"
+fi
+
+autosign=$(rpm --eval "%{?_openpgp_autosign_id}")
+if [ -n "${autosign}" ]; then
+    log "Autosign already configured"
+    exit 0
+fi
+
+# is there an explicit signing program configured?
+prog=$(rpm --eval "%{?_openpgp_sign}")
+if [ -z "${prog}" ]; then
+    # is there a legacy signing setup, indicating gpg?
+    gpgname=$(rpm --eval "%{?_gpg_name}")
+    if [ -n "${gpgname}" ]; then
+        prog="gpg"
+    fi
+fi
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -p|--prog)
+        prog="${2}"
+        shift
+        ;;
+    *)
+        error "Unknown argument: ${1}"
+        ;;
+    esac
+    shift
+done
+
+# if still not known, try to autodetect by presence
+if [ -z "${prog}" ]; then
+    for p in sq gpg; do
+        if [ -n "$(progpath ${p})" ]; then
+            prog="${p}"
+            break
+        fi
+    done
+fi
+
+case $prog in
+gpg)
+    genkey_gpg
+    ;;
+sq)
+    genkey_sq
+    ;;
+*)
+    if [ -z "${prog}" ]; then
+        error "No signing program found, install sequoia-sq or gnupg"
+    else
+        error "Unknown signing program: ${prog}"
+    fi
+    ;;
+esac
+
+log "To import this public key (certificate), run:"
+log "\tsudo rpmkeys --import ${keypath}"

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -90,6 +90,7 @@ snapshot()
             bwrap --unshare-pid --dev-bind $RPMTEST / --clearenv \
                   --setenv PATH $(env -i sh -c 'echo $PATH') \
                   --setenv HOME /root \
+                  --setenv USER root \
                   --setenv GPG_TTY "" \
                   --chdir / --dev /dev --proc /proc --die-with-parent "$@"
         ;;

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1513,7 +1513,7 @@ RPMTEST_CHECK([
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser u myuser 876 - /home/myuser /bin/sh}"\
   /data/SPECS/deptest.spec
-runroot rpmkeys --import --root /alt /root/rpm-key.asc
+runroot rpmkeys --import --root /alt /root/.config/rpm/*.asc
 runroot rpm -U --root /alt /build/RPMS/noarch/deptest-user-1.0-1.noarch.rpm 2> /dev/null
 runroot tail -1 /alt/etc/passwd
 runroot rpm -V --root /alt ${VERIFYOPTS} deptest-user

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2004,7 +2004,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([keyring rebuild rpmdb])
 AT_KEYWORDS([rpmkeys signature])
-RPMTEST_INIT
 
 runroot rpmkeys \
         --define "_keyring rpmdb" \
@@ -2062,7 +2061,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([keyring rebuild fs])
 AT_KEYWORDS([rpmkeys signature])
-RPMTEST_INIT
 
 runroot rpmkeys \
         --define "_keyring rpmdb" \
@@ -2136,7 +2134,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([keyring rebuild openpgp])
 AT_KEYWORDS([rpmkeys signature])
-RPMTEST_INIT
 
 runroot rpmkeys \
         --define "_keyring rpmdb" \

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2153,8 +2153,8 @@ runroot rpmkeys --define "_keyring openpgp" --list | cut -c43-55
 runroot rpmkeys --define "_keyring fs" --list
 ]],
 [0],
-[rpmbuild-user
-rpmbuild-user
+[rpmbuild-root
+rpmbuild-root
 ],
 [])
 
@@ -2194,4 +2194,48 @@ runroot rpmkeys --define "_keyring openpgp" -Kv /data/RPMS/hello-2.0-1.x86_64-si
     Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
 ],
 [ignore])
+RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([autosign setup])
+AT_KEYWORDS([autosign signature])
+
+rpmconf=$(rpm --eval "%{_rpmconfigdir}")
+
+RPMTEST_CHECK([
+runroot ${RPM_CONFIGDIR_PATH}/rpm-setup-autosign
+],
+[0],
+[],
+[Autosign already configured
+])
+
+RPMTEST_CHECK([
+runroot rm -rf /root/.config/rpm
+runroot ${RPM_CONFIGDIR_PATH}/rpm-setup-autosign -p gpg
+],
+[0],
+[],
+[stderr])
+
+RPMTEST_CHECK([[
+cmd=$(grep "^[[:space:]]sudo" stderr | cut -c6-)
+test -n "${cmd}" && runroot ${cmd}
+]],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet /data/SPECS/vattrtest.spec
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/vattrtest-1.0-1.noarch.rpm
+],
+[0],
+[],
+[])
 RPMTEST_CLEANUP

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -320,7 +320,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [])
 
 RPMTEST_CHECK([[
-runroot sq --cert-store=${krpath} cert list --gossip 2>&1 | grep -e "^ - [[:xdigit:]]\{40\}" | cut -c4-
+runroot sq --home=none --cert-store=${krpath} cert list --gossip 2>&1 | grep -e "^ - [[:xdigit:]]\{40\}" | cut -c4-
 ]],
 [0],
 [771B18D3D7BAA28734333C424344591E1964C5FC
@@ -1448,7 +1448,7 @@ AT_KEYWORDS([rpmsign sequoia signature])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 
 RPMTEST_CHECK([
-cat << EOF >> ${HOME}/.config/rpm/macros
+cat << EOF > ${HOME}/.config/rpm/macros
 %_openpgp_sign sq
 %_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
 %_sq_path ${HOME}/.config/rpm/sq
@@ -1512,7 +1512,7 @@ AT_KEYWORDS([rpmsign signature multisig v4])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 
 RPMTEST_CHECK([
-cat << EOF >> ${HOME}/.config/rpm/macros
+cat << EOF > ${HOME}/.config/rpm/macros
 %_openpgp_sign sq
 %_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
 EOF
@@ -1626,9 +1626,10 @@ AT_KEYWORDS([rpmsign signature multisig v6])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
 
 RPMTEST_CHECK([
-cat << EOF >> ${HOME}/.config/rpm/macros
+cat << EOF > ${HOME}/.config/rpm/macros
 %_openpgp_sign sq
 %_openpgp_sign_id 771B18D3D7BAA28734333C424344591E1964C5FC
+%_openpgp_autosign_id %{_openpgp_sign_id}
 EOF
 
 runroot sq key import /data/keys/*.secret


### PR DESCRIPTION
See commits for details, but short summary: split autosigning setup from our test-suite setup into a standalone script that generates a passwordless key, configures rpmbuild to use it for autosigning, exports the pubkey and emits a command to import it to rpm keystore.

I fully expect there to be corner cases this doesn't correctly handle yet, we just need to have a script that works for the majority of users for the alpha.

Fixes: #3522