### PR TITLE
Bump library version to 10.6.0 in preparation of 6.0 alpha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(RPM_VENDOR "vendor" CACHE STRING "rpm vendor string")
 # - incrementing a more significant version segment resets changes to
 #   any less significant segments
 set(RPM_SOVERSION 10)
-set(RPM_LIBVERSION ${RPM_SOVERSION}.0.0)
+set(RPM_LIBVERSION ${RPM_SOVERSION}.6.0)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/tests/pinned/rpmlibver.txt
+++ b/tests/pinned/rpmlibver.txt
@@ -1,4 +1,4 @@
-librpm.so.10.0.0
-librpmbuild.so.10.0.0
-librpmio.so.10.0.0
-librpmsign.so.10.0.0
+librpm.so.10.6.0
+librpmbuild.so.10.6.0
+librpmio.so.10.6.0
+librpmsign.so.10.6.0


### PR DESCRIPTION
Rpm 4.20.1 is at 10.2 now and we're expecting at least one more feature release that might warrant bumping to 10.3 and so we don't want to collide with that. Lets leave it some room to grow just in case, the last 4.x branch might be out there for a while.

That 6 is just a number that is somewhat bigger than 2 :innocent: