### PR TITLE
Add an AI-policy to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,3 +186,8 @@ requirements are generally accepted though.
 
 Translations should be submitted through [Fedora Weblate](https://translate.fedoraproject.org/projects/rpm/),
 the upstream project cannot review translations.
+
+## AI Policy
+
+As a policy, the RPM project does not accept use of generative AI
+in contributions.


### PR DESCRIPTION
The license of anything AI generated is questionable at best, as is the content itself. Poisoning this well with AI slop is just not acceptable.

The last straw driving us to add this is GitHub now advertising Copilot Agent in each and every ticket in "click here to fix this" style. The last thing we want is "helpful" folken submitting AI generated "fixes".

The times. Sigh.