### PR TITLE
Fix a regression on rpmbuild -rs failure on non-existent directory

### DIFF
--- a/build/build.cc
+++ b/build/build.cc
@@ -436,6 +436,10 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	    what &= ~(RPMBUILD_PREP|RPMBUILD_RMBUILD);
 	}
 
+	/* If we don't create a build dir, we can't very well remove it */
+	if (!(what & RPMBUILD_MKBUILDDIR))
+	    what &= ~(RPMBUILD_RMBUILD);
+
 	if ((what & RPMBUILD_CHECKBUILDREQUIRES) &&
 	    (rc = doCheckBuildRequires(ts, spec, test)))
 		goto exit;

--- a/tests/data/SPECS/minibr.spec
+++ b/tests/data/SPECS/minibr.spec
@@ -1,0 +1,16 @@
+%bcond_with genbr
+
+Name: minibr
+Version: 1
+Release: 1
+License: k
+Summary: Minimal spec
+
+%if %{with genbr}
+%generate_buildrequires
+echo rpm-build
+%endif
+
+%description
+
+%files

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -92,6 +92,52 @@ runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-1.0-1.src.rpm
 
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([rpmbuild -rs srpm])
+AT_KEYWORDS([build])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bs /data/SPECS/minibr.spec
+],
+[0],
+[Wrote: /build/SRPMS/minibr-1-1.src.rpm
+],
+[ignore])
+
+RPMTEST_CHECK([
+runroot rpmbuild -rs /build/SRPMS/minibr-1-1.src.rpm
+],
+[0],
+[Installing /build/SRPMS/minibr-1-1.src.rpm
+Wrote: /build/SRPMS/minibr-1-1.src.rpm
+],
+[ignore])
+
+# must not leave junk behind
+RPMTEST_CHECK([
+ls ${RPMTEST}/build/BUILD
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpmbuild -rs --with genbr /build/SRPMS/minibr-1-1.src.rpm
+],
+[0],
+[Installing /build/SRPMS/minibr-1-1.src.rpm
+Wrote: /build/SRPMS/minibr-1-1.src.rpm
+],
+[ignore])
+
+# must not leave junk behind
+RPMTEST_CHECK([
+ls ${RPMTEST}/build/BUILD
+],
+[0],
+[],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([rpmbuild -b buildsystem])
 AT_KEYWORDS([build buildsystem])
 


### PR DESCRIPTION
More fallout from the intermediate build directory in 4.20: since commit 5b2abeae2602dbb1052935a32b9009d618067b85 we no longer create an accidental build-directory for some cases, but still try to remove it in others. And fails.

Add test-cases rpmbuild -rs test-cases with and without %generate_buildrequires which adds its own spices to the mix.

Try to tackle this in a moderately generic way: if we didn't create a build directory, we shouldn't try to delete it either. The test-suite passes, but countless untested rpmbuild invocation cases remain.

That's the problem with all these strange build modes: somebody needs to test, maintain and debug them...

Fixes: #3682