### PR TITLE
Fix a refactoring regression in rich dependency and rpmdb set calcula…

### DIFF
--- a/lib/backend/dbiset.cc
+++ b/lib/backend/dbiset.cc
@@ -101,6 +101,8 @@ int dbiIndexSetPruneSet(dbiIndexSet set, dbiIndexSet oset, int sorted)
     if (set->recs.empty() || oset == NULL || oset->recs.empty())
 	return 1;
 
+    if (set->recs.size() > 1 && !sorted)
+	dbiIndexSetSort(set);
     if (oset->recs.size() > 1 && !sorted)
 	dbiIndexSetSort(oset);
 
@@ -120,6 +122,8 @@ int dbiIndexSetFilterSet(dbiIndexSet set, dbiIndexSet oset, int sorted)
 	return num ? 0 : 1;
     }
 
+    if (set->recs.size() > 1 && !sorted)
+	dbiIndexSetSort(set);
     if (oset->recs.size() > 1 && !sorted)
 	dbiIndexSetSort(oset);
 

--- a/lib/backend/dbiset.hh
+++ b/lib/backend/dbiset.hh
@@ -51,9 +51,10 @@ int dbiIndexSetAppendOne(dbiIndexSet set, unsigned int hdrNum,
 
 /**
  * Remove an index set from another.
+ * The sets are sorted as a side-effect if sorted is 0.
  * @param set          set of index database items
  * @param oset         set of entries that should be removed
- * @param sorted       oset is already sorted?
+ * @param sorted       are set and oset is already sorted?
  * @return             0 success, 1 failure (no items found)
  */
 RPM_GNUC_INTERNAL
@@ -61,9 +62,10 @@ int dbiIndexSetPruneSet(dbiIndexSet set, dbiIndexSet oset, int sorted);
 
 /**
  * Filter (intersect) an index set with another.
+ * The sets are sorted as a side-effect if sorted is 0.
  * @param set          set of index database items
  * @param oset         set of entries that should be intersected
- * @param sorted       oset is already sorted?
+ * @param sorted       are set and oset are already sorted?
  * @return             0 success, 1 failure (no items removed)
  */
 RPM_GNUC_INTERNAL

--- a/lib/backend/dbiset.hh
+++ b/lib/backend/dbiset.hh
@@ -65,7 +65,7 @@ int dbiIndexSetPruneSet(dbiIndexSet set, dbiIndexSet oset, int sorted);
  * The sets are sorted as a side-effect if sorted is 0.
  * @param set          set of index database items
  * @param oset         set of entries that should be intersected
- * @param sorted       are set and oset are already sorted?
+ * @param sorted       are set and oset already sorted?
  * @return             0 success, 1 failure (no items removed)
  */
 RPM_GNUC_INTERNAL

--- a/lib/backend/dbiset.hh
+++ b/lib/backend/dbiset.hh
@@ -54,7 +54,7 @@ int dbiIndexSetAppendOne(dbiIndexSet set, unsigned int hdrNum,
  * The sets are sorted as a side-effect if sorted is 0.
  * @param set          set of index database items
  * @param oset         set of entries that should be removed
- * @param sorted       are set and oset is already sorted?
+ * @param sorted       are set and oset already sorted?
  * @return             0 success, 1 failure (no items found)
  */
 RPM_GNUC_INTERNAL

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -313,17 +313,23 @@ AT_KEYWORDS([install, boolean])
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
 	--define "reqs (deptest-two with flavor = desktop)" \
+	--define "provs feat = 4.0" \
 	  /data/SPECS/deptest.spec
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg two" \
-	--define "provs flavor = desktop" \
+	--define "provs flavor = desktop feat = 1.5" \
+	  /data/SPECS/deptest.spec
+
+runroot rpmbuild --quiet -bb \
+	--define "pkg three" \
+	--define "reqs (feat >= 1.0 with feat < 3.0)" \
 	  /data/SPECS/deptest.spec
 
 # satisfied WITH require in transaction
 RPMTEST_CHECK([
 RPMDB_RESET
-runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
+runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
 [0],
 [],


### PR DESCRIPTION
…tions

Commit 52f311e224254d7cb28bf2ced22db7b50e1a2653 failed to take into account that std::set_difference() and std::set_intersection() require both data sets to be sorted, whereas the old manual implementation only required the second set to be sorted.

Add a minimal testcase for the WITH rich dep case from the original report. Technically the same issue could occur with WITHOUT rich dependencies and rpmdb lookups through dbiFindMatches() but I don't reproducers for those so just fixing the code for the "obvious" error.

I'm not 100% confident this addresses all such assumptions in the codebase. dbiIndexSet should really use a data structure that doesn't require manual sorting like this, but then that's a much bigger change as the rpmdb code is currently accessing the set members via an index...

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2360342