### PR TITLE
Add rpm version to man pages

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -14,8 +14,9 @@ set(extra
 # Build all manuals
 set(manuals ${core} ${extra})
 foreach(man ${manuals})
-	add_custom_command(OUTPUT ${man} COMMAND ${SCDOC}
-			< ${CMAKE_CURRENT_SOURCE_DIR}/${man}.scd
+	add_custom_command(OUTPUT ${man} COMMAND
+			sed '1 s/$$/ \"RPM ${CMAKE_PROJECT_VERSION}\"/'
+			< ${CMAKE_CURRENT_SOURCE_DIR}/${man}.scd | ${SCDOC}
 			> ${man} DEPENDS ${man}.scd)
 endforeach()
 add_custom_target(man ALL DEPENDS ${manuals})


### PR DESCRIPTION
Many projects like to show the installed version in the left footer in their man pages so do the same, it seems useful.

In scdoc(5), this is done by appending a quoted string to the preamble:

    NAME(section) ["left_footer" ["center_header"]]

Do this while processing man pages with scdoc(1), instead of configuring each .scd file with cmake first, which would seem wasteful just for this purpose.

Note that scd2html(1) doesn't render the "left_footer" in any way so we need to add it manually there (already done in mkpage).