### PR TITLE
Rework the way rpm package format version is passed around

### DIFF
--- a/build/files.cc
+++ b/build/files.cc
@@ -1177,7 +1177,7 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
 			rpmstrPoolStr(fl->pool, flp->gname));
 
 	/* Use 64bit filesizes always on v6, on older only if required. */
-	if (pkg->rpmformat >= 6 || fl->largeFiles) {
+	if (spec->rpmformat >= 6 || fl->largeFiles) {
 	    rpm_loff_t rsize64 = (rpm_loff_t)flp->fl_size;
 	    headerPutUint64(h, RPMTAG_LONGFILESIZES, &rsize64, 1);
             (void) rpmlibNeedsFeature(pkg, "LargeFiles", "4.12.0-1");
@@ -1281,7 +1281,7 @@ static void genCpioListAndHeader(FileList fl, rpmSpec spec, Package pkg, int isS
     pkg->dpaths[npaths] = NULL;
 
     /* Use 64bit sizes always on v6, on older only if required. */
-    if (pkg->rpmformat < 6 && totalFileSize < UINT32_MAX) {
+    if (spec->rpmformat < 6 && totalFileSize < UINT32_MAX) {
 	rpm_off_t totalsize = totalFileSize;
 	headerPutUint32(h, RPMTAG_SIZE, &totalsize, 1);
     } else {

--- a/build/parseSpec.cc
+++ b/build/parseSpec.cc
@@ -1361,12 +1361,21 @@ static rpmRC finalizeSpec(rpmSpec spec)
 	headerPutString(spec->packages->header, RPMTAG_GROUP, "Unspecified");
     }
 
+    spec->rpmformat = rpmExpandNumeric("%{?_rpmformat}");
+
+    if (spec->rpmformat != 4 && spec->rpmformat != 6) {
+	int default_rpmformat = 4;
+	rpmlog(RPMLOG_WARNING,
+		   _("invalid rpm format %d requested, using %d\n"),
+		   spec->rpmformat, default_rpmformat);
+	spec->rpmformat = 4;
+    }
+
     for (Package pkg = spec->packages; pkg != NULL; pkg = pkg->next) {
 	headerPutString(pkg->header, RPMTAG_OS, os);
 	headerPutString(pkg->header, RPMTAG_PLATFORM, platform);
 	headerPutString(pkg->header, RPMTAG_OPTFLAGS, optflags);
 	headerPutString(pkg->header, RPMTAG_SOURCERPM, spec->sourceRpmName);
-
 
 	if (pkg != spec->packages) {
 	    copyInheritedTags(pkg->header, spec->packages->header);

--- a/build/rpmbuild_internal.hh
+++ b/build/rpmbuild_internal.hh
@@ -128,6 +128,7 @@ typedef struct Package_s * Package;
 struct rpmSpec_s {
     char * buildHost;
     rpm_time_t buildTime;
+    unsigned int rpmformat;	/* v4, v6? */
 
     char * specFile;	/*!< Name of the spec file. */
     char * buildRoot;
@@ -189,7 +190,6 @@ struct Package_s {
     rpmds dependencies[PACKAGE_NUM_DEPS];
     rpmfiles cpioList;
     ARGV_t dpaths;
-    unsigned int rpmformat;	/* v4, v6? */
 
     struct Source * icon;
 

--- a/build/rpmfc.cc
+++ b/build/rpmfc.cc
@@ -1702,7 +1702,7 @@ rpmRC rpmfcGenerateDepends(const rpmSpec spec, Package pkg)
     /* Add per-file colors(#files) */
     headerPutUint32(pkg->header, RPMTAG_FILECOLORS, fc->fcolor.data(), fc->nfiles);
     
-    if (pkg->rpmformat >= 6) {
+    if (spec->rpmformat >= 6) {
 	/* Add mime types(#mime types) */
 	for (rpmsid id = 1; id <= rpmstrPoolNumStr(fc->mdict); id++) {
 	    headerPutString(pkg->header, RPMTAG_MIMEDICT,

--- a/build/spec.cc
+++ b/build/spec.cc
@@ -15,7 +15,6 @@
 
 #include "rpmfi_internal.hh"		/* rpmfiles stuff */
 #include "rpmbuild_internal.hh"
-#include "rpmlog_internal.hh"
 
 #include "debug.h"
 
@@ -103,15 +102,6 @@ Package newPackage(const char *name, rpmstrPool pool, Package *pkglist)
     p->policyList = NULL;
     p->pool = rpmstrPoolLink(pool);
     p->dpaths = NULL;
-    p->rpmformat = rpmExpandNumeric("%{?_rpmformat}");
-
-    if (p->rpmformat != 4 && p->rpmformat != 6) {
-	int default_rpmformat = 4;
-	rpmlogOnce(0, "rpmformat", RPMLOG_WARNING,
-		   _("invalid rpm format %d requested, using %d\n"),
-		   p->rpmformat, default_rpmformat);
-	p->rpmformat = 4;
-    }
 
     if (name)
 	p->name = rpmstrPoolId(p->pool, name, 1);

--- a/tests/data/SPECS/subpkg-mini.spec
+++ b/tests/data/SPECS/subpkg-mini.spec
@@ -1,0 +1,28 @@
+%bcond_with pkgfmt
+
+%if %{with pkgfmt}
+%define _rpmformat %{_myrpmformat}
+%endif
+
+Name:           subpkg-mini
+Version:        1.0
+Release:        1
+Summary:        Test
+License:        Public Domain
+
+%description
+%{summary}.
+
+%package test2
+Summary: Test2.
+%description test2
+
+%package test3
+Summary: Test3.
+%description test3
+
+%files
+
+%files test2
+
+%files test3

--- a/tests/rpmpkgfmt.at
+++ b/tests/rpmpkgfmt.at
@@ -170,3 +170,53 @@ test-test3-1.0-1.x86_64
 [warning: invalid rpm format 9 requested, using 4
 ])
 RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([spec overridden format])
+AT_KEYWORDS([rpmformat build])
+
+RPMTEST_CHECK([
+runroot rpmbuild -ba \
+		--quiet \
+		--with pkgfmt \
+		--define "_myrpmformat 6" \
+		/data/SPECS/subpkg-mini.spec
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp --qf "%{rpmformat} %{name}\n" \
+	/build/RPMS/*/subpkg-mini-*.rpm /build/SRPMS/subpkg-mini*.rpm
+]],
+[0],
+[6 subpkg-mini
+6 subpkg-mini-test2
+6 subpkg-mini-test3
+6 subpkg-mini
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmbuild -ba \
+		--quiet \
+		--with pkgfmt \
+		--define "_myrpmformat 4" \
+		/data/SPECS/subpkg-mini.spec
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp --qf "%{rpmformat} %{name}\n" \
+	/build/RPMS/*/subpkg-mini-*.rpm /build/SRPMS/subpkg-mini*.rpm
+]],
+[0],
+[4 subpkg-mini
+4 subpkg-mini-test2
+4 subpkg-mini-test3
+4 subpkg-mini
+],
+[])
+RPMTEST_CLEANUP


### PR DESCRIPTION
Commit c1ee3881268f3cfed524d1802a0765e24b9b1b98 introduced the package format into the package structure because it seemed to be the path of least pain - the pkg structure was available in all the places that needed this. In retrospective, it's saner to have it centrally in the spec struct and pass around as needed. This avoids rpm's shenanigans with how and when exactly the package structures are initialized, causing inconsistent package versions across a set of packages coming from a single build.

This way we also detect and initialize the format exactly once, and thus avoid having to weed out duplicates from the log.

Add a test that all built packages are of the same version for both 4 and 6 regardless of the default.

Fixes: #3731