### PR TITLE
Fix colon separated lists in rpm-config(5)

### DIFF
--- a/docs/man/rpm-config.5.scd
+++ b/docs/man/rpm-config.5.scd
@@ -107,8 +107,8 @@ opposed opposed to just package building) parts:
 *%\_passwd_path* _PATH_
 	Location of passwd(5) files as : separated list
 
-*%\_pkgverify_digests* _HASHALGO_[:_HASHALGO_:...]
-	Colon separated lists of hash algorithms to calculate digests on the
+*%\_pkgverify_digests* _HASHALGOS_
+	A colon separated list of hash algorithms to calculate digests on the
 	entire package files during verification. The calculated digests
 	are stored in the *Packagedigests* tag of packages in the rpmdb,
 	and the corresponding algorithms in in the *Packagedigestalgos* tag.


### PR DESCRIPTION
Use a consistent style and fix the wrong plural (lists) in %_pkgverify_digests while at it.