### PR TITLE
Fix a couple of shellcheck warnings

### DIFF
--- a/scripts/rpm-setup-autosign
+++ b/scripts/rpm-setup-autosign
@@ -14,12 +14,12 @@ keypath="${rpmhome}/${email}.asc"
 
 function log()
 {
-    echo -e $* 1>&2
+    echo -e "$@" 1>&2
 }
 
 function error()
 {
-    log $*
+    log "$@"
     exit 1
 }
 


### PR DESCRIPTION
```
Error: SHELLCHECK_WARNING (CWE-569): [#def2]
/usr/lib/rpm/rpm-setup-autosign:17:13: warning[SC2048]: Use "$@" (with quotes) to prevent whitespace problems.
   15|   function log()
   16|   {
   17|->     echo -e $* 1>&2
   18|   }
   19|

Error: SHELLCHECK_WARNING (CWE-569): [#def3]
/usr/lib/rpm/rpm-setup-autosign:22:9: warning[SC2048]: Use "$@" (with quotes) to prevent whitespace problems.
   20|   function error()
   21|   {
   22|->     log $*
   23|       exit 1
   24|   }
```

Fixes: https://openscanhub.fedoraproject.org/task/52554/log/added.html#def2