### PR TITLE
Add html stubs (redirects) for future man pages

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -58,6 +58,11 @@ set(manuals
 )
 install(FILES ${manuals} TYPE DOC)
 
+# Temporary redirects for future man pages
+set(redirects
+  	man/rpm-spec.5.md
+)
+
 # Configure the Jekyll site to build
 set(site_files
 	_layouts/default.html
@@ -67,6 +72,7 @@ set(site_files
 	man/index.md
 	Gemfile
 	${manuals}
+	${redirects}
 )
 file(MAKE_DIRECTORY ${site_dir})
 configure_file(index.md.in ${site_dir}/index.md @ONLY)

--- a/docs/man/rpm-spec.5.md
+++ b/docs/man/rpm-spec.5.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /manual/spec
+---


### PR DESCRIPTION
Put redirects in place for man pages that we're planning to write that lead to their current counterparts in docs/manual.  Once a man page is written for one of these, we'll just remove its html stub and an actual html man page will get rendered in its place.

This allows us to already reference such future man pages from various places in the documentation, without having to use the current unwieldy URLs (and remembering to replace those later).