### PR TITLE
rpmlibNeedsFeature() need not request a version range

### DIFF
--- a/build/files.cc
+++ b/build/files.cc
@@ -1180,7 +1180,7 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
 	if (pkg->rpmformat >= 6 || fl->largeFiles) {
 	    rpm_loff_t rsize64 = (rpm_loff_t)flp->fl_size;
 	    headerPutUint64(h, RPMTAG_LONGFILESIZES, &rsize64, 1);
-            (void) rpmlibNeedsFeature(pkg, "LargeFiles", "4.12.0-1");
+            (void) rpmlibNeedsFeature(pkg, "LargeFiles");
 	} else {
 	    rpm_off_t rsize32 = (rpm_off_t)flp->fl_size;
 	    headerPutUint32(h, RPMTAG_FILESIZES, &rsize32, 1);
@@ -1291,15 +1291,15 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
 
     if (digestalgo != RPM_HASH_MD5) {
 	headerPutUint32(h, RPMTAG_FILEDIGESTALGO, &digestalgo, 1);
-	rpmlibNeedsFeature(pkg, "FileDigests", "4.6.0-1");
+	rpmlibNeedsFeature(pkg, "FileDigests");
     }
 
     if (fl->haveCaps) {
-	rpmlibNeedsFeature(pkg, "FileCaps", "4.6.1-1");
+	rpmlibNeedsFeature(pkg, "FileCaps");
     }
 
     if (!isSrc && !rpmExpandNumeric("%{_noPayloadPrefix}"))
-	(void) rpmlibNeedsFeature(pkg, "PayloadFilesHavePrefix", "4.0-1");
+	(void) rpmlibNeedsFeature(pkg, "PayloadFilesHavePrefix");
 
     /* rpmfiNew() only groks compressed filelists */
     headerConvert(h, HEADERCONV_COMPRESSFILELIST);
@@ -1314,7 +1314,7 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
 	headerConvert(h, HEADERCONV_EXPANDFILELIST);
     } else {
 	/* Binary packages with dirNames cannot be installed by legacy rpm. */
-	(void) rpmlibNeedsFeature(pkg, "CompressedFileNames", "3.0.4-1");
+	(void) rpmlibNeedsFeature(pkg, "CompressedFileNames");
     }
 }
 
@@ -2610,7 +2610,7 @@ static rpmRC processPackageFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 
     /* Verify that file attributes scope over hardlinks correctly. */
     if (checkHardLinks(fl.files))
-	(void) rpmlibNeedsFeature(pkg, "PartialHardlinkSets", "4.0.4-1");
+	(void) rpmlibNeedsFeature(pkg, "PartialHardlinkSets");
 
     genCpioListAndHeader(&fl, spec, pkg, 0);
 

