### PR TITLE
Add an API for per-package verify level control + python bindings

### DIFF
--- a/include/rpm/rpmte.h
+++ b/include/rpm/rpmte.h
@@ -264,6 +264,23 @@ rpmfiles rpmteFiles(rpmte te);
  */
 int rpmteVerified(rpmte te);
 
+/** \ingroup rpmte
+ * Get enforced per-package verify level. If per-package verify level
+ * isn't set for this element, rpmtsVfyLevel() value is returned.
+ * @param te            transaction element
+ * @return              package verify level
+ */
+int rpmteVfyLevel(rpmte te);
+
+/** \ingroup rpmte
+ * Set enforced per-package verify level.
+ * vfylevel -1 means using transaction verify level.
+ * @param te            transaction set
+ * @param vfylevel      new per-package verify level
+ * @return              old per-package verify level
+ */
+int rpmteSetVfyLevel(rpmte te, int vfylevel);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/rpmte.cc
+++ b/lib/rpmte.cc
@@ -65,6 +65,7 @@ struct rpmte_s {
     int nrelocs;		/*!< (TR_ADDED) No. of relocations. */
     uint8_t *badrelocs;		/*!< (TR_ADDED) Bad relocations (or NULL) */
     FD_t fd;			/*!< (TR_ADDED) Payload file descriptor. */
+    int vfylevel;		/*!< (TR_ADDED) Per-pkg verify level (if any) */
     int verified;		/*!< (TR_ADDED) Verification status */
     int addop;			/*!< (TR_ADDED) RPMTE_INSTALL/UPDATE/REINSTALL */
 
@@ -176,6 +177,7 @@ static int addTE(rpmte p, Header h, fnpyKey key, rpmRelocation * relocs)
 
     p->pkgFileSize = 0;
     p->headerSize = headerSizeof(h, HEADER_MAGIC_NO);
+    p->vfylevel = -1;
 
     p->dependencies[RPMTAG_NAME] = \
 	rpmdsThisPool(tspool, h, RPMTAG_PROVIDENAME, RPMSENSE_EQUAL);
@@ -786,6 +788,24 @@ void rpmteSetVerified(rpmte te, int verified)
 int rpmteVerified(rpmte te)
 {
     return (te != NULL) ? te->verified : 0;
+}
+
+int rpmteSetVfyLevel(rpmte te, int vfylevel)
+{
+    int ovfylevel = -1;
+    if (te != NULL) {
+	ovfylevel = te->vfylevel;
+	te->vfylevel = vfylevel;
+    }
+    return ovfylevel;
+}
+
+int rpmteVfyLevel(rpmte te)
+{
+    int vfylevel = -1;
+    if (te != NULL)
+	vfylevel = (te->vfylevel >= 0) ? te->vfylevel : rpmtsVfyLevel(te->ts);
+    return vfylevel;
 }
 
 int rpmteAddOp(rpmte te)

--- a/lib/transaction.cc
+++ b/lib/transaction.cc
@@ -1296,7 +1296,6 @@ static int verifyPackageFiles(rpmts ts, rpm_loff_t total)
     rpmte p;
     rpm_loff_t oc = 0;
     rpmVSFlags vsflags = rpmtsVfyFlags(ts);
-    int vfylevel = rpmtsVfyLevel(ts);
 
     rpmtsNotify(ts, NULL, RPMCALLBACK_VERIFY_START, 0, total);
 
@@ -1304,6 +1303,7 @@ static int verifyPackageFiles(rpmts ts, rpm_loff_t total)
 
     pi = rpmtsiInit(ts);
     while ((p = rpmtsiNext(pi, TR_ADDED))) {
+	int vfylevel = rpmteVfyLevel(p);
 	struct rpmvs_s *vs = rpmvsCreate(vfylevel, vsflags, keyring);
 	rpmtsNotify(ts, p, RPMCALLBACK_VERIFY_PROGRESS, oc++, total);
 	verifyPackage(ts, p, vs, vfylevel);

--- a/plugins/audit.c
+++ b/plugins/audit.c
@@ -68,7 +68,6 @@ static rpmRC audit_tsm_post(rpmPlugin plugin, rpmts ts, int res)
     int nelem = rpmtsNElements(ts);
     struct teop *ops = xcalloc(nelem, sizeof(*ops));
     char *dir = audit_encode_nv_string("root_dir", rpmtsRootDir(ts), 0);
-    int enforce = (rpmtsVfyLevel(ts) & RPMSIG_SIGNATURE_TYPE) != 0;
 
     getAuditOps(ts, ops, nelem);
 
@@ -80,6 +79,7 @@ static rpmRC audit_tsm_post(rpmPlugin plugin, rpmts ts, int res)
 	    char *eventTxt = NULL;
 	    int verified = (rpmteVerified(p) & RPMSIG_SIGNATURE_TYPE) ? 1 : 0;
 	    int result = (rpmteFailed(p) == 0);
+	    int enforce = (rpmteVfyLevel(p) & RPMSIG_SIGNATURE_TYPE) != 0;
 
 	    rasprintf(&eventTxt,
 		    "op=%s %s sw_type=rpm key_enforce=%u gpg_res=%u %s",

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -209,6 +209,20 @@ rpmte_Verified(rpmteObject * s)
     return Py_BuildValue("i", rpmteVerified(s->te));
 }
 
+static PyObject *
+rpmte_VfyLevel(rpmteObject *s)
+{
+    return Py_BuildValue("i", rpmteVfyLevel(s->te));
+}
+
+static PyObject *
+rpmte_SetVfyLevel(rpmteObject *s, PyObject *arg)
+{
+    int vfylevel = -1;
+    if (!PyArg_Parse(arg, "i", &vfylevel))
+	return NULL;
+    return Py_BuildValue("i", rpmteSetVfyLevel(s->te, vfylevel));
+}
 
 static struct PyMethodDef rpmte_methods[] = {
     {"Type",	(PyCFunction)rpmte_TEType,	METH_NOARGS,
@@ -257,6 +271,10 @@ static struct PyMethodDef rpmte_methods[] = {
 "te.Files() -- Return file info set of element.\n" },
     {"Verified",(PyCFunction)rpmte_Verified,	METH_NOARGS,
 "te.Verified() -- Return element verification status.\n" },
+    {"VfyLevel",(PyCFunction)rpmte_VfyLevel,	METH_NOARGS,
+     "Return per-element verification level.\n" },
+    {"SetVfyLevel",(PyCFunction)rpmte_SetVfyLevel, METH_O,
+     "Set per-element verification level.\n" },
     {NULL,		NULL}		/* sentinel */
 };
 

--- a/tests/prpm.py
+++ b/tests/prpm.py
@@ -25,6 +25,11 @@ def runts(ts):
         return 1
     return 0
 
+def matchTe(te, args):
+    if te.NEVRA() in args or te.NEVR() in args or te.N() in args:
+        return True
+    return False
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-i', '--install', nargs='+', default=[])
@@ -35,6 +40,7 @@ if __name__ == '__main__':
     parser.add_argument('--root', default='/', action='store')
     parser.add_argument('-n', '--dry-run', action='store_true')
     parser.add_argument('--nosignature', action='store_true')
+    parser.add_argument('--skip-signature', nargs='+', default=[])
     parser.add_argument('--nodeps', action='store_true')
     parser.add_argument('--noorder', action='store_true')
     parser.add_argument('-v', '--verbose', action='store_true')
@@ -56,6 +62,11 @@ if __name__ == '__main__':
 
     if args.nosignature:
         ts.setVfyLevel(rpm.RPMSIG_DIGEST_TYPE)
+
+    if args.skip_signature:
+        for te in ts:
+            if te.Type() == rpm.TR_ADDED and matchTe(te, args.skip_signature):
+                te.SetVfyLevel(rpm.RPMSIG_DIGEST_TYPE)
 
     if not args.noorder:
         ts.order()

--- a/tests/rpmpython2.at
+++ b/tests/rpmpython2.at
@@ -37,4 +37,23 @@ runroot rpm -qa
 ],
 [])
 
+RPMTEST_CHECK([
+runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+runpython prpm.py --nodeps --skip-signature=foo \
+		-i /data/RPMS/foo-1.0-1.noarch.rpm \
+		-u /data/RPMS/hello-2.0-1.x86_64-signed.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -qa
+],
+[0],
+[hlinktest-1.0-1.noarch
+hello-2.0-1.x86_64
+foo-1.0-1.noarch
+],
+[])
 RPMTEST_CLEANUP


### PR DESCRIPTION
When added in 4.14.2, the grand idea was that the enforcing signature policy would be something global that you just don't skip. But reality is more complicated than that, and forcing *all* signatures to be skipped if you need to install one that isn't signed (eg a freshly built package inside a build-system) does not improve security, it makes it so much worse.

So, add a minimal API for getting and setting the verify level per transaction element, in addition to the existing global control and update the main vereify loop and the audit plugin to log the enforcing state on per-element basis. Add a test utilizing the new prpm.py test program.

Fixes: #3604