### PR TITLE
Fix a regression when calling rpmReadPackageFile() with NULL ts

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TESTSUITE_AT
 	rpmgeneral.at
 	rpmvercmp.at
 	rpmmacro.at
+	rpmapi.at
 	rpmdevel.at
 	rpmpython.at
 	rpmpython2.at
@@ -61,10 +62,10 @@ foreach(at ${TESTSUITE_AT})
 	FILE(APPEND ${CMAKE_CURRENT_BINARY_DIR}/rpmtests.at "m4_include([${at}])\n")
 endforeach()
 
-set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint)
+set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint readpkgnullts)
 foreach(prg ${TESTPROGS})
 	add_executable(${prg} EXCLUDE_FROM_ALL ${prg}.c)
-	target_link_libraries(${prg} PRIVATE librpmio)
+	target_link_libraries(${prg} PRIVATE librpm)
 endforeach()
 string(REPLACE ";" " " TESTPROG_NAMES "${TESTPROGS}")
 

--- a/tests/readpkgnullts.c
+++ b/tests/readpkgnullts.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <rpm/rpmlib.h>
+
+int main(int argc, char *argv[])
+{
+    Header h = NULL;
+    FD_t fd = Fopen(argv[1], "r");
+    int rc = rpmReadPackageFile(NULL, fd, argv[1], &h);
+    if (h != NULL) {
+	char *nevra = headerGetAsString(h, RPMTAG_NEVRA);
+	printf("%s\n", nevra);
+	free(nevra);
+    }
+
+    Fclose(fd);
+    headerFree(h);
+    return rc;
+}

--- a/tests/rpmapi.at
+++ b/tests/rpmapi.at
@@ -1,0 +1,13 @@
+AT_BANNER([RPM API tests])
+
+RPMTEST_SETUP([[rpmReadPackage() with NULL ts]])
+AT_KEYWORDS([[api signature]])
+RPMTEST_CHECK([[
+readpkgnullts /data/RPMS/hello-2.0-1.x86_64-signed.rpm
+]],
+[4],
+[hello-2.0-1.x86_64
+],
+[warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+])
+RPMTEST_CLEANUP


### PR DESCRIPTION
Commit 09510e413dbbdecfa6d65406a31517c79dd6c773 introduced unconditional dereferencing of the keyring during verification, and so segfaults on NULL keyring. That can't happen within rpm itself, so we need a new test program to trigger it: call rpmReadPackageFile() with NULL ts.

Start a new test group of API tests, we'll need to do more of these. I wasted an hour or two looking for a way to reproduce this by rpm or the python bindings when writing this tiny test-program took all of five minutes.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2362996