### PR TITLE
Don't print empty return of --eval macro expansion

### DIFF
--- a/lib/poptALL.cc
+++ b/lib/poptALL.cc
@@ -130,6 +130,9 @@ static void rpmcliAllArgCallback( poptContext con,
 	{   char *val = NULL;
 	    if (rpmExpandMacros(NULL, arg, &val, 0) < 0)
 		exit(EXIT_FAILURE);
+	    /* macro expanded to an empty string (eg, %{nil}) */
+	    if (strlen(val) == 0)
+		goto free;
 	    if (fprintf(stdout, "%s\n", val) < 0 ||
 		fflush(stdout) == EOF ||
 		ferror(stdout)) {
@@ -137,6 +140,7 @@ static void rpmcliAllArgCallback( poptContext con,
 		free(val);
 	        exit(EXIT_FAILURE);
 	    }
+free:
 	    free(val);
 	}
 	break;

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3125,10 +3125,7 @@ runroot rpm \
 	--eval "%{with both_features}"
 ],
 [0],
-[
-
-
-1
+[1
 0
 0
 ],
@@ -3197,11 +3194,7 @@ runroot rpm \
 	--eval "%{with normally_off}" \
 ],
 [0],
-[
-
-
-
-0
+[0
 1
 ],
 [])
@@ -3217,9 +3210,7 @@ runroot rpm \
 	--eval "%{with normally_off}" \
 ],
 [0],
-[
-
-0
+[0
 1
 ],
 [])

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -147,8 +147,7 @@ RPMTEST_CHECK([
 rpm --define "this that" --eval '%{?that}'
 ],
 [0],
-[
-])
+[])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP([nested macro in name])
@@ -328,8 +327,7 @@ rpm \
     --eval '%bar'
 ],
 [0],
-[
-arg
+[arg
 ])
 RPMTEST_CLEANUP
 
@@ -663,7 +661,6 @@ foobar
 foobar
 foobar
 /hello/%%
-
 bar
 bar baz\baz
 %%
@@ -795,7 +792,6 @@ foo
 bar
 0
 3
-
 foo
 ],
 [])
@@ -1059,9 +1055,7 @@ rpm \
 [0],
 [0	1
 nil
-
 bbb	zzz
-
 nil
  1:a 2:c
  1:a 2: 3:c
@@ -1088,8 +1082,7 @@ rpm \
 	--eval "%recurse"
 ]],
 [0],
-[ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
-])
+[ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP([lua rpm extensions 1])
@@ -1313,8 +1306,7 @@ RPMTEST_CHECK([
 rpm --define "aa 0" --define "my() %{define:aa 1}%{define:aa 2}" --eval "%my" --eval "%aa"
 ],
 [0],
-[
-0
+[0
 ],
 [ignore])
 RPMTEST_CLEANUP
@@ -1370,7 +1362,6 @@ rpm -v --eval '%{verbose:zzz}'
 [0],
 [0
 1
-
 zzz
 ])
 RPMTEST_CLEANUP


### PR DESCRIPTION
The macro expansion of an --eval need not return anything (eg, it could be a lua script only run for its side effects). That --eval then prints an empty line. A silly example:

`$ rpm --eval '%{lua: a = 1}' --eval '%{lua: print( "Hi!" )}' --eval '%{lua: b = 2}' 

Hi!

`
This trivial commit skips printing if the macro expansion is an empty string. Tested lightly on rpm-4.20.1 (Fedora 42) and forward-ported to master.