### PR TITLE
Fix importing keys from a pipe

### DIFF
--- a/rpmio/rpmio.cc
+++ b/rpmio/rpmio.cc
@@ -237,7 +237,7 @@ off_t fdSize(FD_t fd)
     struct stat sb;
     off_t rc = -1; 
 
-    if (fd != NULL && fstat(Fileno(fd), &sb) == 0)
+    if (fd != NULL && fstat(Fileno(fd), &sb) == 0 && S_ISREG(sb.st_mode))
 	rc = sb.st_size;
     return rc;
 }

--- a/sign/rpmgensig.cc
+++ b/sign/rpmgensig.cc
@@ -631,6 +631,7 @@ static int rpmSign(const char *rpm, int deleting, int flags)
     int res = -1; /* assume failure */
     rpmRC rc;
     struct rpmtd_s utd;
+    off_t fileSize;
     off_t headerStart;
     off_t sigStart;
     struct sigTarget_s sigt_v3;
@@ -722,11 +723,16 @@ static int rpmSign(const char *rpm, int deleting, int flags)
     } else if (deleting) {	/* Nuke all the signature tags. */
 	deleteSigs(sigh);
     } else {
+	fileSize = fdSize(fd);
+	if (fileSize < 0) {
+	    rpmlog(RPMLOG_ERR, _("Could not get a file size of %s\n"), rpm);
+	    goto exit;
+	}
 	/* Signature target containing header + payload */
 	sigt_v3.fd = fd;
 	sigt_v3.start = headerStart;
 	sigt_v3.fileName = rpm;
-	sigt_v3.size = fdSize(fd) - headerStart;
+	sigt_v3.size = fileSize - headerStart;
 
 	/* Signature target containing only header */
 	sigt_v4 = sigt_v3;


### PR DESCRIPTION
This first patch fixes <code> foo | rpmkeys --import -</code>.

The other patch handles fdSize() failure when signing a package. I found it when making sure that my first patch does not cause any regressions. fdSize() failures were handled on all places except this one.

The two patches are not depending on each other, I just find them topically connected. If it is a problem, I can split this pull request. I have prominent interest in the first patch as it would safe me from creating temporary files when importing keys.