### PR TITLE
rpmkeys(8): Correct a typo in _keyringpath macro name

### DIFF
--- a/docs/man/rpmkeys.8.scd
+++ b/docs/man/rpmkeys.8.scd
@@ -101,7 +101,7 @@ See *rpm.common*(8) for the options common to all *rpm* executables.
 There are several configurables affecting the behavior of this
 verification, see *rpm.config*(5) for details:
 - *%\_keyring*
-- *%\_keyring_path*
+- *%\_keyringpath*
 - *%\_pkgverify_flags*
 - *%\_pkgverify_level*
 


### PR DESCRIPTION
"_keyring_path" was found only in this manual. All over the code was "_keyringpath". Wrong is this manual, I conlude. This patch corrects the manual.