### PR TITLE
Add missing manual pages to cmake list

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -26,14 +26,18 @@ set(manuals
 	manual/autosetup.md
 	manual/boolean_dependencies.md
 	manual/buildprocess.md
+	manual/buildsystem.md
 	manual/conditionalbuilds.md
 	manual/dependencies.md
 	manual/dependency_generators.md
 	manual/devel_documentation.md
 	manual/dynamic_specs.md
 	manual/file_triggers.md
+	manual/format_header.md
+	manual/format_lead.md
 	manual/format_v3.md
 	manual/format_v4.md
+	manual/format_v6.md
 	manual/index.md
 	manual/large_files.md
 	manual/lua.md
@@ -49,6 +53,7 @@ set(manuals
 	manual/tags.md
 	manual/triggers.md
 	manual/tsort.md
+	manual/users_and_groups.md
 )
 install(FILES ${manuals} TYPE DOC)
 


### PR DESCRIPTION
Commit fc7d9d95561a57ed836ace9d526760ed137efb10 started using the static cmake list of manual (.md) pages which, unsurprisingly, had been missing some later additions, causing them to not be rendered on the website at all, so add them.

Despite installing the manuals on "make install", we actually use a %doc entry that copies them from the source tree in Fedora's rpm.spec, so no wonder this was overlooked.