### PR TITLE
Add redirected.html layout for Jekyll

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -61,6 +61,7 @@ install(FILES ${manuals} TYPE DOC)
 # Configure the Jekyll site to build
 set(site_files
 	_layouts/default.html
+	_layouts/redirected.html
 	_layouts/favicon.ico
 	assets/css/manpage.css
 	man/index.md

--- a/docs/_layouts/redirected.html
+++ b/docs/_layouts/redirected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="canonical" href="{{ page.redirect_to }}"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+</head>
+<body>
+    <h1>Redirecting...</h1>
+      <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
+      <script>location='{{ page.redirect_to }}'</script>
+</body>
+</html>
+
+


### PR DESCRIPTION
This allows for putting Jekyll redirects in place (which we'll soon need).  We have the same file in the rpm-web repo already but since the in-tree docs are also hosted separately (for the master branch), we need the file here as well...