### PR TITLE
Minimally fix C++ one definition rule violation in the rpmdb backends

### DIFF
--- a/lib/backend/dbi.hh
+++ b/lib/backend/dbi.hh
@@ -27,6 +27,9 @@ typedef enum dbCtrlOp_e {
     DB_CTRL_INDEXSYNC		= 5
 } dbCtrlOp;
 
+struct dbiCursor_s {
+};
+
 typedef struct dbiIndex_s * dbiIndex;
 typedef struct dbiCursor_s * dbiCursor;
 

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -83,7 +83,8 @@ RPMTEST_CHECK([
 # XXX FIXME: should not use system rpmdb for anything, but there's a
 # mystery failure here if pointed to /data/misc which should be equally
 # read-only at this point.
-rpmdb --exportdb --dbpath /usr/lib/sysimage/rpm > rdonly.list
+rpmdb --define "_db_backend sqlite" \
+	--exportdb --dbpath /usr/lib/sysimage/rpm > rdonly.list
 test -s rdonly.list
 ],
 [0],
@@ -677,6 +678,10 @@ RPMTEST_CLEANUP
 # ------------------------------
 RPMTEST_SETUP_RW([rpmdb vacuum])
 AT_KEYWORDS([install rpmdb sqlite])
+# this is only relevant with sqlite db, make sure we get one
+echo "%_db_backend sqlite" >> $RPMTEST/root/.config/rpm/macros
+RPMDB_RESET
+
 RPMTEST_CHECK([
 runroot rpm -U --noscripts --nodeps --ignorearch --noverify --nosignature \
   /data/RPMS/hello-1.0-1.i386.rpm

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -153,6 +153,7 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmkeys migrate from keyid to fingerprint (rpmdb)])
 AT_KEYWORDS([rpmkeys rpmdb])
+echo "%_db_backend sqlite" >> $RPMTEST/root/.config/rpm/macros
 RPMTEST_CHECK([
 echo "%_keyring rpmdb" >> "${RPMTEST}"/"${RPMSYSCONFDIR}"/macros.testenv
 runroot rpm -q --dbpath /data/misc/ gpg-pubkey


### PR DESCRIPTION
Eliminates the remaining warnings when compiling with something like "-O2 -flto=auto" as CXXFLAGS.

This is not pretty C++, just seems the least disruptive way to remove the violation in time for the alpha. The rpmdb layer needs a much bigger overhaul to make it resemble something like C++

Technically bdb_ro.cc didn't require this as it was using explicit C-style casts to its own cursor struct, but might as well change update it as well.

No intended functional changes in any of this, and the test-suite passes with both sqlite and ndb (latter tested locally).

Fixes: #3692