### PR TITLE
Ignore stderr on the sourcerpm test to avoid bogus failures

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2696,7 +2696,7 @@ runroot rpm -q --qf "%{nevr} %{sourcerpm}\n" /build/RPMS/*/test-*-debuginfo-1.0-
 [test-test2-debuginfo-1.0-1 test-1.0-1.src.rpm
 test-test3-debuginfo-1.0-1 test-1.0-1.src.rpm
 ],
-[])
+[ignore])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmbuild multiple subpackages source_nevr])


### PR DESCRIPTION
Older versions of find-debuginfo (or some tooling within) emit an extra "1 block" message on stderr that causes the test to unnecessarily fail on F41 and other older distros.