### PR TITLE
Fix memory leak in rpmspec --shell

### DIFF
--- a/tools/rpmspec.cc
+++ b/tools/rpmspec.cc
@@ -74,6 +74,7 @@ static int doShell(rpmSpec spec)
 	free(exp);
 	if (*line)
 	    add_history(line);
+	free(line);
     }
     return 0;
 }


### PR DESCRIPTION
The history(3) library allocates its own copy of the line string passed to add_history() so we need to free it ourselves.

Found by Coverity.

Fixes: RHEL-55284