### PR TITLE
CMakeLists.txt: Improve checking for CFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,11 +433,10 @@ endif()
 
 # try to ensure some compiler sanity and hardening options where supported
 foreach (flag -fno-strict-overflow -fno-delete-null-pointer-checks -fhardened)
-	check_c_compiler_flag(${flag} found)
-	if (found)
+	check_c_compiler_flag(${flag} compiler-supports${flag})
+	if (compiler-supports${flag})
 		add_compile_options(${flag})
 	endif()
-	unset(found CACHE)
 endforeach()
 
 # generated sources


### PR DESCRIPTION
The previous log wasn't clear:
-- Performing Test found
-- Performing Test found - Success
-- Performing Test found
-- Performing Test found - Success
-- Performing Test found
-- Performing Test found - Failed

Use a new var SUPPORTS_${flag} will make it more clear:
-- Performing Test SUPPORTS_-fno-strict-overflow
-- Performing Test SUPPORTS_-fno-strict-overflow - Success
-- Performing Test SUPPORTS_-fno-delete-null-pointer-checks
-- Performing Test SUPPORTS_-fno-delete-null-pointer-checks - Success
-- Performing Test SUPPORTS_-fhardened
-- Performing Test SUPPORTS_-fhardened - Failed