### PR TITLE
Avoid duplicating package digests with yum/dnf

### DIFF
--- a/lib/transaction.cc
+++ b/lib/transaction.cc
@@ -1265,7 +1265,8 @@ static int verifyPackage(rpmts ts, rpmte p, struct rpmvs_s *vs, int vfylevel)
     if (fd != NULL) {
 	ARGI_t ids = initPkgDigests(fd);
 	prc = rpmpkgRead(vs, fd, NULL, NULL, &vd.msg);
-	finiPkgDigests(fd, ids, prc ? NULL : auxh);
+	int test = rpmtsFlags(ts) & RPMTRANS_FLAG_TEST;
+	finiPkgDigests(fd, ids, (test || prc) ? NULL : auxh);
 	rpmtsNotify(ts, p, RPMCALLBACK_INST_CLOSE_FILE, 0, 0);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TESTSUITE_AT
 	rpmmacro.at
 	rpmdevel.at
 	rpmpython.at
+	rpmpython2.at
 	rpmdepmatch.at
 	rpmquery.at
 	rpmspec.at

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -132,6 +132,14 @@ runroot()
     snapshot exec "$@"
 }
 
+runpython()
+{
+    snapshot exec \
+	--setenv LD_PRELOAD ${ASANLIB} \
+	--setenv ASAN_OPTIONS detect_leaks=0 \
+	"$@"
+}
+
 runroot_user()
 {
     case $1 in

--- a/tests/mktree.common
+++ b/tests/mktree.common
@@ -20,6 +20,7 @@ make_install()
     mkdir -p $DESTDIR/$script_dir
     cp rpmtests atlocal mktree.common setup.sh $DESTDIR/$script_dir/
     cp @CMAKE_CURRENT_SOURCE_DIR@/rpmtests.sh $DESTDIR/$script_dir/
+    cp @CMAKE_CURRENT_SOURCE_DIR@/prpm.py $DESTDIR/@CMAKE_INSTALL_BINDIR@
 
     touch $DESTDIR/.rpmtestsuite
 }

--- a/tests/prpm.py
+++ b/tests/prpm.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+
+import rpm
+import argparse
+
+class transCb:
+    fds = {}
+
+    def __call__(self, what, amount, total, key, data):
+        if what == rpm.RPMCALLBACK_INST_OPEN_FILE:
+            f = open(key, 'rb')
+            self.fds[key] = f
+            return f.fileno()
+        elif what == rpm.RPMCALLBACK_INST_CLOSE_FILE:
+            del self.fds[key]
+
+def doprobs(ts):
+    for p in ts.problems():
+        print(p)
+
+def runts(ts):
+    probs = ts.run(transCb(), "")
+    if probs:
+        doprobs(ts)
+        return 1
+    return 0
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--install', nargs='+', default=[])
+    parser.add_argument('-u', '--upgrade', nargs='+', default=[])
+    parser.add_argument('-e', '--erase', nargs='+', default=[])
+    parser.add_argument('-r', '--reinstall', nargs='+', default=[])
+    parser.add_argument('-R', '--restore', nargs='+', default=[])
+    parser.add_argument('--root', default='/', action='store')
+    parser.add_argument('-n', '--dry-run', action='store_true')
+    parser.add_argument('--nosignature', action='store_true')
+    parser.add_argument('--nodeps', action='store_true')
+    parser.add_argument('--noorder', action='store_true')
+    parser.add_argument('-v', '--verbose', action='store_true')
+    args = parser.parse_args()
+
+    ts = rpm.ts(args.root)
+    ovflags = ts.setVSFlags(ts.getVSFlags() | rpm.RPMVSF_MASK_NOSIGNATURES)
+    for arg in args.install:
+        ts.addInstall(arg, arg, 'i')
+    for arg in args.upgrade:
+        ts.addInstall(arg, arg, 'u')
+    for arg in args.reinstall:
+        ts.addReinstall(arg, arg)
+    for arg in args.restore:
+        ts.addRestore(arg, arg)
+    for arg in args.erase:
+        ts.addErase(arg)
+    ts.setVSFlags(ovflags)
+
+    if args.nosignature:
+        ts.setVfyLevel(rpm.RPMSIG_DIGEST_TYPE)
+
+    if not args.noorder:
+        ts.order()
+
+    if not args.nodeps:
+        rc = ts.check()
+        if rc:
+            doprobs(ts)
+            exit(rc)
+
+    oflags = ts.setFlags(rpm.RPMTRANS_FLAG_TEST)
+    if args.verbose:
+        print("Testing")
+    rc = runts(ts)
+    ts.setFlags(oflags)
+
+    if rc == 0 and not args.dry_run:
+        if args.verbose:
+            print("Committing")
+        rc = runts(ts)
+
+    exit(rc)

--- a/tests/rpmpython2.at
+++ b/tests/rpmpython2.at
@@ -1,0 +1,31 @@
+
+RPMTEST_SETUP_RW([prpm install])
+AT_KEYWORDS([install python])
+AT_SKIP_IF([$PYTHON_DISABLED])
+
+RPMTEST_CHECK([
+runpython prpm.py --nodeps --nosignature \
+		-i /data/RPMS/hello-2.0-1.x86_64.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runpython prpm.py --nodeps --nosignature \
+		-i /data/RPMS/hlinktest-1.0-1.noarch.rpm \
+		-e hello
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -qa
+],
+[0],
+[hlinktest-1.0-1.noarch
+],
+[])
+
+RPMTEST_CLEANUP

--- a/tests/rpmpython2.at
+++ b/tests/rpmpython2.at
@@ -11,6 +11,15 @@ runpython prpm.py --nodeps --nosignature \
 [],
 [])
 
+RPMTEST_CHECK([[
+runroot rpm -qa --qf "[%{packagedigestalgos:hashalgo} %{packagedigests}\n]"
+]],
+[0],
+[SHA256 e05a5191e214b1f05ae2448ebe493e55c6313ab68eaf040b83baa80e25f15d54
+SHA512 5e0a11bf9c4f353b9197446d722e66cc322030e164929356e3fb669201597be77f3a44b4bd6f4fddf8746768809b43dae28f4fad1de315ef42a78e130847eb05
+],
+[])
+
 RPMTEST_CHECK([
 runpython prpm.py --nodeps --nosignature \
 		-i /data/RPMS/hlinktest-1.0-1.noarch.rpm \


### PR DESCRIPTION
Clients like yum/dnf like to do a test-transaction before the real thing, causing verification to run twice and thus duplicating package digests. Skip the header adding on a test transaction to avoid this.
  
We can now test this with prpm.py from the previous commit. It means this stuff gets tested twice. Oh well.

Fixes: #3735
