### PR TITLE
Introduce %{span:...} macro for multiline macro sanity

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -121,6 +121,7 @@ various common operations.
 | `%{lower:...}`   | lowercase a string | 4.19.0
 | `%{rep:...}`     | repeat a string (see Lua `string.rep()`) | 4.19.0
 | `%{reverse:...}` | reverse a string | 4.19.0
+| `%{span:...}`    | as-is string, handy for wrapping multiline macros | 6.0.0
 | `%{sub:...}`     | expand to substring (see Lua `string.sub()`) | 4.19.0
 | `%{upper:...}`   | uppercase a string | 4.19.0
 | `%{shescape:...}`| single quote with escapes for use in shell | 4.18.0

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -1315,6 +1315,11 @@ static void doRpmver(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *pars
     rpmMacroBufAppendStr(mb, VERSION);
 }
 
+static void doSpan(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
+{
+    rpmMacroBufAppendStr(mb, argv[1]);
+}
+
 const static std::unordered_map<std::string,std::pair<std::string,std::string>> xdgvars = {
     { "cache",	{ "XDG_CACHE_HOME",	".cache" } },
     { "config",	{ "XDG_CONFIG_HOME",	".config" } },
@@ -1371,6 +1376,7 @@ static struct builtins_s {
     { "reverse",	doString,	1,	0 },
     { "rpmversion",	doRpmver,	0,	0 },
     { "shrink",		doFoo,		1,	0 },
+    { "span",		doSpan,		1,	0 },
     { "sub",		doString,	1,	0 },
     { "suffix",		doFoo,		1,	0 },
     { "trace",		doTrace,	0,	0 },

--- a/tests/data/macros.testfile
+++ b/tests/data/macros.testfile
@@ -27,3 +27,13 @@ read
 %dnl expansion depends on the braces inside %dnl line
 %dnl e.g. '}' change this meaning
 me}
+
+%multi1 %{span:
+  aa
+
+bb
+  cc
+dd
+
+   eee
+}

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1514,6 +1514,27 @@ thing
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP([span macro])
+AT_KEYWORDS([macros])
+RPMTEST_CHECK([
+rpm \
+	--macros /data/macros.testfile \
+	--eval "%{multi1}"
+],
+[0],
+[
+  aa
+
+bb
+  cc
+dd
+
+   eee
+
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP([macro traceback])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([


### PR DESCRIPTION
The sole purpose of the block macro is to make defining multiline macros nicer with the function-line %{} block syntax. A multiline %{expand:...} is commonly abused for this purpose but it has side-effects.

Lets add one that doesn't: %{block:...} does exactly nothing but insert the macro body as-is, without having to resort to ugly \-line continuations.