### PR TITLE
Make %_passwd_path and %_group_path lists

### DIFF
--- a/lib/rpmug.cc
+++ b/lib/rpmug.cc
@@ -54,7 +54,7 @@ static const char *grpfile(void)
  * Lookup an arbitrary field based on contents of another in a ':' delimited
  * file, such as /etc/passwd or /etc/group.
  */
-static int lookup_field(const char *path, const char *val, int vcol, int rcol,
+static int lookup_field_in_file(const char *path, const char *val, int vcol, int rcol,
 			char **ret)
 {
     int rc = -1; /* assume not found */
@@ -89,6 +89,25 @@ static int lookup_field(const char *path, const char *val, int vcol, int rcol,
 
     fclose(f);
 
+    return rc;
+}
+
+/*
+ * Lookup an arbitrary field based on contents of another in a ':' delimited
+ * file, such as /etc/passwd or /etc/group. Look at multiple files listed in
+ * path separated by colons
+ */
+static int lookup_field(const char *path, const char *val, int vcol, int rcol,
+			char **ret)
+{
+    ARGV_t paths = argvSplitString(path, ":", ARGV_SKIPEMPTY);
+    int rc = -1;
+    for (ARGV_t p = paths; *p; p++) {
+	rc = lookup_field_in_file(*p, val, vcol, rcol, ret);
+	if (!rc)
+	    break;
+    }
+    argvFree(paths);
     return rc;
 }
 

--- a/macros.in
+++ b/macros.in
@@ -133,7 +133,7 @@
 
 %_keyringpath		%{_dbpath}/pubkeys/
 
-# Location of passwd(5) and group(5)
+# Location of passwd(5) and group(5), as : separated list
 %_passwd_path		/etc/passwd
 %_group_path		/etc/group
 

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -625,3 +625,20 @@ runroot rpm -Vv ${VERIFYOPTS} verifyfiles
 ],
 [])
 RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([alternative passwd location])
+AT_KEYWORDS([verify])
+
+runroot rpmbuild -bb --quiet /data/SPECS/klang.spec
+runroot rpm -Uvh /build/RPMS/noarch/klang-*
+echo "klangd:x:1111:1111::/:/sbin/nologin\n" >> ${RPMTEST}/usr/lib/passwd
+echo "klangd:x:8888:" >> ${RPMTEST}/usr/lib/group
+
+RPMTEST_CHECK([
+runroot chown 1111:8888 /var/lib/klangd
+runroot rpm -D "_passwd_path /usr/lib/passwd:/etc/passwd" -D "_group_path /usr/lib/group:/etc/group" -V klang-server
+],
+[0],
+[],
+[])
+RPMTEST_CLEANUP


### PR DESCRIPTION
Look up multiple files if they are listes in the macros separated by colons. This way multiple sources of user and group information can be used.

This is needed as RPM no longer honors nsswitch as it fails for chroots. This way one can at least configure where RPM should look for user/group information.

Related: https://issues.redhat.com/browse/RHEL-78693