### PR TITLE
Move ~/.rpmmacros and ~/.rpmrc to ~/.config/rpm/

### DIFF
--- a/docs/man/rpm-config.5.scd
+++ b/docs/man/rpm-config.5.scd
@@ -38,9 +38,12 @@ _macro path_ uses this to achieve the following hierarchy of settings:
 
 The default _macro path_ can be inspected with *rpm --showrc|grep ^Macro*.
 
-In older versions of rpm, the path of per-user macros was _~/.rpmmacros_.
-This is still processed if it exists and the new configuration directory
-does not exist.
+In older versions of rpm, the path of per-user macros was
+_~/.rpmmacros_.  RPM will try to move this file to the new
+locations. If this is not possible it will create
+_~/.rpmconfig_migration_lock_ to prevent attempting the migration over
+and over again. In this case the file is still processed if it exists
+and the new configuration directory does not exist.
 
 # CONFIGURATION
 The following configurables are supported for the *rpm* runtime (as

--- a/docs/man/rpm-rpmrc.5.scd
+++ b/docs/man/rpm-rpmrc.5.scd
@@ -33,8 +33,11 @@ configuration:
 . User specific configuration
 
 In older rpm versions the path of per-user rpmrc was _~/.rpmrc_.
-This is still processed if it exists and the new configuration directory
-does not exist.
+RPM will try to move this file to the new locations. If this is not
+possible it will create _~/.rpmconfig_migration_lock_ to prevent
+attempting the migration over and over again. In this case the file is
+still processed if it exists and the new configuration directory does
+not exist.
 
 # CONFIGURATION
 _ARCH_ and _OS_ relate to *uname*(2) machine and operating system

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -7,9 +7,9 @@ AT_KEYWORDS([macros])
 
 # .rpmmacros exists, new directory not
 RPMTEST_CHECK([[
-rm -rf ~/.config/rpm ~/.rpmmacros
-touch ~/.rpmmacros
-rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
+runroot rm -rf /root/.config/rpm /root/.rpmmacros
+runroot touch /root/.rpmmacros
+runroot rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
 ]],
 [0],
 [~/.rpmmacros
@@ -48,6 +48,60 @@ SOMENV=/tmp/somewhere rpm --macros "%{getenv:SOMENV}" --eval "%somewhere"
 [/some/where
 ],
 [])
+RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([macro path])
+AT_KEYWORDS([convert .macros])
+RPMTEST_USER
+
+runroot_user rm -f /home/$RPMUSER/.config/rpm
+runroot_user rm -f /home/$RPMUSER/.rpmmacros
+runroot_user rm -f /home/$RPMUSER/.rpmrc
+runroot_user bash -c "echo %foo bar > /home/$RPMUSER/.rpmmacros"
+runroot_user touch "/home/$RPMUSER/.rpmrc"
+
+RPMTEST_CHECK([[
+runroot_user mkdir /home/$RPMUSER/.config
+runroot_user chmod 000 /home/$RPMUSER/.config
+runroot_user rpm -E "%{foo}"
+runroot_user chmod 755 /home/$RPMUSER/.config
+runroot_user ls /home/$RPMUSER/.rpmconfig_migration_lock
+runroot_user rpm -E "%{foo}"
+runroot_user rm /home/$RPMUSER/.rpmconfig_migration_lock
+]],
+[0],
+[bar
+/home/klang/.rpmconfig_migration_lock
+bar
+],
+[error: Could not migrate /home/klang/.rpmmacros to /home/klang/.config/rpm/macros: Permission denied
+error: Could not migrate /home/klang/.rpmrc to /home/klang/.config/rpm/rpmrc: Permission denied
+])
+
+RPMTEST_CHECK([[
+runroot_user readlink /home/$RPMUSER/.rpmmacros
+runroot_user readlink /home/$RPMUSER/.rpmrc
+# don't convert if not tty
+runroot_user rpm -E "%{foo}" < "${RPMTEST}"/data/macros.testfile
+runroot_user readlink /home/$RPMUSER/.rpmmacros
+runroot_user readlink /home/$RPMUSER/.rpmrc
+runroot_user rpm -E "%{foo}"
+runroot_user readlink /home/$RPMUSER/.rpmmacros
+runroot_user readlink /home/$RPMUSER/.rpmrc
+runroot_user rpm -E "%{foo}"
+runroot_user rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
+]],
+[0],
+[bar
+bar
+.config/rpm/macros
+.config/rpm/rpmrc
+bar
+~/.config/rpm/macros
+],
+[warning: Migrated /home/klang/.rpmmacros to /home/klang/.config/rpm/macros (leaving a symlink)
+warning: Migrated /home/klang/.rpmrc to /home/klang/.config/rpm/rpmrc (leaving a symlink)
+])
 RPMTEST_CLEANUP
 
 # ------------------------------


### PR DESCRIPTION
The XDG cofiguration directory is the new default location for the macros and rpmrc file. Migrate legacy files automatically. Create symlinks from the home directory for compatibility with older rpm versions.

Resolves: #3467