--- a/build/pack.cc
+++ b/build/pack.cc
@@ -307,21 +307,21 @@ static char *getIOFlags(Package pkg)
 	} else if (rstreq(s+1, "bzdio")) {
 	    compr = "bzip2";
 	    /* Add prereq on rpm version that understands bzip2 payloads */
-	    (void) rpmlibNeedsFeature(pkg, "PayloadIsBzip2", "3.0.5-1");
+	    (void) rpmlibNeedsFeature(pkg, "PayloadIsBzip2");
 #endif
 #ifdef HAVE_LZMA_H
 	} else if (rstreq(s+1, "xzdio")) {
 	    compr = "xz";
-	    (void) rpmlibNeedsFeature(pkg, "PayloadIsXz", "5.2-1");
+	    (void) rpmlibNeedsFeature(pkg, "PayloadIsXz");
 	} else if (rstreq(s+1, "lzdio")) {
 	    compr = "lzma";
-	    (void) rpmlibNeedsFeature(pkg, "PayloadIsLzma", "4.4.6-1");
+	    (void) rpmlibNeedsFeature(pkg, "PayloadIsLzma");
 #endif
 #ifdef HAVE_ZSTD
 	} else if (rstreq(s+1, "zstdio")) {
 	    compr = "zstd";
 	    /* Add prereq on rpm version that understands zstd payloads */
-	    (void) rpmlibNeedsFeature(pkg, "PayloadIsZstd", "5.4.18-1");
+	    (void) rpmlibNeedsFeature(pkg, "PayloadIsZstd");
 #endif
 	} else {
 	    rpmlog(RPMLOG_ERR, _("Unknown payload compression: %s\n"),
@@ -345,15 +345,15 @@ static void finalizeDeps(Package pkg)
 {
     /* check if the package has a dependency with a '~' */
     if (haveCharInDep(pkg, '~'))
-	(void) rpmlibNeedsFeature(pkg, "TildeInVersions", "4.10.0-1");
+	(void) rpmlibNeedsFeature(pkg, "TildeInVersions");
 
     /* check if the package has a dependency with a '^' */
     if (haveCharInDep(pkg, '^'))
-	(void) rpmlibNeedsFeature(pkg, "CaretInVersions", "4.15.0-1");
+	(void) rpmlibNeedsFeature(pkg, "CaretInVersions");
 
     /* check if the package has a rich dependency */
     if (haveRichDep(pkg))
-	(void) rpmlibNeedsFeature(pkg, "RichDependencies", "4.12.0-1");
+	(void) rpmlibNeedsFeature(pkg, "RichDependencies");
 
     /* All dependencies added finally, write them into the header */
     for (int i = 0; i < PACKAGE_NUM_DEPS; i++) {
@@ -757,7 +757,7 @@ static rpmRC packageBinary(rpmSpec spec, Package pkg, const char *cookie, int ch
     }
 
     if (cheating) {
-	(void) rpmlibNeedsFeature(pkg, "ShortCircuited", "4.9.0-1");
+	(void) rpmlibNeedsFeature(pkg, "ShortCircuited");
     }
 
     if ((rc = getPkgFilename(pkg->header, filename)))
@@ -846,7 +846,7 @@ rpmRC packageSources(rpmSpec spec, char **cookie)
 		    rpmSpecGetSection(spec, RPMBUILD_NONE));
 
     if (rpmSpecGetSection(spec, RPMBUILD_BUILDREQUIRES)) {
-	(void) rpmlibNeedsFeature(sourcePkg, "DynamicBuildRequires", "4.15.0-1");
+	(void) rpmlibNeedsFeature(sourcePkg, "DynamicBuildRequires");
     }
 
     /* XXX this should be %_srpmdir */

--- a/build/parseScript.cc
+++ b/build/parseScript.cc
@@ -363,7 +363,7 @@ int parseScript(rpmSpec spec, int parsePart)
 	if (rpmluaCheckScript(lua, p, partname) != RPMRC_OK) {
 	    goto exit;
 	}
-	(void) rpmlibNeedsFeature(pkg, "BuiltinLuaScripts", "4.2.2-1");
+	(void) rpmlibNeedsFeature(pkg, "BuiltinLuaScripts");
     } else if (progArgv[0][0] == '<') {
 	rpmlog(RPMLOG_ERR,
 		 _("line %d: unsupported internal script: %s\n"),
@@ -375,7 +375,7 @@ int parseScript(rpmSpec spec, int parsePart)
     }
 
     if (scriptFlags) {
-	rpmlibNeedsFeature(pkg, "ScriptletExpansion", "4.9.0-1");
+	rpmlibNeedsFeature(pkg, "ScriptletExpansion");
     }
 
     /* Trigger script insertion is always delayed in order to */
@@ -409,8 +409,7 @@ int parseScript(rpmSpec spec, int parsePart)
 	    td.data = (void *) *progArgv;
 	    td.type = RPM_STRING_TYPE;
 	} else {
-	    (void) rpmlibNeedsFeature(pkg,
-			"ScriptletInterpreterArgs", "4.0.3-1");
+	    (void) rpmlibNeedsFeature(pkg, "ScriptletInterpreterArgs");
 	    td.data = progArgv;
 	    td.type = RPM_STRING_ARRAY_TYPE;
 	}

--- a/build/reqprov.cc
+++ b/build/reqprov.cc
@@ -51,7 +51,7 @@ rpmRC addReqProvPkg(void *cbdata, rpmTagVal tagN,
 int rpmlibNeedsFeature(Package pkg, const char * feature, const char * featureEVR)
 {
     char *reqname = NULL;
-    int flags = RPMSENSE_RPMLIB|RPMSENSE_LESS|RPMSENSE_EQUAL;
+    int flags = RPMSENSE_RPMLIB|RPMSENSE_EQUAL;
     int res;
 
     /* XXX HACK: avoid changing rpmlibNeedsFeature() for just one user */

--- a/build/reqprov.cc
+++ b/build/reqprov.cc
@@ -48,10 +48,10 @@ rpmRC addReqProvPkg(void *cbdata, rpmTagVal tagN,
     return addReqProv(pkg, tagN, N, EVR, Flags, index) ? RPMRC_FAIL : RPMRC_OK;
 }
 
-int rpmlibNeedsFeature(Package pkg, const char * feature, const char * featureEVR)
+int rpmlibNeedsFeature(Package pkg, const char * feature)
 {
     char *reqname = NULL;
-    int flags = RPMSENSE_RPMLIB|RPMSENSE_EQUAL;
+    int flags = RPMSENSE_RPMLIB;
     int res;
 
     /* XXX HACK: avoid changing rpmlibNeedsFeature() for just one user */
@@ -60,7 +60,7 @@ int rpmlibNeedsFeature(Package pkg, const char * feature, const char * featureEV
 
     rasprintf(&reqname, "rpmlib(%s)", feature);
 
-    res = addReqProv(pkg, RPMTAG_REQUIRENAME, reqname, featureEVR, flags, 0);
+    res = addReqProv(pkg, RPMTAG_REQUIRENAME, reqname, NULL, flags, 0);
 
     free(reqname);
 

--- a/build/rpmbuild_internal.hh
+++ b/build/rpmbuild_internal.hh
@@ -596,11 +596,10 @@ int addSource(rpmSpec spec, int specline, const char *srcname, rpmTagVal tag);
  * Add rpmlib feature dependency.
  * @param pkg		package
  * @param feature	rpm feature name (i.e. "rpmlib(Foo)" for feature Foo)
- * @param featureEVR	rpm feature epoch/version/release
  * @return		0 always
  */
 RPM_GNUC_INTERNAL
-int rpmlibNeedsFeature(Package pkg, const char * feature, const char * featureEVR);
+int rpmlibNeedsFeature(Package pkg, const char * feature);
 
 RPM_GNUC_INTERNAL
 rpmRC checkForEncoding(Header h, int addtag);

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -467,7 +467,7 @@ hello-debuginfo-2.0-1
 ],
 [])
 
-# finally, see that we left the tree intact 
+# finally, see that we left the tree intact
 RPMTEST_CHECK([
 runroot find hello-2.0 | sort
 ],
@@ -1250,9 +1250,9 @@ runroot rpm  -qp --requires /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
 [0],
 [/bin/f00f
 /bin/sh
-rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib(FileDigests) <= 4.6.0-1
-rpmlib(PayloadFilesHavePrefix) <= 4.0-1
+rpmlib(CompressedFileNames) = 3.0.4-1
+rpmlib(FileDigests) = 4.6.0-1
+rpmlib(PayloadFilesHavePrefix) = 4.0-1
 ],
 [])
 
@@ -2532,9 +2532,9 @@ runroot rpmbuild \
 runroot rpm -qpR /build/SRPMS/buildrequires-1.0-1.src.rpm
 ],
 [0],
-[rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib(DynamicBuildRequires) <= 4.15.0-1
-rpmlib(FileDigests) <= 4.6.0-1
+[rpmlib(CompressedFileNames) = 3.0.4-1
+rpmlib(DynamicBuildRequires) = 4.15.0-1
+rpmlib(FileDigests) = 4.6.0-1
 ],
 [ignore])
 RPMTEST_CLEANUP
@@ -2660,10 +2660,10 @@ runroot rpm -qpvR /build/SRPMS/buildrequires-1.0-1.buildreqs.nosrc.rpm
 [auto: (bar = 3.4 or bar = 3.5)
 auto: foo > 1.3
 auto: foo-bar = 2.0
-rpmlib: rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib,missingok: rpmlib(DynamicBuildRequires) <= 4.15.0-1
-rpmlib: rpmlib(FileDigests) <= 4.6.0-1
-rpmlib: rpmlib(RichDependencies) <= 4.12.0-1
+rpmlib: rpmlib(CompressedFileNames) = 3.0.4-1
+rpmlib,missingok: rpmlib(DynamicBuildRequires) = 4.15.0-1
+rpmlib: rpmlib(FileDigests) = 4.6.0-1
+rpmlib: rpmlib(RichDependencies) = 4.12.0-1
 ],
 [ignore])
 RPMTEST_CLEANUP

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1250,9 +1250,9 @@ runroot rpm  -qp --requires /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
 [0],
 [/bin/f00f
 /bin/sh
-rpmlib(CompressedFileNames) = 3.0.4-1
-rpmlib(FileDigests) = 4.6.0-1
-rpmlib(PayloadFilesHavePrefix) = 4.0-1
+rpmlib(CompressedFileNames)
+rpmlib(FileDigests)
+rpmlib(PayloadFilesHavePrefix)
 ],
 [])
 
@@ -2532,9 +2532,9 @@ runroot rpmbuild \
 runroot rpm -qpR /build/SRPMS/buildrequires-1.0-1.src.rpm
 ],
 [0],
