### PR TITLE
Docs: Link to lua docs, in macros manual

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -116,13 +116,13 @@ various common operations.
 
 | Macro            | Description | Introduced
 | ---------------- | ----------- | ----------
-| `%{gsub:...}`    | replace occurences of pattern in a string (see Lua `string.gsub()`) | 4.19.0
+| `%{gsub:...}`    | replace occurences of pattern in a string (see Lua [`string.gsub()`][]) | 4.19.0
 | `%{len:...}`     | string length | 4.19.0
 | `%{lower:...}`   | lowercase a string | 4.19.0
-| `%{rep:...}`     | repeat a string (see Lua `string.rep()`) | 4.19.0
+| `%{rep:...}`     | repeat a string (see Lua [`string.rep()`][]) | 4.19.0
 | `%{reverse:...}` | reverse a string | 4.19.0
 | `%{span:...}`    | as-is string, handy for wrapping multiline macros | 6.0.0
-| `%{sub:...}`     | expand to substring (see Lua `string.sub()`) | 4.19.0
+| `%{sub:...}`     | expand to substring (see Lua [`string.sub()`][]) | 4.19.0
 | `%{upper:...}`   | uppercase a string | 4.19.0
 | `%{shescape:...}`| single quote with escapes for use in shell | 4.18.0
 | `%{shrink:...}`  | trim leading and trailing whitespace, reduce intermediate whitespace to a single space | 4.14.0
@@ -418,3 +418,8 @@ packaging similar to the autoconf variables that are used in building packages:
 | `%_oldincludedir`  | /usr/include
 | `%_infodir`        | %{_datadir}/info
 | `%_mandir`         | %{_datadir}/man
+
+
+[`string.gsub()`]: https://www.lua.org/manual/5.4/manual.html#pdf-string.gsub
+[`string.rep()`]: https://www.lua.org/manual/5.4/manual.html#pdf-string.rep
+[`string.sub()`]: https://www.lua.org/manual/5.4/manual.html#pdf-string.sub

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -137,7 +137,7 @@ various common operations.
 | `%{suffix:...}`     | expand to suffix part of a file name |
 | `%{url2path:...}`   | convert url to a local path |
 | `%{uncompress:...}` | expand to a command for outputting argument file to stdout, uncompressing as needed |
-| `%{xdg:...}`        | XDG base directory for `cache`, config`, `data` or `state` | 6.0.0
+| `%{xdg:...}`        | XDG base directory for `cache`, `config`, `data` or `state` | 6.0.0
 
 ### Environment info
 


### PR DESCRIPTION
Some macro functionality is described in terms of Lua functions, e.g.
`%{rep:...}`: "repeat a string (see Lua `string.rep()`)".

When those Lua functions are mentioned, link to the appropriate part of the Lua 5.4 documentation.

I made the links by reference, and placed the URLs at the end of the file. That way, the documentation source stays relatively readable.

Also fixed a minor syntax issue (a missing backtick on an inline literal).