### PR TITLE
Add test to ensure RPMTAG_SOURCERPM on debuginfo

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2684,6 +2684,21 @@ No hello.debug
 [ignore])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages sourcerpm])
+AT_KEYWORDS([build] [sourcerpm])
+RPMTEST_CHECK([[
+runroot rpmbuild -bb --quiet \
+		--define "_debuginfo_subpackages 1" \
+		 /data/SPECS/test-subpackages.spec
+runroot rpm -q --qf "%{nevr} %{sourcerpm}\n" /build/RPMS/*/test-*-debuginfo-1.0-1.*.rpm
+]],
+[0],
+[test-test2-debuginfo-1.0-1 test-1.0-1.src.rpm
+test-test3-debuginfo-1.0-1 test-1.0-1.src.rpm
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([rpmbuild multiple subpackages source_nevr])
 AT_KEYWORDS([build] [source_nevr])
 RPMTEST_CHECK([


### PR DESCRIPTION
Commit e0e43e93777701f5f2e6f7505b8e9b9e9681aee1 fixed a regression where RPMTAG_SOURCERPM would be missing from subpackage debuginfo but didn't include a test, so add one here.

Fixes: #3800