### PR TITLE
Require use of internal dependency generator for v6 packages

### DIFF
--- a/scripts/find-provides
+++ b/scripts/find-provides
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-/usr/lib/rpm/rpmdeps --define="_use_internal_dependency_generator 1" --provides
+dn="$(dirname $0)"
+"${dn}"/rpmdeps --define="_use_internal_dependency_generator 1" --provides

--- a/scripts/find-requires
+++ b/scripts/find-requires
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-/usr/lib/rpm/rpmdeps --define="_use_internal_dependency_generator 1" --requires
+dn="$(dirname $0)"
+"${dn}"/rpmdeps --define="_use_internal_dependency_generator 1" --requires

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1289,6 +1289,7 @@ AT_KEYWORDS([build])
 RPMTEST_CHECK([
 runroot rpmbuild -bb --quiet \
 		--define "_binary_payload w9.gzdio" \
+		--define "_rpmformat 4" \
 		/data/SPECS/filedep.spec
 ],
 [0],
@@ -1370,6 +1371,7 @@ AT_KEYWORDS([build])
 RPMTEST_CHECK([
 runroot rpmbuild -bb --quiet \
 		--define "_binary_payload w9.gzdio" \
+		--define "_rpmformat 4" \
 		--define "_use_internal_dependency_generator 0" \
 		/data/SPECS/filedep.spec
 ],
@@ -1432,6 +1434,105 @@ runroot rpm -qp \
 [
 ]
 [])
+RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([Dependency generation 1.3])
+AT_KEYWORDS([build])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet \
+		--define "_binary_payload w9.gzdio" \
+		--define "_rpmformat 6" \
+		/data/SPECS/filedep.spec
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm  -qp --requires /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+],
+[0],
+[/bin/f00f
+/bin/sh
+rpmlib(CompressedFileNames) <= 3.0.4-1
+rpmlib(FileDigests) <= 4.6.0-1
+rpmlib(LargeFiles) <= 4.12.0-1
+rpmlib(PayloadFilesHavePrefix) <= 4.0-1
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -qp --provides /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+],
+[0],
+[filedep = 1.0-1
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp --qf '["%{FILENAMES}\t%{FILEREQUIRE}"\n]' /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
+[0],
+["/etc/foo.conf	"
+"/usr/bin/bar	/bin/f00f"
+"/usr/bin/foo	/bin/sh"
+"/usr/share/doc/filedep	"
+"/usr/share/doc/filedep/README	"
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp --qf '["%{FILENAMES}\t%{FILEPROVIDE}"\n]' /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
+[0],
+["/etc/foo.conf	"
+"/usr/bin/bar	"
+"/usr/bin/foo	"
+"/usr/share/doc/filedep	"
+"/usr/share/doc/filedep/README	"
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp \
+	--qf '[%{FILEDEPENDSN}\n]\n' \
+	--qf '[%{FILEDEPENDSX}\n]\n' \
+	/build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
+[0],
+[0
+1
+1
+0
+0
+
+0
+0
+1
+0
+0
+0
+0
+
+],
+[])
+RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([Dependency generation 1.4])
+AT_KEYWORDS([build])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet \
+		--define "_binary_payload w9.gzdio" \
+		--define "_rpmformat 6" \
+		--define "_use_internal_dependency_generator 0" \
+		/data/SPECS/filedep.spec
+],
+[1],
+[],
+[error: External dependency generator is incompatible with v6 packages
+])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([Dependency generation 2])

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1283,12 +1283,17 @@ runroot rpmbuild -bb --quiet \
 ])
 RPMTEST_CLEANUP
 
-RPMTEST_SETUP_RW([Dependency generation 1])
+RPMTEST_SETUP_RW([Dependency generation 1.1])
 AT_KEYWORDS([build])
 
+RPMTEST_CHECK([
 runroot rpmbuild -bb --quiet \
 		--define "_binary_payload w9.gzdio" \
 		/data/SPECS/filedep.spec
+],
+[0],
+[],
+[])
 
 RPMTEST_CHECK([
 runroot rpm  -qp --requires /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
@@ -1310,9 +1315,9 @@ runroot rpm -qp --provides /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
 ],
 [])
 
