### PR TITLE
Run Python tests with ASAN

### DIFF
--- a/tests/local.at
+++ b/tests/local.at
@@ -44,8 +44,7 @@ ts = rpm.ts()
 ts.setFlags(rpm.RPMTRANS_FLAG_NOPLUGINS)
 $1
 EOF
-# Python is such a mess wrt ASAN, ignore it for now
-LD_PRELOAD=${ASANLIB} ASAN_OPTIONS=detect_leaks=0 ${PYTHON} test.py
+LD_PRELOAD=${ASANLIB} ${PYTHON} test.py
 ]])
 
 m4_define([RPMTEST_SKIP_IF],[


### PR DESCRIPTION
Python is no longer a mess regarding ASAN.

This is cherry-picked from a longer branch that may have changed something substantial about the usage of Python APIs, so the isolated change is not guaranteed to work. I'd like to use the CI of the project to check this. Python itself is now tested with ASAN upstream.