### PR TITLE
Rename rpmtsRebuildKeystore to rpmtxnRebuildKeystore()

### DIFF
--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -365,6 +365,14 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen);
 rpmRC rpmtxnDeletePubkey(rpmtxn txn, rpmPubkey key);
 
 /** \ingroup rpmts
+ * Rebuild key store using current settings and fill it with keys form keyring
+ * @param txn		transaction handle
+ * @param from		backend to get the keys from
+ * @return		RPMRC_OK on success
+ */
+rpmRC rpmtxnRebuildKeystore(rpmtxn txn, const char * from);
+
+/** \ingroup rpmts
  * Retrieve handle for keyring used for this transaction set
  * @param ts            transaction set
  * @param autoload	load default keyring if keyring is not set
@@ -753,14 +761,6 @@ rpmtsi rpmtsiInit(rpmts ts);
  * @return		next transaction element of type, NULL on termination
  */
 rpmte rpmtsiNext(rpmtsi tsi, rpmElementTypes types);
-
-/** \ingroup rpmts
- * Rebuild key store using current settings and fill it with keys form keyring
- * @param txn		transaction handle
- * @param from		backend to get the keys from
- * @return		RPMRC_OK on success
- */
-rpmRC rpmtsRebuildKeystore(rpmtxn txn, const char * from);
 
 #ifdef __cplusplus
 }

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -400,7 +400,7 @@ rpmRC rpmtsImportPubkey(const rpmts ts, const unsigned char * pkt, size_t pktlen
     return rc;
 }
 
-rpmRC rpmtsRebuildKeystore(rpmtxn txn, const char * from)
+rpmRC rpmtxnRebuildKeystore(rpmtxn txn, const char * from)
 {
     rpmts ts = rpmtxnTs(txn);
     rpmRC rc = RPMRC_OK;

--- a/tools/rpmkeys.cc
+++ b/tools/rpmkeys.cc
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
 
 	rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
 	if (txn) {
-	    ec = rpmtsRebuildKeystore(txn, from);
+	    ec = rpmtxnRebuildKeystore(txn, from);
 	    rpmtxnEnd(txn);
 	}
 	break;


### PR DESCRIPTION
All the newer functions taking rpmtxn as the main argument are prefixed rpmtxn so this looks inconsistent. Missed that in the review of 6c4d979e3629b775e7b08eb44b4afd74dfef2a3a. Also move it closer to the other related functions in the header.

No functional changes.