### PR TITLE
Make rpmkeys key lookup case insensitive

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -117,6 +117,15 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [])
 
 RPMTEST_CHECK([
+runroot rpmkeys -l 771b18d3d7baa28734333c424344591e1964c5fc 771B18D3D7BAA28734333C424344591E1964C5FC
+],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+],
+[])
+
+RPMTEST_CHECK([
 runroot rpmkeys -d abcd gimmekey 1111aaaa2222bbbb
 ],
 [1],
@@ -258,6 +267,14 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [])
 
 RPMTEST_CHECK([
+runroot rpmkeys -l 771b18d3d7baa28734333c424344591e1964c5fc 771B18D3D7BAA28734333C424344591E1964C5FC
+],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+],
+[])
+RPMTEST_CHECK([
 runroot rpmkeys --delete abcd gimmekey 1111aaaa2222bbbb
 ],
 [1],
@@ -368,6 +385,14 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 ],
 [])
 
+RPMTEST_CHECK([
+runroot rpmkeys -l 771b18d3d7baa28734333c424344591e1964c5fc 771B18D3D7BAA28734333C424344591E1964C5FC
+],
+[0],
+[771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+771b18d3d7baa28734333c424344591e1964c5fc rpm.org RSA testkey <rsa@rpm.org> public key
+],
+[])
 RPMTEST_CHECK([
 runroot rpmkeys --delete abcd gimmekey 1111aaaa2222bbbb
 ],

--- a/tools/rpmkeys.cc
+++ b/tools/rpmkeys.cc
@@ -89,8 +89,9 @@ static int matchingKeys(rpmts ts, ARGV_const_t args, int callback(rpmPubkey, voi
 	    while ((key = rpmKeyringIteratorNext(iter))) {
 		const char * fp = rpmPubkeyFingerprintAsHex(key);
 		const char * keyid = rpmPubkeyKeyIDAsHex(key);
-		if (!strcmp(*arg, fp) || !strcmp(*arg, keyid) ||
-		    !strcmp(*arg, keyid+8)) {
+		if (!rstrcasecmp(*arg, fp) || !rstrcasecmp(*arg, keyid) ||
+		    !rstrcasecmp(*arg, keyid+8))
+		{
 		    found = true;
 		}
 		if (found)


### PR DESCRIPTION
Both GnuPG and Sequoia use uppercase hex in all their key id / fingerprint output, but accept lowercase for input. Rpm uses and only accepts lowercase hex for these which makes life a PITA when copy-pasting key ids across. Make the key matching case insensitive.

Add test for all backends, although this is an overkill since the matching is done inside the rpmkeys tool rather than the backend. But in case that changes some day...

Fixes: #3721