### PR TITLE
Fix check_c_compiler_flag cmake tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,7 @@ foreach (flag -fno-strict-overflow -fno-delete-null-pointer-checks -fhardened)
 	if (found)
 		add_compile_options(${flag})
 	endif()
-	unset(found)
+	unset(found CACHE)
 endforeach()
 
 # generated sources


### PR DESCRIPTION
Check_c_compiler_flag sets a cache variable, so CACHE needs to be passed
in order to reset it for the next use.
