### PR TITLE
Fix various minor issues in the man pages

### DIFF
--- a/docs/man/rpm.8.scd
+++ b/docs/man/rpm.8.scd
@@ -43,7 +43,7 @@ code and recipe necessary to produce binary packages.
 *--verify*
 	Verify package(s), comparing information about the installed files in
 	the package with information about the files taken from the package
-	metadata stored in the rpm database. Among other things, verifying
+	metadata stored in the *rpm* database. Among other things, verifying
 	compares the size, digest, permissions, type, owner and group of each
 	file. Any discrepancies are displayed.
 *-q*,
@@ -104,7 +104,7 @@ See *rpm-common*(8) for the options common to all operations.
 
 # INSTALL AND UPGRADE OPTIONS
 *--allfiles*
-	Installs or upgrades all the missingok files in the package,
+	Installs or upgrades all the *missingok* files in the package,
 	regardless if they exist.
 
 *--badreloc*

--- a/docs/man/rpm2archive.1.scd
+++ b/docs/man/rpm2archive.1.scd
@@ -18,8 +18,8 @@ If a '-' argument is given, an rpm stream is read from standard in.
 If standard out is connected to a terminal, the output is written to tar files
 with a ".tgz" suffix, *gzip*(1) compressed by default.
 
-In opposite to *rpm2cpio* *rpm2archive* also works with RPM packages
-containing files greater than 4GB which are not supported by *cpio*.
+In opposite to *rpm2cpio*(1) *rpm2archive* also works with RPM packages
+containing files greater than 4GB which are not supported by *cpio*(1).
 
 # OPTIONS
 

--- a/docs/man/rpmbuild.1.scd
+++ b/docs/man/rpmbuild.1.scd
@@ -89,7 +89,7 @@ all the stages preceding it), and is one of:
 	Build just the source package, but also parse and include dynamic
 	build dependencies - executes up to and including the
 	*%generate_buildrequires* stage and then skips straight to the
-	assembly stage, without creating binary packages. This command can
+	assembly stage, without creating binary packages. This option can
 	be used to fully resolve dynamic build dependencies. See the
 	*DYNAMIC BUILD DEPENDENCIES* section for details.
 
@@ -191,7 +191,7 @@ are satisfied is to run the *-br* option, install the new
 dependencies of the _buildreqs.nosrc.rpm_ package and repeat the whole
 procedure until *rpmbuild* no longer exits with code 11.
 
-If the *-br* command is coupled with *--nodeps*, exit code 11 is
+If the *-br* option is coupled with *--nodeps*, exit code 11 is
 always returned and a _buildreqs.nosrc.rpm_ package is always created.
 
 # FILES

--- a/docs/man/rpmkeys.8.scd
+++ b/docs/man/rpmkeys.8.scd
@@ -123,7 +123,7 @@ On success, 0 is returned, a non-zero failure code otherwise.
 # SEE ALSO
 *popt*(3), *rpm*(8), *rpm-common*(8), *rpm-config*(5), *rpmsign*(1)
 
-*rpmkeys --help* - as rpm supports customizing the options via popt
+*rpmkeys --help* - as *rpm*(8) supports customizing the options via popt
 aliases it's impossible to guarantee that what's described in the
 manual matches what's available.
 

--- a/docs/man/rpmsort.1.scd
+++ b/docs/man/rpmsort.1.scd
@@ -7,8 +7,8 @@ rpmsort - Sort input by RPM Package Manager (RPM) versioning
 *rpmsort* [ _FILE_ ... ]
 
 # DESCRIPTION
-*rpmsort*(1) sorts the input files, and writes a sorted list to standard
-out - like *sort*(1), but aware of RPM versioning.
+*rpmsort*(1) sorts the content of the input files, and writes a sorted list
+to standard out - like *sort*(1), but aware of RPM versioning.
 
 # ARGUMENTS
 _FILE_


### PR DESCRIPTION
These have been reported by the manpage-l10n project (https://manpages-l10n-team.pages.debian.net/manpages-l10n/)

Thanks to https://github.com/hmartink for doing so!

These reported issues were fixed:
```
Man page: rpm2archive.8
Issue 1:  \\f[B]rpm2cpio\\f[R] → \\f[B]rpm2cpio\\f[R](8)
Issue 2:  \\f[B]cpio\\f[R] → \\f[B]cpio\\f[R](1)

"In opposite to \\f[B]rpm2cpio\\f[R] \\f[B]rpm2archive\\f[R] also works with " "RPM packages containing files greater than 4GB which are not supported by " "\\f[B]cpio\\f[R].\\fR"
--
Man page: rpm.8
Issue:    missingok? This is not present in the UI translation

"Installs or upgrades all the missingok files in the package, regardless if " "they exist."

Made missingok bold as it is a keyword.

--
Man page: rpm.8
Issue 2:  rpm → \\f[B]rpm\\f[R]

"Verifying a package compares information about the installed files in the " "package with information about the files taken from the package metadata " "stored in the rpm database.  Among other things, verifying compares the " "size, digest, permissions, type, owner and group of each file.  Any " "discrepancies are displayed.  Files that were not installed from the " "package, for example, documentation files excluded on installation using the " "\\[dq]\\f[B]--excludedocs\\f[R]\\[dq] option, will be silently ignored.\\fR" --
Man page: rpmbuild.8
Issue:    the \\f[B]-br\\f[R] command → the \\f[B]-br\\f[R] option

"If the \\f[B]-br\\f[R] command is coupled with \\f[B]--nodeps\\f[R], exit " "code 11 is always returned and a \\f[I]buildreqs.nosrc.rpm\\f[R] package is " "always created.\\fR"
--
Man page: rpmkeys.8
Issue:    rpm → \\f[B]rpm\\f[R](8)

"\\f[B]rpmkeys --help\\f[R] - as rpm supports customizing the options via " "popt aliases it\\[aq]s impossible to guarantee that what\\[aq]s described in " "the manual matches what\\[aq]s available.\\fR"
--
Man page: rpmsort.8
Issue:    Are versions read from stdin? Or are files read?

"If \\[aq]-\\[aq] is given as an argument, or no arguments are given, " "versions are read from standard in and written to standard out."

Reworded DESCRIPTION for clarity
```
Resolves: #3738