### PR TITLE
Turn docs index into a publishable landing page

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           mkdir _build
           podman run -v $PWD:/srv:z --workdir /srv/_build --rm rpm sh -c \
-            "cmake .. && make pages"
+            "cmake -DWITH_DOXYGEN=ON .. && make pages"
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(site_dir ${CMAKE_BINARY_DIR}/site)
+
+# Generates Jekyll source pages
+add_custom_target(pages)
+
 if (WITH_DOXYGEN)
     find_package(Doxygen REQUIRED)
 endif()
@@ -6,13 +11,14 @@ if (DOXYGEN_FOUND)
 	file(GLOB headers ${CMAKE_SOURCE_DIR}/include/rpm/*.h)
 	set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)
 	set(DOXYGEN_OPTIMIZE_OUTPUT_FOR_C YES)
+	set(DOXYGEN_HTML_OUTPUT ${site_dir}/api)
 	if (ENABLE_WERROR)
 		set(DOXYGEN_WARN_AS_ERROR YES)
 	endif()
 	doxygen_add_docs(apidoc librpm/Doxyheader.h ${headers}
 			ALL USE_STAMP_FILE)
-	set(doxsrc ${CMAKE_CURRENT_BINARY_DIR})
-	install(DIRECTORY ${doxsrc}/html/ DESTINATION ${CMAKE_INSTALL_DOCDIR}/API)
+	add_dependencies(pages apidoc)
+	install(DIRECTORY ${DOXYGEN_HTML_OUTPUT}/ DESTINATION ${CMAKE_INSTALL_DOCDIR}/API)
 endif()
 
 set(manuals
@@ -53,7 +59,6 @@ set(manuals
 install(FILES ${manuals} TYPE DOC)
 
 # Configure the Jekyll site to build
-set(site_dir ${CMAKE_BINARY_DIR}/site)
 set(site_files
 	_layouts/default.html
 	_layouts/favicon.ico
@@ -68,9 +73,6 @@ configure_file(_config.yml.in ${site_dir}/_config.yml @ONLY)
 foreach(file ${site_files})
 	configure_file(${file} ${site_dir}/${file} COPYONLY)
 endforeach()
-
-# Generates additional Jekyll pages to build
-add_custom_target(pages)
 
 if (PODMAN)
 	option(JEKYLL_SERVE "Serve site locally when built" ON)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -55,7 +55,6 @@ install(FILES ${manuals} TYPE DOC)
 # Configure the Jekyll site to build
 set(site_dir ${CMAKE_BINARY_DIR}/site)
 set(site_files
-	_config.yml
 	_layouts/default.html
 	_layouts/favicon.ico
 	assets/css/manpage.css
@@ -65,6 +64,7 @@ set(site_files
 	${manuals}
 )
 file(MAKE_DIRECTORY ${site_dir})
+configure_file(_config.yml.in ${site_dir}/_config.yml @ONLY)
 foreach(file ${site_files})
 	configure_file(${file} ${site_dir}/${file} COPYONLY)
 endforeach()

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,0 @@
-collections:
-  man:
-    output: true

--- a/docs/_config.yml.in
+++ b/docs/_config.yml.in
@@ -1,0 +1,1 @@
+version: @CMAKE_PROJECT_VERSION@

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,15 +3,8 @@ layout: default
 title: rpm.org - Documentation
 ---
 
-This is the in-tree documentation of RPM. It is meant to blend into
-the project's home page at [https://rpm.org](https://rpm.org).
+# RPM {{ site.version }} Documentation
 
-There are two separate sets of documents here:
-
-* [RPM's man pages](man/index.md)
-* [RPM's Reference Manual](manual/index.md)
-
-The API documention is also build here. But if you see this it is probably not built yet. 
-If it is built (in-tree) it can be found [here](html/index.html).
-
-The API documentation for the release can be found on [rpm.org's Documentation page](https://rpm.org/documentation.html)
+* [Man pages](man/)
+* [Reference Manual](manual/)
+* [API Documentation](api/)

--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -24,11 +24,10 @@ add_custom_target(man ALL DEPENDS ${manuals})
 
 # Render Jekyll-ready HTML pages from the manuals
 if (SCD2HTML)
-	file(MAKE_DIRECTORY ${site_dir}/_man)
 	configure_file(mkpage.in mkpage @ONLY)
 	set(manuals_html "")
 	foreach(man ${manuals})
-		set(file ${site_dir}/_man/${man}.html)
+		set(file ${site_dir}/man/${man}.html)
 		list(APPEND manuals_html ${file})
 		add_custom_command(OUTPUT ${file} COMMAND ./mkpage
 				${CMAKE_CURRENT_SOURCE_DIR}/${man}.scd ${file}

--- a/docs/man/index.md
+++ b/docs/man/index.md
@@ -3,33 +3,34 @@ layout: default
 title: rpm.org - RPM Manual Pages
 ---
 
-{% assign tools = site.man      | where: 'type', 'tool' %}
-{% assign progs = site.man      | where: 'type', 'program' %}
-{% assign configs = site.man    | where: 'type', 'config' %}
-{% assign plugins = site.man    | where: 'type', 'plugin' %}
+{% assign manpages = site.pages | where: 'topic', 'manpage' %}
+{% assign tools = manpages      | where: 'type', 'tool' %}
+{% assign progs = manpages      | where: 'type', 'program' %}
+{% assign configs = manpages    | where: 'type', 'config' %}
+{% assign plugins = manpages    | where: 'type', 'plugin' %}
 
 # RPM Manual Pages
 
 ## System Tools
 
 {% for page in tools -%}
-- [{{ page.name }}]({{ page.slug }}) - {{ page.summary }}
+- [{{ page.title }}]({{ page.slug }}) - {{ page.summary }}
 {% endfor %}
 
 ## User Programs
 
 {% for page in progs -%}
-- [{{ page.name }}]({{ page.slug }}) - {{ page.summary }}
+- [{{ page.title }}]({{ page.slug }}) - {{ page.summary }}
 {% endfor %}
 
 ## Configuration & File Formats
 
 {% for page in configs -%}
-- [{{ page.name }}]({{ page.slug }}) - {{ page.summary }}
+- [{{ page.title }}]({{ page.slug }}) - {{ page.summary }}
 {% endfor %}
 
 ## Plugins
 
 {% for page in plugins -%}
-- [{{ page.name }}]({{ page.slug }}) - {{ page.summary }}
+- [{{ page.title }}]({{ page.slug }}) - {{ page.summary }}
 {% endfor %}

--- a/docs/man/mkpage.in
+++ b/docs/man/mkpage.in
@@ -55,7 +55,7 @@ css: manpage.css
 
 FOOTER="\
 <footer>
-<p id=\"version\">RPM @CMAKE_PROJECT_VERSION@</p>
+<p id=\"version\">RPM {{ site.version }}</p>
 <p id=\"index\"><a href="./">Index</a></p>
 <p id=\"date\">$(date -I)</p>
 </footer>

--- a/docs/man/mkpage.in
+++ b/docs/man/mkpage.in
@@ -12,6 +12,7 @@
 SCD_FILE=$1
 OUT_FILE=$2
 SCD_BASE=$(basename ${SCD_FILE%.*})
+OUT_BASE=$(basename ${OUT_FILE%.*})
 
 # Conventional name(SECTION) string
 MAN_NAME=$(echo $SCD_BASE | sed 's/\.\(.\)$/(\1)/')
@@ -42,9 +43,10 @@ get_type() {
 
 HEADER="\
 ---
+topic: manpage
 layout: default
-title: rpm.org - $MAN_NAME
-name: $MAN_NAME
+title: $MAN_NAME
+slug: $OUT_BASE
 type: $(get_type $MAN_NAME $MAN_SECN)
 summary: $(get_summary $SCD_FILE)
 css: manpage.css


### PR DESCRIPTION
The docs index page is currently only used as a "landing page" for local `make site` preview. With versioned docs (#3611), we'll link to it from https://rpm.org/documentation.html, so make it a bit more presentable and useful. This involves the following (details in the commit messages):

* Update the index page itself (fix API link, add RPM version, etc.)
* Use normal Jekyll pages for the HTML man pages (not a collection)
* Build API docs as part of `make pages`

Once this is merged, I'll backport some of it (mainly the index page) to the current stable branches (`rpm-4.20.x` and `rpm-4.19.x`) so that we can link to those from rpm.org as well.

Preview: https://dmnks.github.io/rpm/