### PR TITLE
Add an option to use a different mtime

### DIFF
--- a/build/files.cc
+++ b/build/files.cc
@@ -1022,7 +1022,19 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
     int override_date = 0;
     time_t mtime_clamp = 0;
     char *srcdate = getenv("SOURCE_DATE_EPOCH");
+    char *msrcdate = getenv("SOURCE_DATE_EPOCH_MTIME");
     char *mtime_policy_str = rpmExpand("%{?build_mtime_policy}", NULL);
+
+    /* If SOURCE_DATE_EPOCH_MTIME is set, use it for file modification time
+     * stamps, it is supposed to be newer. This can be used if we might want to
+     * compare if the file content remains the same when a build dependency
+     * changes while a build script embeds SOURCE_DATE_EPOCH in the file
+     * content. mtimes are required to increase with new versions and releases
+     * of an rpm with the same name, as rsync without --checksum and similar
+     * tools would get confused if the content changes without newer mtime. */
+    if (msrcdate != NULL) {
+       srcdate = msrcdate;
+    }
 
     /* backward compatibility */
     if (!*mtime_policy_str) {

--- a/docs/manual/buildprocess.md
+++ b/docs/manual/buildprocess.md
@@ -110,6 +110,7 @@ The supported values for `%build_mtime_policy` are:
   leave the mtimes as is
 * `clamp_to_source_date_epoch`
   clamp the mtimes so that they are not bigger than the `SOURCE_DATE_EPOCH`
+  or `SOURCE_DATE_EPOCH_MTIME` if it is set. The latter takes precedence.
 * `clamp_to_buildtime`
   clamp the mtimes so that they are not bigger than the package build time (i.e. the time that
   is used for the `BUILDTIME` tag)


### PR DESCRIPTION
File mtimes are required to increase with new versions and releases
of an rpm with the same name, as rsync without --checksum and similar
tools would get confused if the content changes without newer mtime.

If SOURCE_DATE_EPOCH_MTIME is set, use it instead for file modification time
stamps. It is supposed to be newer. This can be used if we might want to
compare if the file content remains the same when a build dependency
changes while a build script embeds SOURCE_DATE_EPOCH in the file
content.

This can be used to support automatic rebuilds. Normally automatic
rebuilds work, but together with reproducible builds an undesirable
situation may occur. If a build embeds SOURCE_DATE_EPOCH in the
output, then the output changes every time such a rebuild happens, which
can be very often. This is to be avoided as updating packages without
necessity is too expensive.

Co-Authored-By: Jan Zerebecki <jan.suse@zerebecki.de>