-RPMTEST_CHECK([
-runroot rpm -qp --qf '[["%{FILENAMES}\t%{FILEREQUIRE}"\n]]' /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
-],
+RPMTEST_CHECK([[
+runroot rpm -qp --qf '["%{FILENAMES}\t%{FILEREQUIRE}"\n]' /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
 [0],
 ["/etc/foo.conf	"
 "/usr/bin/bar	/bin/f00f"
@@ -1322,9 +1327,9 @@ runroot rpm -qp --qf '[["%{FILENAMES}\t%{FILEREQUIRE}"\n]]' /build/RPMS/noarch/f
 ],
 [])
 
-RPMTEST_CHECK([
-runroot rpm -qp --qf '[["%{FILENAMES}\t%{FILEPROVIDE}"\n]]' /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
-],
+RPMTEST_CHECK([[
+runroot rpm -qp --qf '["%{FILENAMES}\t%{FILEPROVIDE}"\n]' /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
 [0],
 ["/etc/foo.conf	"
 "/usr/bin/bar	"
@@ -1332,6 +1337,100 @@ runroot rpm -qp --qf '[["%{FILENAMES}\t%{FILEPROVIDE}"\n]]' /build/RPMS/noarch/f
 "/usr/share/doc/filedep	"
 "/usr/share/doc/filedep/README	"
 ],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp \
+	--qf '[%{FILEDEPENDSN}\n]\n' \
+	--qf '[%{FILEDEPENDSX}\n]\n' \
+	/build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
+[0],
+[0
+1
+1
+0
+0
+
+0
+0
+1
+0
+0
+0
+0
+
+],
+[])
+RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([Dependency generation 1.2])
+AT_KEYWORDS([build])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet \
+		--define "_binary_payload w9.gzdio" \
+		--define "_use_internal_dependency_generator 0" \
+		/data/SPECS/filedep.spec
+],
+[0],
+[],
+[warning: Deprecated external dependency generator is used!
+])
+
+RPMTEST_CHECK([
+runroot rpm  -qp --requires /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+],
+[0],
+[/bin/f00f
+/bin/sh
+rpmlib(CompressedFileNames) <= 3.0.4-1
+rpmlib(FileDigests) <= 4.6.0-1
+rpmlib(PayloadFilesHavePrefix) <= 4.0-1
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -qp --provides /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+],
+[0],
+[filedep = 1.0-1
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp --qf '["%{FILENAMES}\t%{FILEREQUIRE}"\n]' /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
+[0],
+["/etc/foo.conf	"
+"/usr/bin/bar	"
+"/usr/bin/foo	"
+"/usr/share/doc/filedep	"
+"/usr/share/doc/filedep/README	"
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp --qf '["%{FILENAMES}\t%{FILEPROVIDE}"\n]' /build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
+[0],
+["/etc/foo.conf	"
+"/usr/bin/bar	"
+"/usr/bin/foo	"
+"/usr/share/doc/filedep	"
+"/usr/share/doc/filedep/README	"
+],
+[])
+
+RPMTEST_CHECK([[
+runroot rpm -qp \
+	--qf '[%{FILEDEPENDSN}\n]\n' \
+	--qf '[%{FILEDEPENDSX}\n]\n' \
+	/build/RPMS/noarch/filedep-1.0-1.noarch.rpm
+]],
+[0],
+[
+]
 [])
 RPMTEST_CLEANUP
 


### PR DESCRIPTION
The external dependency generator has been supposedly deprecated for two decades by now, and we've been issuing a deprecation warning on it for nine year by now. And, we'll continue to do so as long as we support v4 package generation, because we can't very well make something mandatory there at this point. Instead, error out if external dependency   generator is used for v6 packages. Add tests + make the package version explicit in them all.

Fixes: #2373


The first commit turned out to be necessary to test the external depgen at all, the second one is to just fleshen out the related v4 tests a bit.