### PR TITLE
Consolidate payload flags documentation to rpm-payloadflags(5) man page

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -3,6 +3,7 @@ set(core
 	rpm.8 rpmbuild.1 rpmdb.8 rpmkeys.8 rpmsign.1 rpmspec.1
 	rpmdeps.1 rpmgraph.1 rpmlua.1 rpm-common.8 rpmsort.1
 	rpm-macrofile.5 rpm-config.5 rpm-rpmrc.5 rpm-setup-autosign.1
+	rpm-payloadflags.5
 )
 set(extra
 	rpm-plugins.8 rpm-plugin-prioreset.8 rpm-plugin-syslog.8

--- a/docs/man/rpm-payloadflags.5.scd
+++ b/docs/man/rpm-payloadflags.5.scd
@@ -1,0 +1,86 @@
+RPM-PAYLOADFLAGS(5)
+
+# NAME
+*rpm-payloadflags* - RPM payload flags
+
+# SYNOPSIS
+*w*[_FLAGS_]._TYPE_
+
+# DESCRIPTION
+The payload flags determine how the payload of an RPM package is compressed
+when the package is built. The flags are stored in the *Payloadcompressor*
+and *Payloadflags* tags of the package header, which are used to determine
+how to uncompress the payload contents during installation.
+
+The peculiar syntax is directly inherited from librpm's *Fopen()* IO API,
+where *w* means opening a file for writing.
+
+The following compression types are supported, but availability may
+vary depending on how RPM was compiled.
+
+[- _TYPE_
+:< Description
+|  *ufdio*
+:  uncompressed
+|  *gzdio*
+:  gzip (aka zlib)
+|  *bzdio*
+:  bzip2
+|  *xzdio*
+:  xz
+|  *lzdio*
+:  legazy lzma
+|  *zstdio*
+:  zstd
+
+The compression _FLAGS_ must be listed in the following order and can be any of:
+
+[- _FLAGS_
+:< Description
+:- Types
+|  <0-9>
+:  compression level
+:  all (*ufdio* ignores)
+|  T[0-N]
+:  number of threads (no number or 0 = autodetect)
+:  *xzdio*, *zstdio*
+|  L<0-9>
+:  window size(see *--long* in *zstd*(1))
+:  *zstdio*
+
+If a flag is omitted, the compressor's default value will be used.
+
+A higher compression level generally means better compression ratio at the
+cost of increased resource use and compression times.
+
+*T* is equivalent to *T0* and causes the number of threads to be
+automatically detected. Note that while using threads can speed up compression
+considerably, it typically causes the compression ratio to go down, and
+make the output less predicable.
+
+# EXAMPLES
+[[ Mode
+:< Description
+|  *w9.gzdio*
+:  gzip level 9, default for package payload
+|  *w9.bzdio*
+:  bzip2 level 9, bzip2's default
+|  *w.xzdio*
+:  xz default level
+|  *w7T16.xzdio*
+:  xz level 7 using 16 threads
+|  *w7T0.xzdio*
+:  xz level 7, autodetect no. of threads
+|  *w6.lzdio*
+:  lzma (legacy) level 6, lzma's default
+|  *w19T8.zstdio*
+:  zstd level 19 using 8 threads
+|  *w7T.zstdio*
+:  zstd level 7, autodetect no. of threads
+|  *w.ufdio*
+:  uncompressed
+
+# SEE ALSO
+*rpmbuild-config*(5), *rpm-config*(5)
+
+*http://www.rpm.org/*

--- a/docs/manual/tags.md
+++ b/docs/manual/tags.md
@@ -92,8 +92,8 @@ Filedigestalgo    | 5011 | int32        | ID of file digest algorithm. If missin
 Longarchivesize   | 271  | int64        | (Uncompressed) payload size when > 4GB.
 Longsize          | 5009 | int64        | Installed package size when > 4GB.
 Mimedict          | 5116 | int32        | Dictionary of MIME types, only >= v6.
-Payloadcompressor | 1125 | string       | Payload compressor name (as passed to rpmio `Fopen()`)
-Payloadflags      | 1126 | string       | Payload compressor level (as passed to rpmio `Fopen()`)
+Payloadcompressor | 1125 | string       | Payload compressor name (see `rpm-payloadflags`(5))
+Payloadflags      | 1126 | string       | Payload compressor level (see `rpm-payloadflags`(5))
 Payloadformat     | 1124 | string       | Payload format (`cpio`)
 Prefixes          | 1098 | string array | Relocatable prefixes (on relocatable packages).
 Size              | 1009 | int32        | Installed package size.

--- a/include/rpm/rpmio.h
+++ b/include/rpm/rpmio.h
@@ -62,56 +62,11 @@ int Fclose( FD_t fd);
 FD_t	Fdopen(FD_t ofd, const char * fmode);
 
 /** \ingroup rpmio
- * fopen(3) clone.
- *
- * Supports compression.
+ * fopen(3) clone with compression support.
  *
  * The `fmode` parameter is based on that of `fopen(3)`, but may also include a
- * compression method (`type` and `flags`) to use when opening the stream, and
- * has the following format:
- *
- * ```
- * <mode>[flags].<type>
- * ```
- *
- * The compression `type` (compressor) is mandatory, determines the supported
- * `mode` chars (also mandatory), and can be one of the following:
- * 
- * | Type	| Description	    | Mode chars    |
- * |------------|-------------------|---------------|
- * | `ufdio`	| uncompressed	    | `r,w,a,b,+,x` |
- * | `gzdio`	| gzip		    | `r,w,a`	    |
- * | `bzdio`	| bzip2             | `r,w,a`	    |
- * | `xzdio`	| xz                | `r,w,a`	    |
- * | `lzdio`	| lzma (legacy)     | `r,w,a`	    |
- * | `zstdio`	| zstd              | `r,w,a`	    |
- *
- * Compression `flags` must be listed in the following order and can be any of:
- * 
- * | Flag	| Description				    | Types		    |
- * |------------|-------------------------------------------|-----------------------|
- * | `0-9`	| compression level			    | all except `ufdio`    |
- * | `T<0-N>`	| no. of threads (0 = autodetect)	    | `xzdio` and `zstdio`  |
- * | `L<0-9>`	| window size (see `--long` in `zstd(1)`)   | `zstdio`		    |
- *
- * If a flag is omitted, the compressor's default value will be used.
- *
- * \anchor example-mode-strings
- * Example mode strings:
- * 
- * | Mode	    | Description				|
- * |----------------|-------------------------------------------|
- * |`w9.gzdio`	    | gzip level 9, default for package payload	|
- * |`w9.bzdio`	    | bzip2 level 9, bzip2's default		|
- * |`w6.xzdio`	    | xz level 6, xz's default			|
- * |`w.xzdio`	    | xz level 6, xz's default			|
- * |`w7T16.xzdio`   | xz level 7 using 16 threads		|
- * |`w7T0.xzdio`    | xz level 7, autodetect no. of threads	|
- * |`w6.lzdio`	    | lzma (legacy) level 6, lzma's default	|
- * |`w3.zstdio`	    | zstd level 3, zstd's default		|
- * |`w19T8.zstdio`  | zstd level 19 using 8 threads		|
- * |`w7T0.zstdio`   | zstd level 7, autodetect no. of threads   |
- * |`w.ufdio`	    | uncompressed				|
+ * compression method (`type` and `flags`) to use when opening the stream.
+ * See `rpm-payloadflags`(5) manual for details.
  */
 FD_t	Fopen(const char * path,
 			const char * fmode);

--- a/macros.in
+++ b/macros.in
@@ -366,18 +366,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #%packager
 
 #	Compression type and level for source/binary package payloads.
-#		"w9.gzdio"	gzip level 9 (v4 and srpm default)
-#		"w9.bzdio"	bzip2 level 9.
-#		"w6.xzdio"	xz level 6, xz's default.
-#		"w7T16.xzdio"	xz level 7 using 16 threads
-#		"w7T0.xzdio"	xz level 7 using %{getncpus} threads
-#		"w7T.xzdio"	xz level 7 using %{getncpus} threads
-#		"w6.lzdio"	lzma-alone level 6, lzma's default
-#		"w3.zstdio"	zstd level 3, zstd's default
-#		"w19T8.zstdio"	zstd level 19 using 8 threads
-#		"w7T0.zstdio"	zstd level 7 using %{getncpus} threads
-#		"w19.zstdio"	zstd level 19 (v6 default)
-#		"w.ufdio"	uncompressed
+#	See rpm-payloadflags(5).
 #
 #%_source_payload	w9.gzdio
 %_binary_payload	%[ %_rpmformat >=6 ? "w19.zstdio" : "w9.gzdio" ]


### PR DESCRIPTION
Add a new rpm-payloadflags(5) man page update/add pointers where relevant so we don't need to carry the same info in multiple places.

Fixes: #3764