### PR TITLE
Add some signature tag level tests around signing + minor rpmdump updates

### DIFF
--- a/tests/data/misc/rpmdump4-addsign-v6.txt
+++ b/tests/data/misc/rpmdump4-addsign-v6.txt
@@ -1,0 +1,71 @@
+Signature:
+Header magic: 1e8ad8e (reserved: 0)
+Index entries: 9 (144 bytes)
+Data size: 5172 bytes
+Header size: 5316 bytes
+Padding: 4 bytes
+Region entries 9
+Region size 160
+Dribbles: 0
+
+Tag #0 [region]
+	tagno:    62 (Headersignatures)
+	type:      7 (blob)
+	offset: 5156
+	count:    16
+
+	region trailer
+		tagno:    62 (Headersignatures)
+		type:      7 (blob)
+		offset: -144
+		count:    16
+
+Tag #1 [region]
+	tagno:   268 (Rsa)
+	type:      7 (blob)
+	offset:    0
+	count:   382
+
+Tag #2 [region]
+	tagno:   269 (Sha1)
+	type:      6 (string)
+	offset:  382
+	count:     1
+
+Tag #3 [region]
+	tagno:   273 (Sha256)
+	type:      6 (string)
+	offset:  423
+	count:     1
+
+Tag #4 [region]
+	tagno:   278 (Openpgp)
+	type:      8 (argv)
+	offset:  488
+	count:     1
+
+Tag #5 [region]
+	tagno:  1000 (Size)
+	type:      4 (int32)
+	offset: 1004
+	count:     1
+
+Tag #6 [region]
+	tagno:  1004 (Md5)
+	type:      7 (blob)
+	offset: 1008
+	count:    16
+
+Tag #7 [region]
+	tagno:  1007 (Payloadsize)
+	type:      4 (int32)
+	offset: 1024
+	count:     1
+
+Tag #8 [region]
+	tagno:  1008 (Reservedspace)
+	type:      7 (blob)
+	offset: 1028
+	count:  4128
+
+Header:

--- a/tests/data/misc/rpmdump4-delsign-v6.txt
+++ b/tests/data/misc/rpmdump4-delsign-v6.txt
@@ -1,0 +1,59 @@
+Signature:
+Header magic: 1e8ad8e (reserved: 0)
+Index entries: 7 (112 bytes)
+Data size: 4276 bytes
+Header size: 4388 bytes
+Padding: 4 bytes
+Region entries 7
+Region size 128
+Dribbles: 0
+
+Tag #0 [region]
+	tagno:    62 (Headersignatures)
+	type:      7 (blob)
+	offset: 4260
+	count:    16
+
+	region trailer
+		tagno:    62 (Headersignatures)
+		type:      7 (blob)
+		offset: -112
+		count:    16
+
+Tag #1 [region]
+	tagno:   269 (Sha1)
+	type:      6 (string)
+	offset:    0
+	count:     1
+
+Tag #2 [region]
+	tagno:   273 (Sha256)
+	type:      6 (string)
+	offset:   41
+	count:     1
+
+Tag #3 [region]
+	tagno:  1000 (Size)
+	type:      4 (int32)
+	offset:  108
+	count:     1
+
+Tag #4 [region]
+	tagno:  1004 (Md5)
+	type:      7 (blob)
+	offset:  112
+	count:    16
+
+Tag #5 [region]
+	tagno:  1007 (Payloadsize)
+	type:      4 (int32)
+	offset:  128
+	count:     1
+
+Tag #6 [region]
+	tagno:  1008 (Reservedspace)
+	type:      7 (blob)
+	offset:  132
+	count:  4128
+
+Header:

--- a/tests/data/misc/rpmdump6-addsign-v6.txt
+++ b/tests/data/misc/rpmdump6-addsign-v6.txt
@@ -1,0 +1,41 @@
+Signature:
+Header magic: 1e8ad8e (reserved: 0)
+Index entries: 4 (64 bytes)
+Data size: 4722 bytes
+Header size: 4786 bytes
+Padding: 6 bytes
+Region entries 4
+Region size 80
+Dribbles: 0
+
+Tag #0 [region]
+	tagno:    62 (Headersignatures)
+	type:      7 (blob)
+	offset: 4706
+	count:    16
+
+	region trailer
+		tagno:    62 (Headersignatures)
+		type:      7 (blob)
+		offset:  -64
+		count:    16
+
+Tag #1 [region]
+	tagno:   273 (Sha256)
+	type:      6 (string)
+	offset:    0
+	count:     1
+
+Tag #2 [region]
+	tagno:   278 (Openpgp)
+	type:      8 (argv)
+	offset:   65
+	count:     1
+
+Tag #3 [region]
+	tagno:   999 (Reserved)
+	type:      7 (blob)
+	offset:  578
+	count:  4128
+
+Header:

--- a/tests/data/misc/rpmdump6-delsign-v6.txt
+++ b/tests/data/misc/rpmdump6-delsign-v6.txt
@@ -1,0 +1,35 @@
+Signature:
+Header magic: 1e8ad8e (reserved: 0)
+Index entries: 3 (48 bytes)
+Data size: 4209 bytes
+Header size: 4257 bytes
+Padding: 7 bytes
+Region entries 3
+Region size 64
+Dribbles: 0
+
+Tag #0 [region]
+	tagno:    62 (Headersignatures)
+	type:      7 (blob)
+	offset: 4193
+	count:    16
+
+	region trailer
+		tagno:    62 (Headersignatures)
+		type:      7 (blob)
+		offset:  -48
+		count:    16
+
+Tag #1 [region]
+	tagno:   273 (Sha256)
+	type:      6 (string)
+	offset:    0
+	count:     1
+
+Tag #2 [region]
+	tagno:   999 (Reserved)
+	type:      7 (blob)
+	offset:   65
+	count:  4128
+
+Header:

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1563,6 +1563,15 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [])
 
+# XXX the reserve tag size is currently WRONG here due to #3768
+RPMTEST_CHECK([
+cp /data/misc/rpmdump4-addsign-v6.txt expout
+runroot ${RPM_CONFIGDIR_PATH}/rpmdump /tmp/hello-2.0-1.x86_64.rpm | sed -n '/^Signature:$/,/^Header:$/p'
+],
+[0],
+[expout],
+[])
+
 RPMTEST_CHECK([
 # resigning with identical key shouldn't add anything
 runroot rpmsign --addsign --rpmv6 /tmp/hello-2.0-1.x86_64.rpm &> /dev/null
@@ -1645,6 +1654,13 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [])
 
+RPMTEST_CHECK([
+cp /data/misc/rpmdump4-delsign-v6.txt expout
+runroot ${RPM_CONFIGDIR_PATH}/rpmdump /tmp/hello-2.0-1.x86_64.rpm | sed -n '/^Signature:$/,/^Header:$/p'
+],
+[0],
+[expout],
+[])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmsign --addsign multisig v6])
@@ -1673,6 +1689,15 @@ runroot rpmbuild -bb --quiet \
 ],
 [0],
 [],
+[])
+
+# XXX the reserve tag size is currently WRONG here due to #3768
+RPMTEST_CHECK([
+cp /data/misc/rpmdump6-addsign-v6.txt expout
+runroot ${RPM_CONFIGDIR_PATH}/rpmdump /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm| sed -n '/^Signature:$/,/^Header:$/p'
+],
+[0],
+[expout],
 [])
 
 RPMTEST_CHECK([
@@ -1723,6 +1748,21 @@ done
 SIGGPG: (none)
 SIGPGP: (none)
 ],
+[])
+
+RPMTEST_CHECK([
+runroot rpmsign --delsign /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+cp /data/misc/rpmdump6-delsign-v6.txt expout
+runroot ${RPM_CONFIGDIR_PATH}/rpmdump /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm| sed -n '/^Signature:$/,/^Header:$/p'
+],
+[0],
+[expout],
 [])
 RPMTEST_CLEANUP
 

--- a/tools/rpmdump.cc
+++ b/tools/rpmdump.cc
@@ -45,9 +45,9 @@ static const char *sigTagName(uint32_t tag)
     case RPMSIGTAG_LONGARCHIVESIZE: return "Longarchivesize";
     case RPMSIGTAG_SHA256: return "Sha256";
     case RPMSIGTAG_FILESIGNATURES: return "Filesignatures";
-    case RPMSIGTAG_FILESIGNATURELENGTH: return "filesignaturelength";
-    case RPMSIGTAG_VERITYSIGNATURES: return "veritysignatures";
-    case RPMSIGTAG_VERITYSIGNATUREALGO: return "veritysignaturealgo";
+    case RPMSIGTAG_FILESIGNATURELENGTH: return "Filesignaturelength";
+    case RPMSIGTAG_VERITYSIGNATURES: return "Veritysignatures";
+    case RPMSIGTAG_VERITYSIGNATUREALGO: return "Veritysignaturealgo";
     case RPMSIGTAG_RESERVED: return "Reserved";
     default:
 	break;

--- a/tools/rpmdump.cc
+++ b/tools/rpmdump.cc
@@ -48,6 +48,7 @@ static const char *sigTagName(uint32_t tag)
     case RPMSIGTAG_FILESIGNATURELENGTH: return "Filesignaturelength";
     case RPMSIGTAG_VERITYSIGNATURES: return "Veritysignatures";
     case RPMSIGTAG_VERITYSIGNATUREALGO: return "Veritysignaturealgo";
+    case RPMSIGTAG_OPENPGP: return "Openpgp";
     case RPMSIGTAG_RESERVED: return "Reserved";
     default:
 	break;


### PR DESCRIPTION
Somehow we didn't have any lowlevel signature tag tests related to signing, add some. Unsurprisingly, the untested thing has bugs (filed #3768). This means we're now testing for the WRONG size values here, but at least this lets us see that the right tags are there.

Also rpmdump was missing a tag and case-issues with some tag names.