-[rpmlib(CompressedFileNames) = 3.0.4-1
-rpmlib(DynamicBuildRequires) = 4.15.0-1
-rpmlib(FileDigests) = 4.6.0-1
+[rpmlib(CompressedFileNames)
+rpmlib(DynamicBuildRequires)
+rpmlib(FileDigests)
 ],
 [ignore])
 RPMTEST_CLEANUP
@@ -2660,10 +2660,10 @@ runroot rpm -qpvR /build/SRPMS/buildrequires-1.0-1.buildreqs.nosrc.rpm
 [auto: (bar = 3.4 or bar = 3.5)
 auto: foo > 1.3
 auto: foo-bar = 2.0
-rpmlib: rpmlib(CompressedFileNames) = 3.0.4-1
-rpmlib,missingok: rpmlib(DynamicBuildRequires) = 4.15.0-1
-rpmlib: rpmlib(FileDigests) = 4.6.0-1
-rpmlib: rpmlib(RichDependencies) = 4.12.0-1
+rpmlib: rpmlib(CompressedFileNames)
+rpmlib,missingok: rpmlib(DynamicBuildRequires)
+rpmlib: rpmlib(FileDigests)
+rpmlib: rpmlib(RichDependencies)
 ],
 [ignore])
 RPMTEST_CLEANUP

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -1358,9 +1358,9 @@ RPMTEST_CHECK([
 runroot rpm  -qp --requires /build/RPMS/noarch/filetypes-1.0-1.noarch.rpm
 ],
 [0],
-[rpmlib(CompressedFileNames) = 3.0.4-1
-rpmlib(FileDigests) = 4.6.0-1
-rpmlib(PayloadFilesHavePrefix) = 4.0-1
+[rpmlib(CompressedFileNames)
+rpmlib(FileDigests)
+rpmlib(PayloadFilesHavePrefix)
 ],
 [])
 
@@ -1394,11 +1394,11 @@ RPMTEST_CHECK([
 runroot rpm  -qp --requires /build/RPMS/noarch/filetypes-1.0-1.noarch.rpm
 ],
 [0],
-[rpmlib(CompressedFileNames) = 3.0.4-1
-rpmlib(FileDigests) = 4.6.0-1
-rpmlib(LargeFiles) = 4.12.0-1
-rpmlib(PayloadFilesHavePrefix) = 4.0-1
-rpmlib(PayloadIsZstd) = 5.4.18-1
+[rpmlib(CompressedFileNames)
+rpmlib(FileDigests)
+rpmlib(LargeFiles)
+rpmlib(PayloadFilesHavePrefix)
+rpmlib(PayloadIsZstd)
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -1358,9 +1358,9 @@ RPMTEST_CHECK([
 runroot rpm  -qp --requires /build/RPMS/noarch/filetypes-1.0-1.noarch.rpm
 ],
 [0],
-[rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib(FileDigests) <= 4.6.0-1
-rpmlib(PayloadFilesHavePrefix) <= 4.0-1
+[rpmlib(CompressedFileNames) = 3.0.4-1
+rpmlib(FileDigests) = 4.6.0-1
+rpmlib(PayloadFilesHavePrefix) = 4.0-1
 ],
 [])
 
@@ -1394,11 +1394,11 @@ RPMTEST_CHECK([
 runroot rpm  -qp --requires /build/RPMS/noarch/filetypes-1.0-1.noarch.rpm
 ],
 [0],
-[rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib(FileDigests) <= 4.6.0-1
-rpmlib(LargeFiles) <= 4.12.0-1
-rpmlib(PayloadFilesHavePrefix) <= 4.0-1
-rpmlib(PayloadIsZstd) <= 5.4.18-1
+[rpmlib(CompressedFileNames) = 3.0.4-1
+rpmlib(FileDigests) = 4.6.0-1
+rpmlib(LargeFiles) = 4.12.0-1
+rpmlib(PayloadFilesHavePrefix) = 4.0-1
+rpmlib(PayloadIsZstd) = 5.4.18-1
 ],
 [])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Previous discussion: https://github.com/rpm-software-management/rpm/discussions/2374#discussioncomment-8073170

In practice this is equivalent to the previous behavior, as 'provides' never used a range and do not inject the actual version of the RPM library.  