### PR TITLE
Use cmake variable for rpm version in docs

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -65,11 +65,10 @@ set(site_files
 	assets/css/manpage.css
 	man/index.md
 	Gemfile
-	index.md
 	${manuals}
 )
 file(MAKE_DIRECTORY ${site_dir})
-configure_file(_config.yml.in ${site_dir}/_config.yml @ONLY)
+configure_file(index.md.in ${site_dir}/index.md @ONLY)
 foreach(file ${site_files})
 	configure_file(${file} ${site_dir}/${file} COPYONLY)
 endforeach()

--- a/docs/_config.yml.in
+++ b/docs/_config.yml.in
@@ -1,1 +1,0 @@
-version: @CMAKE_PROJECT_VERSION@

--- a/docs/index.md.in
+++ b/docs/index.md.in
@@ -3,7 +3,7 @@ layout: default
 title: rpm.org - Documentation
 ---
 
-# RPM {{ site.version }} Documentation
+# RPM @CMAKE_PROJECT_VERSION@ Documentation
 
 * [Man pages](man/)
 * [Reference Manual](manual/)

--- a/docs/man/mkpage.in
+++ b/docs/man/mkpage.in
@@ -55,7 +55,7 @@ css: manpage.css
 
 FOOTER="\
 <footer>
-<p id=\"version\">RPM {{ site.version }}</p>
+<p id=\"version\">RPM @CMAKE_PROJECT_VERSION@</p>
 <p id=\"index\"><a href="./">Index</a></p>
 <p id=\"date\">$(date -I)</p>
 </footer>


### PR DESCRIPTION
Commit 0bec95bd9d3b015642fd47721501f39b8ede4eb7 added a Jekyll site variable "version" to use in documents, however that turns out to be impractical for versioned docs generated from the rpm-web repo since the variable would have to be added to _config.yml in that repo, which is just needlessly complicated.

Instead, just use the cmake variable in the pages that actually need to render the rpm version, which is the index page and individual html man pages.

This effectively reverts the above commit.