### PR TITLE
Eliminate uses of the non-portable signal(2) API

### DIFF
--- a/build/rpmfc.cc
+++ b/build/rpmfc.cc
@@ -269,7 +269,10 @@ static int getOutputFrom(ARGV_t argv,
 	return -1;
     }
     
-    sighandler_t oldhandler = signal(SIGPIPE, SIG_IGN);
+    struct sigaction act, oact;
+    memset(&act, 0, sizeof(act));
+    act.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &act, &oact);
 
     child = fork();
     if (child < 0) {
@@ -285,7 +288,8 @@ static int getOutputFrom(ARGV_t argv,
 	goto exit;
     }
     if (child == 0) {
-	signal(SIGPIPE, SIG_DFL);
+	act.sa_handler = SIG_DFL;
+	sigaction(SIGPIPE, &act, NULL);
 
 	close(toProg[1]);
 	close(fromProg[0]);
@@ -424,7 +428,7 @@ reap:
     ret = 0;
 
 exit:
-    signal(SIGPIPE, oldhandler);
+    sigaction(SIGPIPE, &oact, NULL);
     return ret;
 }
 


### PR DESCRIPTION
Commit 7bb4dfd0bcadc7c6177d6fe88a4bcccf7fac98b9 switched the signal() return type to sighandler_t required by the switch to C++, but turns out this is a GNU extension and breaks build on other systems.

Switch to sigaction() which is an actual standard. The intended fix is the compile breakage, but considering all the other shenanigans of signal(), who knows if it actually fixes something else as well.

This was the last user of signal(), lets keep it that way.

Fixes: #3688