### PR TITLE
Add man pages to explain rpm runtime macro configuration

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -2,7 +2,7 @@ set(core
 	gendiff.1 rpm2cpio.1 rpm2archive.1
 	rpm.8 rpmbuild.1 rpmdb.8 rpmkeys.8 rpmsign.1 rpmspec.1
 	rpmdeps.1 rpmgraph.1 rpmlua.1 rpm-common.8 rpmsort.1
-	rpm-macrofile.5 rpm-setup-autosign.1
+	rpm-macrofile.5 rpm-config.5 rpm-rpmrc.5 rpm-setup-autosign.1
 )
 set(extra
 	rpm-plugins.8 rpm-plugin-prioreset.8 rpm-plugin-syslog.8

--- a/docs/man/rpm-common.8.scd
+++ b/docs/man/rpm-common.8.scd
@@ -157,53 +157,6 @@ On success, 0 is returned, a non-zero failure code otherwise.
 
 # FILES
 
-## rpmrc Configuration
-
-Each file in the colon separated rpmrc path is read sequentially by
-*rpm* for configuration information. Only the first file in the
-list must exist, and tildes will be expanded to the value of
-*$HOME*. The default rpmrc path is as follows:
-
-```
-/usr/lib/rpm/rpmrc:
-/usr/lib/rpm/<vendor>/rpmrc:
-/etc/rpmrc:
-~/.config/rpm/rpmrc
-```
-
-If *XDG_CONFIG_HOME* environment variable is set, it replaces _~/.config_
-in the path.
-
-In older rpm versions the path of per-user rpmrc was _~/.rpmrc_.
-This is still processed if it exists and the new configuration directory
-does not exist.
-
-## Macro Configuration
-
-Each file or *glob*(7) pattern in the colon-separated macro path is
-read sequentially by *rpm* for macro definitions. Tildes will be expanded
-to the value of the environment variable *HOME*. The default macro path
-is as follows:
-
-```
-/usr/lib/rpm/macros:
-/usr/lib/rpm/macros.d/macros.*:
-/usr/lib/rpm/platform/%{\_target}/macros:
-/usr/lib/rpm/fileattrs/*.attr:
-/usr/lib/rpm/<vendor>/macros:
-/etc/rpm/macros.*:
-/etc/rpm/macros:
-/etc/rpm/%{\_target}/macros:
-~/.config/rpm/macros
-```
-
-If *XDG_CONFIG_HOME* environment variable is set, it replaces _~/.config_
-in the path.
-
-In older versions of rpm, the path of per-user macros was _~/.rpmmacros_.
-This is still processed if it exists and the new configuration directory
-does not exist.
-
 ## Database
 
 ```
@@ -217,4 +170,4 @@ does not exist.
 ```
 
 # SEE ALSO
-*popt*(3), *rpm*(8)
+*popt*(3), *rpm*(8) *rpm-config*(5), *rpm-rpmrc*(5)

--- a/docs/man/rpm-config.5.scd
+++ b/docs/man/rpm-config.5.scd
@@ -1,0 +1,217 @@
+RPM-CONFIG(5)
+
+# NAME
+*rpm-config* - rpm runtime macro configuration
+
+# SYNOPSIS
+_NAME_ _VALUE_
+
+# FILES
+_/usr/lib/rpm/macros_++
+_/usr/lib/rpm/macros.d/macros.\*_++
+_/usr/lib/rpm/platform/%{\_target}/macros_++
+_/usr/lib/rpm/fileattrs/\*.attr_++
+_/usr/lib/rpm/<vendor>/macros_++
+_/etc/rpm/macros.\*_++
+_/etc/rpm/macros_++
+_/etc/rpm/%{\_target}/macros_++
+_~/.config/rpm/macros_
+
+# DESCRIPTION
+The primary configuration mechanism in *rpm* is via macros. On startup,
+*rpm* reads a set of macro files (*rpm-macrofile*(5)) as defined
+in the _macro path_.
+
+Each file or *glob*(7) pattern in the colon-separated _macro path_ is
+read sequentially by *rpm* for macro definitions. *%{\_target}* is
+expanded to the detected <arch>-<os> platform. Tildes are expanded
+to the value of the environment variable *HOME*.
+
+If a macro is defined multiple times, the last entry wins. The default
+_macro path_ uses this to achieve the following hierarchy of settings:
+. Generic *rpm* factory defaults
+. Platform-specific *rpm* factory defaults
+. Vendor (distribution) specific settings
+. Host specific settings
+. User specific settings
+. Command-line override settings
+
+The default _macro path_ can be inspected with *rpm --showrc|grep ^Macro*.
+
+In older versions of rpm, the path of per-user macros was _~/.rpmmacros_.
+This is still processed if it exists and the new configuration directory
+does not exist.
+
+# CONFIGURATION
+The following configurables are supported for the *rpm* runtime (as
+opposed opposed to just package building) parts:
+
+*%\_color_output* _MODE_
+	Output coloring mode. Valid values are *never* and *auto*.
+
+*%\_db_backend* _BACKEND_
+	The database backend to use. Possible values for _BACKEND_ are:
+	- *dummy*: Dummy backend (no actual functionality)
+	- *bdb_ro*: Berkeley DB (read-only)
+	- *ndb*: Native database (no external dependencies)
+	- *sqlite*: Sqlite database
+
+*%\_dbpath* _DIRECTORY_
+	The location of the rpm database file(s).
+
+*%\_excludedocs* _VALUE_
+	Boolean (i.e. 1 == "yes", 0 == "no") that controls whether files
+	marked as %doc should be installed.
+
+*%\_flush_io* _VALUE_
+	Flush file IO during transactions (at a severe cost in performance
+	for rotational disks). Possible values are 1 to enable, 0 to disable.
+
+*%\_group_path* _PATH_
+	Location of group(5) files as : separated list
+
+*%\_httpport* _PORT_
+	The port of HTTP proxy (used for FTP/HTTP).
+
+*%\_httpproxy* _HOSTNAME_
+	The hostname of HTTP proxy (used for FTP/HTTP).
+
+*%\_install_langs* _LOCALES_
+	A colon separated list of desired locales to be installed;
+	*all* means install all locale specific files.
+
+*%\_install_script_path* _PATH_
+	The PATH put into the environment before running %pre/%post et al.
+
+*%\_keyring* _BACKEND_
+	The keyring type to use. Possible values for _BACKEND_ are:
+	- *fs*: Plain ASCII files in a directory
+	- *openpgp*: Shared OpenPGP certificate directory
+	- *rpmdb*: Pseudo-packages in the rpmdb
+
+*%\_keyringpath* _DIRECTORY_
+	The location of the keyring path for non-rpmdb variants.
+
+*%\_minimize_writes* _VALUE_
+	Minimize writes during transactions (at the cost of more reads) to
+	conserve eg SSD disks (EXPERIMENTAL). Possible values are:
+	- *0*: disable
+	- *1*: enable
+	- *-1*: (or undefined) autodetect on platforms where supported,
+	  otherwise default to disabled
+
+*%\_netsharedpath* _PATH_
+	A colon separated list of paths where files should *not* be installed.
+	Usually, these are network file system mount points.
+
+*%\_passwd_path* _PATH_
+	Location of passwd(5) files as : separated list
+
+*%\_pkgverify_flags* _VSFLAGS_
+	Transaction package verification flags, used for fine-grained
+	control of *%\_pkgverify_level* operation.
+	Set to 0x0 for full compatibility with v4 packages.
+
+*%\_pkgverify_level* _MODE_
+	Enforced package verification mode in transactions,
+	where _MODE_ is one of:
+	- *all*: require valid digest(s) and signature(s)
+	- *signature*: require valid signature(s)
+	- *digest*: require valid digest(s)
+	- *none*: legacy rpm behavior, nothing required
+
+*%\_prefer_color* _VALUE_
+	Package conflict resolution in bi-arch transactions.
+	See also *%\_transaction_color*. Possible values are:
+	- *0*: disabled
+	- *1*: prefer 32-bit packages
+	- *2*: prefer 64-bit packages
+
+*%\_\_plugindir* _DIRECTORY_
+	Transaction plugin directory.
+
+*%\_query_all_fmt* _FORMAT_
+	Default output format string for rpm -qa.
+	*%* signs need to be escaped, eg. *%%{nevra}*.
+
+*%\_rpmlock_path* _FILE_
+	The path of the file used for transaction fcntl lock.
+
+*%\_tmppath* _PATH_
+	The directory where temporary files are created.
+
+*%\_\_urlhelpercmd* _EXECUTABLE_
+	The executable to use for retrieving remote files.
+
+*%\_\_urlhelperopts* _OPTIONS_
+	Generic options to pass to the *%\_\_urlhelpercmd* command.
+
+*%\_\_urlhelper_localopts* _OPTIONS_
+	User/host specific options to pass to the *%\_\_urlhelpercmd* command.
+
+*%\_\_urlhelper_proxyopts* _OPTIONS_
+	Proxy options to pass to the *%\_\_urlhelpercmd* command.
+
+*%\_urlhelper* _COMMAND_
+	Full command (with options) to use when retrieving remote files.
+	Normally pieced together from the double-underscore *%\_\_urlhelper\**
+	macros.
+
+*%\_transaction_color* _VALUE_
+	Package and file conflict behavior in bi-arch transactions.
+	See also *%\_prefer_color*. Possible values are:
+	- *0*: do not consider "colors", only use arch compatibility map
+	- *1*: only allow 32-bit packages
+	- *2*: only allow 64-bit packages
+	- *3*: allow 32- and 64-bit packages to share files
+
+*%\_vsflags_erase* _VSFLAGS_
+	Transaction verification flags used when erasing or updating packages.
+
+*%\_vsflags_install* _VSFLAGS_
+	Transaction verification flags used when installing packages.
+
+*%\_vsflags_query* _VSFLAGS_
+	Transaction verification flags used when querying packages.
+
+*%\_vsflags_rebuilddb* _VSFLAGS_
+	Transaction verification flags used when rebuilding the database.
+
+*%\_vsflags_verify* _VSFLAGS_
+	Transaction verification flags used when verifying packages.
+
+## Verification flags
+Digest/signature verification flags for various rpm operations are controlled
+by a bitmask known as _VSFLAGS_. These flags control various aspects
+of digital checksum and signature verification when reading rpm package
+files and their headers.
+
+_VSFLAGS_ is formed by bitwise or'ing the individual flags:
+- *0x00001* (RPMVSF_NOHDRCHK): don't verify headers from rpmdb
+- *0x00100* (RPMVSF_NOSHA1HEADER): don't verify header SHA1 digest
+- *0x00200* (RPMVSF_NOSHA256HEADER): don't verify header SHA255 digest
+- *0x00400* (RPMVSF_NODSAHEADER): don't verify header DSA signature(s)
+- *0x00800* (RPMVSF_NORSAHEADER): don't verify header RSA signature(s)
+- *0x01000* (RPMVSF_NOOPENPGP): don't verify header OpenPGP signature(s)
+- *0x10000* (RPMVSF_NOPAYLOAD): don't verify package payload digest
+- *0x20000* (RPMVSF_NOMD5): don't verify legacy header+payload MD5 digest
+- *0x40000* (RPMVSF_NODSA): don't verify legacy header+payload DSA signature
+- *0x80000* (RPMVSF_NORSA): don't verify legacy header+payload RSA signature
+
+RPM's Python bindings can be helpful for working with these values,
+for example:
+```
+>>> import rpm
+>>> hex(rpm.RPMVSF_NOSHA1HEADER)
+'0x100'
+>>> hex(rpm.RPMVSF_NOSHA1HEADER|rpm.RPMVSF_NOMD5)
+'0x20100'
+>>>
+```
+
+# ENVIRONMENT
+If *XDG_CONFIG_HOME* environment variable is set, it replaces _~/.config_
+in the _macro path_.
+
+# SEE ALSO
+*rpm*(8), *rpm-common*(8), *rpm-macrofile*(5), *rpm-rpmrc*(5)

--- a/docs/man/rpm-man-template.scd
+++ b/docs/man/rpm-man-template.scd
@@ -76,7 +76,7 @@ Typographic conventions:
 - Put option aliases on separate lines
 - Put option arguments with pre-determined values into <> (see below)
 
-See *rpm.common*(8) for the options common to all *rpm* executables.
+See *rpm-common*(8) for the options common to all *rpm* executables.
 
 *-d*,
 *--do-this*
@@ -124,7 +124,7 @@ if necessary.
 List main configurables affecting this program here, but don't describe.
 If the command has no relevant configuration, delete this section.
 
-See *rpm.config*(5) for details:
+See *rpm-config*(5) for details:
 - *%\_bar_mode*
 - *%\_foo_mode*
 
@@ -155,6 +155,6 @@ Describe files specific to this command.
 Delete this section if there are none.
 
 # SEE ALSO
-*rpm*(8) *rpm.common*(8) *popt*(3)
+*rpm*(8) *rpm-common*(8) *rpm-config*(5) *popt*(3)
 
 *http://www.rpm.org/*

--- a/docs/man/rpm-rpmrc.5.scd
+++ b/docs/man/rpm-rpmrc.5.scd
@@ -1,0 +1,100 @@
+RPM-RPMRC(5)
+
+# NAME
+*rpm-rpmrc* - rpm platform compatibility configuration
+
+# SYNOPSIS
+_VARIABLE_: {_ARCH_|_OS_}: _VALUE_ ...
+
+_VARIABLE_: _ARCH_ _VALUE_
+
+# FILES
+_/usr/lib/rpm/rpmrc_++
+_/usr/lib/rpm/<vendor>/rpmrc_++
+_/etc/rpmrc_++
+_~/.config/rpm/rpmrc_
+
+# DESCRIPTION
+The low-level machine architecture and OS configuration in *rpm* is
+managed via a set of rpmrc files as defined by the _rpmrc path_.
+Most users never need to look at, much less touch these files.
+
+Each file in the colon separated _rpmrc path_ is read sequentially by
+*rpm* for configuration information. Tildes will be expanded to the
+value of the environment variable *HOME*.
+The first file in the path must exist, others are considered optional.
+
+If a value is defined multiple times, the last entry wins. The default
+_rpmrc path_ uses this to achieve the following hierarchy of platform
+configuration:
+. Generic *rpm* factory defaults
+. Vendor (distribution) specific configuration
+. Host specific configuration
+. User specific configuration
+
+In older rpm versions the path of per-user rpmrc was _~/.rpmrc_.
+This is still processed if it exists and the new configuration directory
+does not exist.
+
+# CONFIGURATION
+_ARCH_ and _OS_ relate to *uname*(2) machine and operating system
+information, but are not 1:1 equivalent.
+The following directives are supported in the rpmrc files:
+
+*arch_canon* _ARCH_: _CANON_ARCH_ _ARCH_NUM_
+	Names and numbers of known architectures to
+	alias different spellings to a canonical one.
+	_CANON_ARCH_ is what the _ARCH_ entries in other rpmrc
+	directives refer to.
+
+	The number is not used for any calculations by *rpm* but
+	must be present for historical reasons.
+
+*arch_compat*: _ARCH_: _COMPAT_ARCH_ ...
+	Declare compatibility between machine architectures,
+	ie. _ARCH_ machines can install packages for _COMPAT_ARCH_
+	architecture.
+
+*archcolor*: _ARCH_ _COLOR_
+	Declare the "color" of _ARCH_. The color relates to the word length
+	aka bitness of the architecture:
+	- *0* means none (noarch packages and similar)
+	- *1* means 32-bit
+	- *2* means 64-bit
+
+*buildarch_compat*: _ARCH_: _COMPAT_ARCH_ ...
+	Declare compatibility between build architectures targets,
+	ie. _ARCH_ machines can produce _COMPAT_ARCH_ binaries.
+
+*buildarchtranslate*: _ARCH_: _TRANSLATE_ARCH_
+	Automatically translate detected host architecture _ARCH_ to
+	_TRANSLATE_ARCH_ when building packages. This is used to map
+	sub-architectures to a main one, for example when building on a
+	*x86_64_v2* host we typically want the generated package to be
+	of the main *x86_64* architecture.
+
+*optflags*: _ARCH_ _OPTFLAGS_
+	Compiler flags to use when building packages for _ARCH_ architecture.
+	The _OPTFLAGS_ value is available as *%{optflags}* macro in
+	spec files.
+
+*os_canon*: _OS_: _CANON_OS_ _OS_NUM_
+	Names and numbers of known operating systems to
+	alias different spellings to a canonical one.
+	_CANON_OS_ is what the _OS_ entries in other rpmrc directives
+	refer to.
+
+	The number is not used for any calculations by *rpm* but
+	must be present for historical reasons.
+
+*os_compat*: _OS_: _COMPAT_OS_ ...
+	Declare compatibility between operating systems, ie.
+	_OS_ machine can install packages for _COMPAT_OS_ operating
+	system.
+
+# ENVIRONMENT
+If *XDG_CONFIG_HOME* environment variable is set, it replaces _~/.config_
+in the _rpmrc path_.
+
+# SEE ALSO
+*rpm*(8), *rpm-common*(8), *rpm-config*(5)

--- a/docs/man/rpm.8.scd
+++ b/docs/man/rpm.8.scd
@@ -654,7 +654,7 @@ unique to verify mode are:
 On success, 0 is returned, a non-zero failure code otherwise.
 
 # FILES
-See *rpm-common*(8).
+See *rpm-common*(8), *rpm-config*(5) and *rpm-rpmrc*(5).
 
 # SEE ALSO
 *rpm-common*(8), *popt*(3), *rpm2cpio*(1), *rpmbuild*(1), *rpmdb*(8),

--- a/docs/man/rpmkeys.8.scd
+++ b/docs/man/rpmkeys.8.scd
@@ -99,7 +99,7 @@ See *rpm-common*(8) for the options common to all *rpm* executables.
 # CONFIGURATION
 
 There are several configurables affecting the behavior of this
-verification, see *rpm.config*(5) for details:
+verification, see *rpm-config*(5) for details:
 - *%\_keyring*
 - *%\_keyringpath*
 - *%\_pkgverify_flags*
@@ -121,7 +121,7 @@ On success, 0 is returned, a non-zero failure code otherwise.
 	Verify hello-2.0-1.x86_64.rpm package file.
 
 # SEE ALSO
-*popt*(3), *rpm*(8), *rpm-common*(8), *rpmsign*(1)
+*popt*(3), *rpm*(8), *rpm-common*(8), *rpm-config*(5), *rpmsign*(1)
 
 *rpmkeys --help* - as rpm supports customizing the options via popt
 aliases it's impossible to guarantee that what's described in the

--- a/macros.in
+++ b/macros.in
@@ -1,11 +1,7 @@
-#/*! \page config_macros Default configuration: @RPM_CONFIGDIR@/macros
-# \verbatim
-#
 # This is a global RPM configuration file. All changes made here will
-# be lost when the rpm package is upgraded. Any per-system configuration
-# should be added to /etc/rpm/macros, while per-user configuration should
-# be added to ~/.rpmmacros.
+# be lost when the rpm package is upgraded.
 #
+# See rpm-macrofile(5) and rpm-config(5) for more information.
 
 #==============================================================================
 # ---- A macro that expands to nothing.


### PR DESCRIPTION
Turns out we need to add both rpm-rpmrc(5) and rpm-config(5) at once to explain the configuration adequately. Note that this differs from rpm-macrofile(5) which is a generic format usable for other purposes as well, but rpmrc is strictly tied to the path processing etc so there's no separating the format and how it gets processed.

Fixes: #3620
Fixes: #3614