### PR TITLE
Isolate module state to enable running in multiple subinterpreters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,7 @@ endif()
 list(APPEND db_backends dummy)
 
 if (ENABLE_PYTHON)
-	find_package(Python3 3.7 COMPONENTS Interpreter Development REQUIRED)
+	find_package(Python3 3.10 COMPONENTS Interpreter Development REQUIRED)
 endif()
 
 if (WITH_CAP)

--- a/INSTALL
+++ b/INSTALL
@@ -101,7 +101,7 @@ These are available from
     http://tukaani.org/xz/
 
 Python bindings to RPM library are built by default, but it can be disabled
-with -DENABLE_PYTHON=OFF. You'll need to have Python >= 3.7
+with -DENABLE_PYTHON=OFF. You'll need to have Python >= 3.10
 runtime and C API development environment installed.
 Python is available from:
     http://www.python.org/

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -19,7 +19,7 @@ Python3_add_library(_rpm
 )
 
 # Select Python stable ABI
-target_compile_definitions(_rpm PRIVATE Py_LIMITED_API=0x03070000)
+target_compile_definitions(_rpm PRIVATE Py_LIMITED_API=0x030A0000)
 
 target_link_libraries(_rpm PRIVATE librpmio librpm librpmbuild librpmsign)
 

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -12,6 +12,8 @@
 #include "rpmtd-py.h"
 #include "rpmver-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 /** \ingroup python
  * \class Rpm
  * \brief START HERE / RPM base module for the Python API

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -165,7 +165,7 @@ static PyObject * hdrAsBytes(hdrObject * s)
     char *buf = headerExport(s->h, &len);
 
     if (buf == NULL || len == 0) {
-	PyErr_SetString(pyrpmError, "can't unload bad header\n");
+	PyErr_SetString(modstate->pyrpmError, "can't unload bad header\n");
     } else {
 	res = PyBytes_FromStringAndSize(buf, len);
     }
@@ -191,7 +191,7 @@ static PyObject * hdrFormat(hdrObject * s, PyObject * args, PyObject * kwds)
 
     r = headerFormat(s->h, fmt, &err);
     if (!r) {
-	PyErr_SetString(pyrpmError, err);
+	PyErr_SetString(modstate->pyrpmError, err);
 	return NULL;
     }
 
@@ -317,7 +317,7 @@ static PyObject *hdr_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     }
 
     if (h == NULL) {
-	PyErr_SetString(pyrpmError, "bad header");
+	PyErr_SetString(modstate->pyrpmError, "bad header");
 	return NULL;
     }
     
@@ -400,7 +400,7 @@ static PyObject * hdrGetTag(Header h, rpmTagVal tag)
 
     (void) headerGet(h, tag, &td, HEADERGET_EXT);
     if (rpmtdGetFlags(&td) & RPMTD_INVALID) {
-	PyErr_SetString(pyrpmError, "invalid header data");
+	PyErr_SetString(modstate->pyrpmError, "invalid header data");
     } else {
 	/* rpmtd_AsPyobj() knows how to handle empty containers and all */
 	res = rpmtd_AsPyobj(&td);
@@ -646,8 +646,6 @@ static PyType_Slot hdr_Type_Slots[] = {
     {Py_tp_new, hdr_new},
     {0, NULL},
 };
-
-PyTypeObject* hdr_Type;
 PyType_Spec hdr_Type_Spec = {
     .name = "rpm.hdr",
     .basicsize = sizeof(hdrObject),
@@ -680,8 +678,8 @@ PyObject * versionCompare (PyObject * self, PyObject * args, PyObject * kwds)
     hdrObject * h1, * h2;
     char * kwlist[] = {"version0", "version1", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", kwlist, hdr_Type,
-	    &h1, hdr_Type, &h2))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", kwlist, modstate->hdr_Type,
+                                     &h1, modstate->hdr_Type, &h2))
 	return NULL;
 
     return Py_BuildValue("i", rpmVersionCompare(h1->h, h2->h));

--- a/python/header-py.h
+++ b/python/header-py.h
@@ -4,16 +4,12 @@
 #include <rpm/rpmtypes.h>
 
 typedef struct hdrObject_s hdrObject;
-
-extern PyTypeObject* hdr_Type;
 extern PyType_Spec hdr_Type_Spec;
 
-#define hdrObject_Check(v)	((v)->ob_type == hdr_Type)
+#define hdrObject_Check(v)	((v)->ob_type == modstate->hdr_Type)
 
 #define DEPRECATED_METHOD(_msg) \
     PyErr_WarnEx(PyExc_PendingDeprecationWarning, (_msg), 2);
-
-extern PyObject * pyrpmError;
 
 PyObject * hdr_Wrap(PyTypeObject *subtype, Header h);
 

--- a/python/header-py.h
+++ b/python/header-py.h
@@ -6,7 +6,14 @@
 typedef struct hdrObject_s hdrObject;
 extern PyType_Spec hdr_Type_Spec;
 
-#define hdrObject_Check(v)	((v)->ob_type == modstate->hdr_Type)
+static inline int hdrObject_Check(PyObject *v) {
+	rpmmodule_state_t *modstate = rpmModState_FromObject(v);
+    if (!modstate) {
+        PyErr_Clear();
+        return 0;
+    }
+    return (v)->ob_type == modstate->hdr_Type;
+}
 
 #define DEPRECATED_METHOD(_msg) \
     PyErr_WarnEx(PyExc_PendingDeprecationWarning, (_msg), 2);

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -9,6 +9,8 @@
 #include "rpmarchive-py.h"
 #include "rpmstrpool-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 struct rpmarchiveObject_s {
     PyObject_HEAD
     PyObject *md_dict;

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -244,8 +244,6 @@ static PyType_Slot rpmarchive_Type_Slots[] = {
     {Py_tp_methods, rpmarchive_methods},
     {0, NULL},
 };
-
-PyTypeObject* rpmarchive_Type;
 PyType_Spec rpmarchive_Type_Spec = {
     .name = "rpm.archive",
     .basicsize = sizeof(rpmarchiveObject),

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -18,11 +18,22 @@ struct rpmarchiveObject_s {
 
 static void rpmarchive_dealloc(rpmarchiveObject * s)
 {
+    PyObject_GC_UnTrack(s);
     rpmfilesFree(s->files);
     rpmfiArchiveClose(s->archive);
     rpmfiFree(s->archive);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmarchive_traverse(hdrObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject *rpmarchive_error(int rc)
@@ -236,6 +247,7 @@ static PyObject *disabled_new(PyTypeObject *type,
 static PyType_Slot rpmarchive_Type_Slots[] = {
     {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmarchive_dealloc},
+    {Py_tp_traverse, rpmarchive_traverse},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
     {Py_tp_doc, rpmarchive_doc},
@@ -247,7 +259,7 @@ static PyType_Slot rpmarchive_Type_Slots[] = {
 PyType_Spec rpmarchive_Type_Spec = {
     .name = "rpm.archive",
     .basicsize = sizeof(rpmarchiveObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT| Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmarchive_Type_Slots,
 };
 

--- a/python/rpmarchive-py.h
+++ b/python/rpmarchive-py.h
@@ -6,8 +6,6 @@
 typedef struct rpmarchiveObject_s rpmarchiveObject;
 extern PyType_Spec rpmarchive_Type_Spec;
 
-#define rpmarchiveObject_Check(v)	((v)->ob_type == modstate->rpmarchive_Type)
-
 PyObject * rpmarchive_Wrap(PyTypeObject *subtype,
 			   rpmfiles files, rpmfi archive);
 

--- a/python/rpmarchive-py.h
+++ b/python/rpmarchive-py.h
@@ -4,11 +4,9 @@
 #include <rpm/rpmarchive.h>
 
 typedef struct rpmarchiveObject_s rpmarchiveObject;
-
-extern PyTypeObject* rpmarchive_Type;
 extern PyType_Spec rpmarchive_Type_Spec;
 
-#define rpmarchiveObject_Check(v)	((v)->ob_type == rpmarchive_Type)
+#define rpmarchiveObject_Check(v)	((v)->ob_type == modstate->rpmarchive_Type)
 
 PyObject * rpmarchive_Wrap(PyTypeObject *subtype,
 			   rpmfiles files, rpmfi archive);

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -121,7 +121,7 @@ rpmds_Find(rpmdsObject * s, PyObject * arg)
 {
     rpmdsObject * o;
 
-    if (!PyArg_Parse(arg, "O!:Find", rpmds_Type, &o))
+    if (!PyArg_Parse(arg, "O!:Find", modstate->rpmds_Type, &o))
 	return NULL;
 
     /* XXX make sure ods index is valid, real fix in lib/rpmds.c. */
@@ -135,7 +135,7 @@ rpmds_Merge(rpmdsObject * s, PyObject * arg)
 {
     rpmdsObject * o;
 
-    if (!PyArg_Parse(arg, "O!:Merge", rpmds_Type, &o))
+    if (!PyArg_Parse(arg, "O!:Merge", modstate->rpmds_Type, &o))
 	return NULL;
 
     return Py_BuildValue("i", rpmdsMerge(&s->ds, o->ds));
@@ -145,7 +145,7 @@ rpmds_Search(rpmdsObject * s, PyObject * arg)
 {
     rpmdsObject * o;
 
-    if (!PyArg_Parse(arg, "O!:Merge", rpmds_Type, &o))
+    if (!PyArg_Parse(arg, "O!:Merge", modstate->rpmds_Type, &o))
         return NULL;
 
     return Py_BuildValue("i", rpmdsSearch(s->ds, o->ds));
@@ -155,7 +155,7 @@ static PyObject *rpmds_Compare(rpmdsObject * s, PyObject * o)
 {
     rpmdsObject * ods;
 
-    if (!PyArg_Parse(o, "O!:Compare", rpmds_Type, &ods))
+    if (!PyArg_Parse(o, "O!:Compare", modstate->rpmds_Type, &ods))
 	return NULL;
 
     return PyBool_FromLong(rpmdsCompare(s->ds, ods->ds));
@@ -179,7 +179,7 @@ static PyObject * rpmds_Rpmlib(rpmdsObject * s, PyObject *args, PyObject *kwds)
     /* XXX check return code, permit arg (NULL uses system default). */
     rpmdsRpmlibPool(pool, &ds, NULL);
 
-    return rpmds_Wrap(rpmds_Type, ds);
+    return rpmds_Wrap(modstate->rpmds_Type, ds);
 }
 
 static struct PyMethodDef rpmds_methods[] = {
@@ -370,8 +370,6 @@ static PyType_Slot rpmds_Type_Slots[] = {
     {Py_tp_new, rpmds_new},
     {0, NULL},
 };
-
-PyTypeObject* rpmds_Type;
 PyType_Spec rpmds_Type_Spec = {
     .name = "rpm.ds",
     .basicsize = sizeof(rpmdsObject),

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -232,9 +232,20 @@ The current index in ds is positioned at overlapping member." },
 static void
 rpmds_dealloc(rpmdsObject * s)
 {
+    PyObject_GC_UnTrack(s);
     s->ds = rpmdsFree(s->ds);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmds_traverse(hdrObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static Py_ssize_t rpmds_length(rpmdsObject * s)
@@ -358,6 +369,7 @@ static char rpmds_doc[] =
 
 static PyType_Slot rpmds_Type_Slots[] = {
     {Py_tp_dealloc, rpmds_dealloc},
+    {Py_tp_traverse, rpmds_traverse},
     {Py_mp_length, rpmds_length},
     {Py_mp_subscript, rpmds_subscript},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -373,7 +385,7 @@ static PyType_Slot rpmds_Type_Slots[] = {
 PyType_Spec rpmds_Type_Spec = {
     .name = "rpm.ds",
     .basicsize = sizeof(rpmdsObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmds_Type_Slots,
 };
 

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -8,6 +8,8 @@
 #include "rpmds-py.h"
 #include "rpmstrpool-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 struct rpmdsObject_s {
     PyObject_HEAD
     PyObject *md_dict;		/*!< to look like PyModuleObject */

--- a/python/rpmds-py.h
+++ b/python/rpmds-py.h
@@ -6,8 +6,6 @@
 typedef struct rpmdsObject_s rpmdsObject;
 extern PyType_Spec rpmds_Type_Spec;
 
-#define rpmdsObject_Check(v)	((v)->ob_type == modstate->rpmds_Type)
-
 rpmds dsFromDs(rpmdsObject * ds);
 
 PyObject * rpmds_Wrap(PyTypeObject *subtype, rpmds ds);

--- a/python/rpmds-py.h
+++ b/python/rpmds-py.h
@@ -4,11 +4,9 @@
 #include <rpm/rpmds.h>
 
 typedef struct rpmdsObject_s rpmdsObject;
-
-extern PyTypeObject* rpmds_Type;
 extern PyType_Spec rpmds_Type_Spec;
 
-#define rpmdsObject_Check(v)	((v)->ob_type == rpmds_Type)
+#define rpmdsObject_Check(v)	((v)->ob_type == modstate->rpmds_Type)
 
 rpmds dsFromDs(rpmdsObject * ds);
 

--- a/python/rpmfd-py.c
+++ b/python/rpmfd-py.c
@@ -4,6 +4,8 @@
 #include "header-py.h"	/* XXX for utf8FromPyObject() only */
 #include "rpmfd-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 struct rpmfdObject_s {
     PyObject_HEAD
     PyObject *md_dict;

--- a/python/rpmfd-py.c
+++ b/python/rpmfd-py.c
@@ -4,8 +4,6 @@
 #include "header-py.h"	/* XXX for utf8FromPyObject() only */
 #include "rpmfd-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 struct rpmfdObject_s {
     PyObject_HEAD
     PyObject *md_dict;
@@ -19,11 +17,11 @@ FD_t rpmfdGetFd(rpmfdObject *fdo)
     return fdo->fd;
 }
 
-int rpmfdFromPyObject(PyObject *obj, rpmfdObject **fdop)
+int rpmfdFromPyObject(rpmmodule_state_t *modstate, PyObject *obj, rpmfdObject **fdop)
 {
     rpmfdObject *fdo = NULL;
 
-    if (rpmfdObject_Check(obj)) {
+    if (obj->ob_type == modstate->rpmfd_Type) {
 	Py_INCREF(obj);
 	fdo = (rpmfdObject *) obj;
     } else {

--- a/python/rpmfd-py.c
+++ b/python/rpmfd-py.c
@@ -136,12 +136,23 @@ static PyObject *rpmfd_close(rpmfdObject *s)
 
 static void rpmfd_dealloc(rpmfdObject *s)
 {
+    PyObject_GC_UnTrack(s);
     PyObject *res = do_close(s);
     Py_XDECREF(res);
     free(s->mode);
     free(s->flags);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmfd_traverse(hdrObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject *rpmfd_fileno(rpmfdObject *s)
@@ -346,6 +357,7 @@ static PyGetSetDef rpmfd_getseters[] = {
 
 static PyType_Slot rpmfd_Type_Slots[] = {
     {Py_tp_dealloc, rpmfd_dealloc},
+    {Py_tp_traverse, rpmfd_traverse},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
     {Py_tp_doc, rpmfd_doc},
@@ -358,6 +370,6 @@ static PyType_Slot rpmfd_Type_Slots[] = {
 PyType_Spec rpmfd_Type_Spec = {
     .name = "rpm.fd",
     .basicsize = sizeof(rpmfdObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmfd_Type_Slots,
 };

--- a/python/rpmfd-py.c
+++ b/python/rpmfd-py.c
@@ -25,7 +25,7 @@ int rpmfdFromPyObject(PyObject *obj, rpmfdObject **fdop)
 	Py_INCREF(obj);
 	fdo = (rpmfdObject *) obj;
     } else {
-	fdo = (rpmfdObject *) PyObject_CallFunctionObjArgs((PyObject *)rpmfd_Type,
+	fdo = (rpmfdObject *) PyObject_CallFunctionObjArgs((PyObject *) modstate->rpmfd_Type,
                                                            obj, NULL);
     }
     if (fdo == NULL) return 0;
@@ -355,8 +355,6 @@ static PyType_Slot rpmfd_Type_Slots[] = {
     {Py_tp_new, PyType_GenericNew},
     {0, NULL},
 };
-
-PyTypeObject* rpmfd_Type;
 PyType_Spec rpmfd_Type_Spec = {
     .name = "rpm.fd",
     .basicsize = sizeof(rpmfdObject),

--- a/python/rpmfd-py.h
+++ b/python/rpmfd-py.h
@@ -4,11 +4,9 @@
 #include <rpm/rpmio.h>
 
 typedef struct rpmfdObject_s rpmfdObject;
-
-extern PyTypeObject* rpmfd_Type;
 extern PyType_Spec rpmfd_Type_Spec;
 
-#define rpmfdObject_Check(v)	((v)->ob_type == rpmfd_Type)
+#define rpmfdObject_Check(v)	((v)->ob_type == modstate->rpmfd_Type)
 
 FD_t rpmfdGetFd(rpmfdObject *fdo);
 

--- a/python/rpmfd-py.h
+++ b/python/rpmfd-py.h
@@ -6,11 +6,18 @@
 typedef struct rpmfdObject_s rpmfdObject;
 extern PyType_Spec rpmfd_Type_Spec;
 
-#define rpmfdObject_Check(v)	((v)->ob_type == modstate->rpmfd_Type)
+static inline int rpmfdObject_Check(PyObject *v) {
+	rpmmodule_state_t *modstate = rpmModState_FromObject(v);
+    if (!modstate) {
+        PyErr_Clear();
+        return 0;
+    }
+    return (v)->ob_type == modstate->rpmfd_Type;
+}
 
 FD_t rpmfdGetFd(rpmfdObject *fdo);
 
-int rpmfdFromPyObject(PyObject *obj, rpmfdObject **fdop);
+int rpmfdFromPyObject(rpmmodule_state_t *modstate, PyObject *obj, rpmfdObject **fdop);
 
 
 #endif

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -349,7 +349,9 @@ PyType_Spec rpmfile_Type_Spec = {
 
 PyObject * rpmfile_Wrap(rpmfiles files, int ix)
 {
-    rpmfileObject *s = PyObject_New(rpmfileObject, modstate->rpmfile_Type);
+    PyTypeObject *type = modstate->rpmfile_Type;
+    allocfunc alloc = (allocfunc)PyType_GetSlot(type, Py_tp_alloc);
+    rpmfileObject *s = (rpmfileObject*)alloc(type, 0);
     if (s == NULL) return NULL;
 
     s->files = rpmfilesLink(files);

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -340,8 +340,6 @@ static PyType_Slot rpmfile_Type_Slots[] = {
     {Py_tp_getset, rpmfile_getseters},
     {0, NULL},
 };
-
-PyTypeObject* rpmfile_Type;
 PyType_Spec rpmfile_Type_Spec = {
     .name = "rpm.file",
     .basicsize = sizeof(rpmfileObject),
@@ -351,7 +349,7 @@ PyType_Spec rpmfile_Type_Spec = {
 
 PyObject * rpmfile_Wrap(rpmfiles files, int ix)
 {
-    rpmfileObject *s = PyObject_New(rpmfileObject, rpmfile_Type);
+    rpmfileObject *s = PyObject_New(rpmfileObject, modstate->rpmfile_Type);
     if (s == NULL) return NULL;
 
     s->files = rpmfilesLink(files);
@@ -466,7 +464,7 @@ static PyObject *rpmfiles_archive(rpmfilesObject *s,
     }
     Py_DECREF(fdo);
 
-    return rpmarchive_Wrap(rpmarchive_Type, s->files, archive);
+    return rpmarchive_Wrap(modstate->rpmarchive_Type, s->files, archive);
 }
 
 static PyObject *rpmfiles_subscript(rpmfilesObject *s, PyObject *item)
@@ -562,8 +560,6 @@ static PyType_Slot rpmfiles_Type_Slots[] = {
     {Py_tp_new, rpmfiles_new},
     {0, NULL},
 };
-
-PyTypeObject* rpmfiles_Type;
 PyType_Spec rpmfiles_Type_Spec = {
     .name = "rpm.files",
     .basicsize = sizeof(rpmfilesObject),

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -19,9 +19,20 @@ struct rpmfileObject_s {
 
 static void rpmfile_dealloc(rpmfileObject * s)
 {
+    PyObject_GC_UnTrack(s);
     s->files = rpmfilesFree(s->files);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmfile_traverse(rpmfileObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static char rpmfile_doc[] =
@@ -332,6 +343,7 @@ static PyObject *disabled_new(PyTypeObject *type,
 static PyType_Slot rpmfile_Type_Slots[] = {
     {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmfile_dealloc},
+    {Py_tp_traverse, rpmfile_traverse},
     {Py_tp_str, rpmfile_name},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
@@ -343,7 +355,7 @@ static PyType_Slot rpmfile_Type_Slots[] = {
 PyType_Spec rpmfile_Type_Spec = {
     .name = "rpm.file",
     .basicsize = sizeof(rpmfileObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmfile_Type_Slots,
 };
 
@@ -368,9 +380,20 @@ struct rpmfilesObject_s {
 
 static void rpmfiles_dealloc(rpmfilesObject * s)
 {
+    PyObject_GC_UnTrack(s);
     s->files = rpmfilesFree(s->files);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmfiles_traverse(rpmfilesObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject * rpmfiles_new(PyTypeObject * subtype, PyObject *args, PyObject *kwds)
@@ -550,6 +573,7 @@ static char rpmfiles_doc[] =
 
 static PyType_Slot rpmfiles_Type_Slots[] = {
     {Py_tp_dealloc, rpmfiles_dealloc},
+    {Py_tp_traverse, rpmfiles_traverse},
     {Py_sq_length, rpmfiles_length},
     {Py_sq_item, rpmfiles_getitem},
     {Py_sq_contains, rpmfiles_contains},
@@ -565,7 +589,7 @@ static PyType_Slot rpmfiles_Type_Slots[] = {
 PyType_Spec rpmfiles_Type_Spec = {
     .name = "rpm.files",
     .basicsize = sizeof(rpmfilesObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmfiles_Type_Slots,
 };
 

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -9,6 +9,8 @@
 #include "rpmarchive-py.h"
 #include "rpmstrpool-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 /* A single file from rpmfiles set, can't be independently instanciated */
 struct rpmfileObject_s {
     PyObject_HEAD

--- a/python/rpmfiles-py.h
+++ b/python/rpmfiles-py.h
@@ -5,14 +5,11 @@
 
 typedef struct rpmfileObject_s rpmfileObject;
 typedef struct rpmfilesObject_s rpmfilesObject;
-
-extern PyTypeObject* rpmfile_Type;
 extern PyType_Spec rpmfile_Type_Spec;
-extern PyTypeObject* rpmfiles_Type;
 extern PyType_Spec rpmfiles_Type_Spec;
 
-#define rpmfileObject_Check(v)	((v)->ob_type == rpmfile_Type)
-#define rpmfilesObject_Check(v)	((v)->ob_type == rpmfiles_Type)
+#define rpmfileObject_Check(v)	((v)->ob_type == modstate->rpmfile_Type)
+#define rpmfilesObject_Check(v)	((v)->ob_type == modstate->rpmfiles_Type)
 
 PyObject * rpmfile_Wrap(rpmfiles files, int ix);
 PyObject * rpmfiles_Wrap(PyTypeObject *subtype, rpmfiles files);

--- a/python/rpmfiles-py.h
+++ b/python/rpmfiles-py.h
@@ -8,10 +8,25 @@ typedef struct rpmfilesObject_s rpmfilesObject;
 extern PyType_Spec rpmfile_Type_Spec;
 extern PyType_Spec rpmfiles_Type_Spec;
 
-#define rpmfileObject_Check(v)	((v)->ob_type == modstate->rpmfile_Type)
-#define rpmfilesObject_Check(v)	((v)->ob_type == modstate->rpmfiles_Type)
+static inline int rpmfileObject_Check(PyObject *v) {
+	rpmmodule_state_t *modstate = rpmModState_FromObject(v);
+    if (!modstate) {
+        PyErr_Clear();
+        return 0;
+    }
+    return (v)->ob_type == modstate->rpmfile_Type;
+}
 
-PyObject * rpmfile_Wrap(rpmfiles files, int ix);
+static inline int rpmfilesObject_Check(PyObject *v) {
+	rpmmodule_state_t *modstate = rpmModState_FromObject(v);
+    if (!modstate) {
+        PyErr_Clear();
+        return 0;
+    }
+    return (v)->ob_type == modstate->rpmfiles_Type;
+}
+
+PyObject * rpmfile_Wrap(rpmmodule_state_t *modstate, rpmfiles files, int ix);
 PyObject * rpmfiles_Wrap(PyTypeObject *subtype, rpmfiles files);
 
 #endif

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -117,6 +117,7 @@ static void rpmii_dealloc(rpmiiObject * s)
 
 static int rpmii_traverse(rpmiiObject * s, visitproc visit, void *arg)
 {
+    Py_VISIT(s->ref);
     if (python_version >= 0x03090000) {
         Py_VISIT(Py_TYPE(s));
     }

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -7,6 +7,8 @@
 #include "rpmii-py.h"
 #include "header-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 /** \ingroup python
  * \class Rpmii
  * \brief A python rpm.ii key iterator object represents the keys of a

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -105,11 +105,22 @@ static struct PyMethodDef rpmii_methods[] = {
 
 static void rpmii_dealloc(rpmiiObject * s)
 {
+    PyObject_GC_UnTrack(s);
     s->ii = rpmdbIndexIteratorFree(s->ii);
     rpmtdFree(s->keytd);
     Py_DECREF(s->ref);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmii_traverse(rpmiiObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static int rpmii_bool(rpmiiObject *s)
@@ -132,6 +143,7 @@ static PyObject *disabled_new(PyTypeObject *type,
 static PyType_Slot rpmii_Type_Slots[] = {
     {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmii_dealloc},
+    {Py_tp_traverse, rpmii_traverse},
     {Py_nb_bool, rpmii_bool},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
@@ -144,7 +156,7 @@ static PyType_Slot rpmii_Type_Slots[] = {
 PyType_Spec rpmii_Type_Spec = {
     .name = "rpm.ii",
     .basicsize = sizeof(rpmiiObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT  | Py_TPFLAGS_HAVE_GC| Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmii_Type_Slots,
 };
 

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -141,8 +141,6 @@ static PyType_Slot rpmii_Type_Slots[] = {
     {Py_tp_methods, rpmii_methods},
     {0, NULL},
 };
-
-PyTypeObject* rpmii_Type;
 PyType_Spec rpmii_Type_Spec = {
     .name = "rpm.ii",
     .basicsize = sizeof(rpmiiObject),

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -7,8 +7,6 @@
 #include "rpmii-py.h"
 #include "header-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 /** \ingroup python
  * \class Rpmii
  * \brief A python rpm.ii key iterator object represents the keys of a

--- a/python/rpmii-py.h
+++ b/python/rpmii-py.h
@@ -4,8 +4,6 @@
 typedef struct rpmiiObject_s rpmiiObject;
 extern PyType_Spec rpmii_Type_Spec;
 
-#define rpmiiObject_Check(v)	((v)->ob_type == modstate->rpmii_Type)
-
 PyObject * rpmii_Wrap(PyTypeObject *subtype, rpmdbIndexIterator ii, PyObject *s);
 
 #endif

--- a/python/rpmii-py.h
+++ b/python/rpmii-py.h
@@ -2,11 +2,9 @@
 #define H_RPMII_PY
 
 typedef struct rpmiiObject_s rpmiiObject;
-
-extern PyTypeObject* rpmii_Type;
 extern PyType_Spec rpmii_Type_Spec;
 
-#define rpmiiObject_Check(v)	((v)->ob_type == rpmii_Type)
+#define rpmiiObject_Check(v)	((v)->ob_type == modstate->rpmii_Type)
 
 PyObject * rpmii_Wrap(PyTypeObject *subtype, rpmdbIndexIterator ii, PyObject *s);
 

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -2,8 +2,6 @@
 #include <rpm/rpmkeyring.h>
 #include "rpmkeyring-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 struct rpmPubkeyObject_s {
     PyObject_HEAD
     PyObject *md_dict;
@@ -121,6 +119,10 @@ static PyObject *rpmKeyring_new(PyTypeObject *subtype,
 static PyObject *rpmKeyring_addKey(rpmKeyringObject *s, PyObject *arg)
 {
     rpmPubkeyObject *pubkey = NULL;
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
 
     if (!PyArg_Parse(arg, "O!", modstate->rpmPubkey_Type, &pubkey))
 	return NULL;
@@ -174,7 +176,7 @@ PyObject * rpmKeyring_Wrap(PyTypeObject *subtype, rpmKeyring keyring)
     return (PyObject*) s;
 }
 
-int rpmKeyringFromPyObject(PyObject *item, rpmKeyring *keyring)
+int rpmKeyringFromPyObject(rpmmodule_state_t *modstate, PyObject *item, rpmKeyring *keyring)
 {
     rpmKeyringObject *kro;
     if (!PyArg_Parse(item, "O!", modstate->rpmKeyring_Type, &kro))

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -10,9 +10,20 @@ struct rpmPubkeyObject_s {
 
 static void rpmPubkey_dealloc(rpmPubkeyObject * s)
 {
+    PyObject_GC_UnTrack(s);
     s->pubkey = rpmPubkeyFree(s->pubkey);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmPubkey_traverse(rpmPubkeyObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject *rpmPubkey_new(PyTypeObject *subtype, 
@@ -59,6 +70,7 @@ static char rpmPubkey_doc[] = "";
 
 static PyType_Slot rpmPubkey_Type_Slots[] = {
     {Py_tp_dealloc, rpmPubkey_dealloc},
+    {Py_tp_traverse, rpmPubkey_traverse},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
     {Py_tp_doc, rpmPubkey_doc},
@@ -69,7 +81,7 @@ static PyType_Slot rpmPubkey_Type_Slots[] = {
 PyType_Spec rpmPubkey_Type_Spec = {
     .name = "rpm.pubkey",
     .basicsize = sizeof(rpmPubkeyObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmPubkey_Type_Slots,
 };
 
@@ -81,9 +93,20 @@ struct rpmKeyringObject_s {
 
 static void rpmKeyring_dealloc(rpmKeyringObject * s)
 {
+    PyObject_GC_UnTrack(s);
     rpmKeyringFree(s->keyring);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmKeyring_traverse(rpmKeyringObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject *rpmKeyring_new(PyTypeObject *subtype, 
@@ -114,6 +137,7 @@ static char rpmKeyring_doc[] =
 
 static PyType_Slot rpmKeyring_Type_Slots[] = {
     {Py_tp_dealloc, rpmKeyring_dealloc},
+    {Py_tp_traverse, rpmKeyring_traverse},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
     {Py_tp_doc, rpmKeyring_doc},
@@ -124,7 +148,7 @@ static PyType_Slot rpmKeyring_Type_Slots[] = {
 PyType_Spec rpmKeyring_Type_Spec = {
     .name = "rpm.keyring",
     .basicsize = sizeof(rpmKeyringObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmKeyring_Type_Slots,
 };
 

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -66,8 +66,6 @@ static PyType_Slot rpmPubkey_Type_Slots[] = {
     {Py_tp_new, rpmPubkey_new},
     {0, NULL},
 };
-
-PyTypeObject* rpmPubkey_Type;
 PyType_Spec rpmPubkey_Type_Spec = {
     .name = "rpm.pubkey",
     .basicsize = sizeof(rpmPubkeyObject),
@@ -99,7 +97,7 @@ static PyObject *rpmKeyring_addKey(rpmKeyringObject *s, PyObject *arg)
 {
     rpmPubkeyObject *pubkey = NULL;
 
-    if (!PyArg_Parse(arg, "O!", rpmPubkey_Type, &pubkey))
+    if (!PyArg_Parse(arg, "O!", modstate->rpmPubkey_Type, &pubkey))
 	return NULL;
 
     return Py_BuildValue("i", rpmKeyringAddKey(s->keyring, pubkey->pubkey));
@@ -123,8 +121,6 @@ static PyType_Slot rpmKeyring_Type_Slots[] = {
     {Py_tp_new, rpmKeyring_new},
     {0, NULL},
 };
-
-PyTypeObject* rpmKeyring_Type;
 PyType_Spec rpmKeyring_Type_Spec = {
     .name = "rpm.keyring",
     .basicsize = sizeof(rpmKeyringObject),
@@ -155,7 +151,7 @@ PyObject * rpmKeyring_Wrap(PyTypeObject *subtype, rpmKeyring keyring)
 int rpmKeyringFromPyObject(PyObject *item, rpmKeyring *keyring)
 {
     rpmKeyringObject *kro;
-    if (!PyArg_Parse(item, "O!", rpmKeyring_Type, &kro))
+    if (!PyArg_Parse(item, "O!", modstate->rpmKeyring_Type, &kro))
 	return 0;
     *keyring = kro->keyring;
     return 1;

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -2,6 +2,8 @@
 #include <rpm/rpmkeyring.h>
 #include "rpmkeyring-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 struct rpmPubkeyObject_s {
     PyObject_HEAD
     PyObject *md_dict;

--- a/python/rpmkeyring-py.h
+++ b/python/rpmkeyring-py.h
@@ -11,5 +11,5 @@ extern PyType_Spec rpmPubkey_Type_Spec;
 PyObject * rpmPubkey_Wrap(PyTypeObject *subtype, rpmPubkey pubkey);
 PyObject * rpmKeyring_Wrap(PyTypeObject *subtype, rpmKeyring keyring);
 
-int rpmKeyringFromPyObject(PyObject *item, rpmKeyring *keyring);
+int rpmKeyringFromPyObject(rpmmodule_state_t *modstate, PyObject *item, rpmKeyring *keyring);
 #endif

--- a/python/rpmkeyring-py.h
+++ b/python/rpmkeyring-py.h
@@ -5,10 +5,7 @@
 
 typedef struct rpmPubkeyObject_s rpmPubkeyObject;
 typedef struct rpmKeyringObject_s rpmKeyringObject;
-
-extern PyTypeObject* rpmKeyring_Type;
 extern PyType_Spec rpmKeyring_Type_Spec;
-extern PyTypeObject* rpmPubkey_Type;
 extern PyType_Spec rpmPubkey_Type_Spec;
 
 PyObject * rpmPubkey_Wrap(PyTypeObject *subtype, rpmPubkey pubkey);

--- a/python/rpmmacro-py.c
+++ b/python/rpmmacro-py.c
@@ -5,6 +5,8 @@
 #include "header-py.h"	/* XXX for pyrpmError, doh */
 #include "rpmmacro-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 PyObject *
 rpmmacro_AddMacro(PyObject * self, PyObject * args, PyObject * kwds)
 {

--- a/python/rpmmacro-py.c
+++ b/python/rpmmacro-py.c
@@ -5,8 +5,6 @@
 #include "header-py.h"	/* XXX for pyrpmError, doh */
 #include "rpmmacro-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 PyObject *
 rpmmacro_AddMacro(PyObject * self, PyObject * args, PyObject * kwds)
 {
@@ -37,12 +35,16 @@ rpmmacro_DelMacro(PyObject * self, PyObject * args, PyObject * kwds)
 }
 
 PyObject * 
-rpmmacro_ExpandMacro(PyObject * self, PyObject * args, PyObject * kwds)
+rpmmacro_ExpandMacro(PyObject *mod, PyObject * args, PyObject * kwds)
 {
     const char *macro;
     PyObject *res = NULL;
     int num = 0;
     char * kwlist[] = {"macro", "numeric", NULL};
+    rpmmodule_state_t *modstate = rpmModState_FromModule(mod);
+    if (!modstate) {
+	    return NULL;
+    }
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|i", kwlist, &macro, &num))
         return NULL;

--- a/python/rpmmacro-py.c
+++ b/python/rpmmacro-py.c
@@ -50,7 +50,7 @@ rpmmacro_ExpandMacro(PyObject * self, PyObject * args, PyObject * kwds)
     } else {
 	char *str = NULL;
 	if (rpmExpandMacros(NULL, macro, &str, 0) < 0)
-	    PyErr_SetString(pyrpmError, "error expanding macro");
+	    PyErr_SetString(modstate->pyrpmError, "error expanding macro");
 	else
 	    res = utf8FromString(str);
 	free(str);

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -6,6 +6,8 @@
 #include "rpmmi-py.h"
 #include "header-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 /** \ingroup python
  * \class Rpmmi
  * \brief A python rpm.mi match iterator object represents the result of a

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -76,7 +76,7 @@ rpmmi_iternext(rpmmiObject * s)
 	return NULL;
     }
     headerLink(h);
-    return hdr_Wrap(hdr_Type, h);
+    return hdr_Wrap(modstate->hdr_Type, h);
 }
 
 static PyObject *
@@ -202,8 +202,6 @@ static PyType_Slot rpmmi_Type_Slots[] = {
     {Py_tp_methods, rpmmi_methods},
     {0, NULL},
 };
-
-PyTypeObject* rpmmi_Type;
 PyType_Spec rpmmi_Type_Spec = {
     .name = "rpm.mi",
     .basicsize = sizeof(rpmmiObject),

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -6,8 +6,6 @@
 #include "rpmmi-py.h"
 #include "header-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 /** \ingroup python
  * \class Rpmmi
  * \brief A python rpm.mi match iterator object represents the result of a
@@ -72,6 +70,10 @@ static PyObject *
 rpmmi_iternext(rpmmiObject * s)
 {
     Header h;
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+        return NULL;
+    }
 
     if (s->mi == NULL || (h = rpmdbNextIterator(s->mi)) == NULL) {
 	s->mi = rpmdbFreeIterator(s->mi);

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -138,6 +138,7 @@ static void rpmmi_dealloc(rpmmiObject * s)
 
 static int rpmmi_traverse(rpmmiObject * s, visitproc visit, void *arg)
 {
+    Py_VISIT(s->ref);
     if (python_version >= 0x03090000) {
         Py_VISIT(Py_TYPE(s));
     }

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -127,10 +127,21 @@ static struct PyMethodDef rpmmi_methods[] = {
 
 static void rpmmi_dealloc(rpmmiObject * s)
 {
+    PyObject_GC_UnTrack(s);
     s->mi = rpmdbFreeIterator(s->mi);
     Py_DECREF(s->ref);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmmi_traverse(rpmmiObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static Py_ssize_t rpmmi_length(rpmmiObject * s)
@@ -192,6 +203,7 @@ static PyObject *disabled_new(PyTypeObject *type,
 static PyType_Slot rpmmi_Type_Slots[] = {
     {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmmi_dealloc},
+    {Py_tp_traverse, rpmmi_traverse},
     {Py_nb_bool, rpmmi_bool},
     {Py_mp_length, rpmmi_length},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -205,7 +217,7 @@ static PyType_Slot rpmmi_Type_Slots[] = {
 PyType_Spec rpmmi_Type_Spec = {
     .name = "rpm.mi",
     .basicsize = sizeof(rpmmiObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmmi_Type_Slots,
 };
 

--- a/python/rpmmi-py.h
+++ b/python/rpmmi-py.h
@@ -2,11 +2,9 @@
 #define H_RPMMI_PY
 
 typedef struct rpmmiObject_s rpmmiObject;
-
-extern PyTypeObject* rpmmi_Type;
 extern PyType_Spec rpmmi_Type_Spec;
 
-#define rpmmiObject_Check(v)	((v)->ob_type == rpmmi_Type)
+#define rpmmiObject_Check(v)	((v)->ob_type == modstate->rpmmi_Type)
 
 PyObject * rpmmi_Wrap(PyTypeObject *subtype, rpmdbMatchIterator mi, PyObject *s);
 

--- a/python/rpmmi-py.h
+++ b/python/rpmmi-py.h
@@ -4,8 +4,6 @@
 typedef struct rpmmiObject_s rpmmiObject;
 extern PyType_Spec rpmmi_Type_Spec;
 
-#define rpmmiObject_Check(v)	((v)->ob_type == modstate->rpmmi_Type)
-
 PyObject * rpmmi_Wrap(PyTypeObject *subtype, rpmdbMatchIterator mi, PyObject *s);
 
 #endif

--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -314,7 +314,7 @@ static int initAndAddType(PyObject *m, PyTypeObject **type, PyType_Spec *spec,
                           char *name)
 {
     if (!*type) {
-        *type = (PyTypeObject *)PyType_FromSpec(spec);
+        *type = (PyTypeObject *)PyType_FromModuleAndSpec(m, spec, NULL);
         if (!*type) return 0;
     }
     /* We intentionally leak a reference to `type` (only once per type per

--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -29,7 +29,7 @@
  * \name Module: rpm
  */
 
-PyObject * pyrpmError;
+rpmmodule_state_t *modstate = NULL;
 
 static PyObject * archScore(PyObject * self, PyObject * arg)
 {
@@ -229,12 +229,12 @@ static void addRpmTags(PyObject *module)
 static int initModule(PyObject *m);
 
 static int rpmModuleTraverse(PyObject *m, visitproc visit, void *arg) {
-    Py_VISIT(pyrpmError);
+    Py_VISIT(modstate->pyrpmError);
     return 0;
 }
 
 static int rpmModuleClear(PyObject *m) {
-    Py_CLEAR(pyrpmError);
+    Py_CLEAR(modstate->pyrpmError);
     return 0;
 }
 
@@ -316,6 +316,13 @@ static int initModule(PyObject *m)
     }
     moduleInitialized = 1;
 
+    modstate = malloc(sizeof(rpmmodule_state_t));
+    if (!modstate) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    memset(modstate, 0, sizeof(rpmmodule_state_t));
+
     PyObject * d;
 
     /* failure to initialize rpm (crypto and all) is rather fatal too... */
@@ -324,74 +331,74 @@ static int initModule(PyObject *m)
 
     d = PyModule_GetDict(m);
 
-    pyrpmError = PyErr_NewException("_rpm.error", NULL, NULL);
-    if (pyrpmError != NULL)
-	PyDict_SetItemString(d, "error", pyrpmError);
+    modstate->pyrpmError = PyErr_NewException("_rpm.error", NULL, NULL);
+    if (modstate->pyrpmError != NULL)
+	PyDict_SetItemString(d, "error", modstate->pyrpmError);
 
-    if (!initAndAddType(m, &hdr_Type, &hdr_Type_Spec, "hdr")) {
+    if (!initAndAddType(m, &modstate->hdr_Type, &hdr_Type_Spec, "hdr")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmarchive_Type, &rpmarchive_Type_Spec, "archive")) {
+    if (!initAndAddType(m, &modstate->rpmarchive_Type, &rpmarchive_Type_Spec, "archive")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmds_Type, &rpmds_Type_Spec, "ds")) {
+    if (!initAndAddType(m, &modstate->rpmds_Type, &rpmds_Type_Spec, "ds")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmfd_Type, &rpmfd_Type_Spec, "fd")) {
+    if (!initAndAddType(m, &modstate->rpmfd_Type, &rpmfd_Type_Spec, "fd")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmfile_Type, &rpmfile_Type_Spec, "file")) {
+    if (!initAndAddType(m, &modstate->rpmfile_Type, &rpmfile_Type_Spec, "file")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmfiles_Type, &rpmfiles_Type_Spec, "files")) {
+    if (!initAndAddType(m, &modstate->rpmfiles_Type, &rpmfiles_Type_Spec, "files")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmKeyring_Type, &rpmKeyring_Type_Spec, "keyring")) {
+    if (!initAndAddType(m, &modstate->rpmKeyring_Type, &rpmKeyring_Type_Spec, "keyring")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmmi_Type, &rpmmi_Type_Spec, "mi")) {
+    if (!initAndAddType(m, &modstate->rpmmi_Type, &rpmmi_Type_Spec, "mi")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmii_Type, &rpmii_Type_Spec, "ii")) {
+    if (!initAndAddType(m, &modstate->rpmii_Type, &rpmii_Type_Spec, "ii")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmProblem_Type, &rpmProblem_Type_Spec, "prob")) {
+    if (!initAndAddType(m, &modstate->rpmProblem_Type, &rpmProblem_Type_Spec, "prob")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmPubkey_Type, &rpmPubkey_Type_Spec, "pubkey")) {
+    if (!initAndAddType(m, &modstate->rpmPubkey_Type, &rpmPubkey_Type_Spec, "pubkey")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmstrPool_Type, &rpmstrPool_Type_Spec, "strpool")) {
+    if (!initAndAddType(m, &modstate->rpmstrPool_Type, &rpmstrPool_Type_Spec, "strpool")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmte_Type, &rpmte_Type_Spec, "te")) {
+    if (!initAndAddType(m, &modstate->rpmte_Type, &rpmte_Type_Spec, "te")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmts_Type, &rpmts_Type_Spec, "ts")) {
+    if (!initAndAddType(m, &modstate->rpmts_Type, &rpmts_Type_Spec, "ts")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &rpmver_Type, &rpmver_Type_Spec, "ver")) {
+    if (!initAndAddType(m, &modstate->rpmver_Type, &rpmver_Type_Spec, "ver")) {
 	return -1;
     }
 
-    if (!initAndAddType(m, &spec_Type, &spec_Type_Spec, "spec")) {
+    if (!initAndAddType(m, &modstate->spec_Type, &spec_Type_Spec, "spec")) {
 	return -1;
     }
-    if (!initAndAddType(m, &specPkg_Type, &specPkg_Type_Spec, "specPkg")) {
+    if (!initAndAddType(m, &modstate->specPkg_Type, &specPkg_Type_Spec, "specPkg")) {
 	return -1;
     }
 

--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -29,7 +29,6 @@
  * \name Module: rpm
  */
 
-rpmmodule_state_t *modstate = NULL;
 unsigned long python_version = 0;
 
 static PyObject * archScore(PyObject * self, PyObject * arg)
@@ -367,7 +366,7 @@ static int initModule(PyObject *m)
 	}
     }
 
-    modstate = PyModule_GetState(m);
+    rpmmodule_state_t *modstate = PyModule_GetState(m);
     if (!modstate) {
 	return -1;
     }

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -89,8 +89,6 @@ static PyType_Slot rpmProblem_Type_Slots[] = {
     {Py_tp_getset, rpmprob_getseters},
     {0, NULL},
 };
-
-PyTypeObject* rpmProblem_Type;
 PyType_Spec rpmProblem_Type_Spec = {
     .name = "rpm.prob",
     .basicsize = sizeof(rpmProblemObject),
@@ -122,7 +120,7 @@ PyObject *rpmps_AsList(rpmps ps)
     psi = rpmpsInitIterator(ps);
 
     while ((prob = rpmpsiNext(psi))) {
-        PyObject *pyprob = rpmprob_Wrap(rpmProblem_Type, prob);
+        PyObject *pyprob = rpmprob_Wrap(modstate->rpmProblem_Type, prob);
         if (!pyprob) {
             Py_DECREF(problems);
             rpmpsFreeIterator(psi);

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -2,6 +2,8 @@
 
 #include "rpmps-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 struct rpmProblemObject_s {
     PyObject_HEAD
     PyObject *md_dict;

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -2,8 +2,6 @@
 
 #include "rpmps-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 struct rpmProblemObject_s {
     PyObject_HEAD
     PyObject *md_dict;
@@ -120,7 +118,7 @@ PyObject *rpmprob_Wrap(PyTypeObject *subtype, rpmProblem prob)
     return (PyObject *) s;
 }
 
-PyObject *rpmps_AsList(rpmps ps)
+PyObject *rpmps_AsList(rpmmodule_state_t *modstate, rpmps ps)
 {
     PyObject *problems;
     rpmpsi psi;

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -66,9 +66,20 @@ static PyObject *rpmprob_str(rpmProblemObject *s)
 
 static void rpmprob_dealloc(rpmProblemObject *s)
 {
+    PyObject_GC_UnTrack(s);
     s->prob = rpmProblemFree(s->prob);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmprob_traverse(rpmProblemObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject *disabled_new(PyTypeObject *type,
@@ -82,6 +93,7 @@ static PyObject *disabled_new(PyTypeObject *type,
 static PyType_Slot rpmProblem_Type_Slots[] = {
     {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmprob_dealloc},
+    {Py_tp_traverse, rpmprob_traverse},
     {Py_tp_str, rpmprob_str},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
@@ -92,7 +104,7 @@ static PyType_Slot rpmProblem_Type_Slots[] = {
 PyType_Spec rpmProblem_Type_Spec = {
     .name = "rpm.prob",
     .basicsize = sizeof(rpmProblemObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmProblem_Type_Slots,
 };
 

--- a/python/rpmps-py.h
+++ b/python/rpmps-py.h
@@ -4,11 +4,9 @@
 #include <rpm/rpmps.h>
 
 typedef struct rpmProblemObject_s rpmProblemObject;
-
-extern PyTypeObject* rpmProblem_Type;
 extern PyType_Spec rpmProblem_Type_Spec;
 
-#define rpmProblemObject_Check(v)	((v)->ob_type == rpmProblem_Type)
+#define rpmProblemObject_Check(v)	((v)->ob_type == modstate->rpmProblem_Type)
 
 PyObject * rpmprob_Wrap(PyTypeObject *subtype, rpmProblem prob);
 

--- a/python/rpmps-py.h
+++ b/python/rpmps-py.h
@@ -6,10 +6,8 @@
 typedef struct rpmProblemObject_s rpmProblemObject;
 extern PyType_Spec rpmProblem_Type_Spec;
 
-#define rpmProblemObject_Check(v)	((v)->ob_type == modstate->rpmProblem_Type)
-
 PyObject * rpmprob_Wrap(PyTypeObject *subtype, rpmProblem prob);
 
-PyObject *rpmps_AsList(rpmps ps);
+PyObject *rpmps_AsList(rpmmodule_state_t *modstate, rpmps ps);
 
 #endif

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -12,9 +12,20 @@ static char strpool_doc[] = "";
 
 static void strpool_dealloc(rpmstrPoolObject *s)
 {
+    PyObject_GC_UnTrack(s);
     s->pool = rpmstrPoolFree(s->pool);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int strpool_traverse(rpmstrPoolObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject *strpool_new(PyTypeObject *subtype,
@@ -91,6 +102,7 @@ static struct PyMethodDef strpool_methods[] = {
 
 static PyType_Slot rpmstrPool_Type_Slots[] = {
     {Py_tp_dealloc, strpool_dealloc},
+    {Py_tp_traverse, strpool_traverse},
     {Py_mp_length, strpool_length},
     {Py_mp_subscript, strpool_id2str},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -103,7 +115,7 @@ static PyType_Slot rpmstrPool_Type_Slots[] = {
 PyType_Spec rpmstrPool_Type_Spec = {
     .name = "rpm.strpool",
     .basicsize = sizeof(rpmstrPoolObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmstrPool_Type_Slots,
 };
 

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -2,6 +2,8 @@
 #include <rpm/rpmstrpool.h>
 #include "rpmstrpool-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 struct rpmstrPoolObject_s {
     PyObject_HEAD
     PyObject *md_dict;

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -2,8 +2,6 @@
 #include <rpm/rpmstrpool.h>
 #include "rpmstrpool-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 struct rpmstrPoolObject_s {
     PyObject_HEAD
     PyObject *md_dict;
@@ -133,7 +131,7 @@ PyObject * rpmstrPool_Wrap(PyTypeObject *subtype, rpmstrPool pool)
     return (PyObject *) s;
 }
 
-int poolFromPyObject(PyObject *item, rpmstrPool *pool)
+int poolFromPyObject(rpmmodule_state_t *modstate, PyObject *item, rpmstrPool *pool)
 {
     rpmstrPoolObject *p = NULL;
     if (PyArg_Parse(item, "O!", modstate->rpmstrPool_Type, &p))

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -100,8 +100,6 @@ static PyType_Slot rpmstrPool_Type_Slots[] = {
     {Py_tp_new, strpool_new},
     {0, NULL},
 };
-
-PyTypeObject* rpmstrPool_Type;
 PyType_Spec rpmstrPool_Type_Spec = {
     .name = "rpm.strpool",
     .basicsize = sizeof(rpmstrPoolObject),
@@ -124,7 +122,7 @@ PyObject * rpmstrPool_Wrap(PyTypeObject *subtype, rpmstrPool pool)
 int poolFromPyObject(PyObject *item, rpmstrPool *pool)
 {
     rpmstrPoolObject *p = NULL;
-    if (PyArg_Parse(item, "O!", rpmstrPool_Type, &p))
+    if (PyArg_Parse(item, "O!", modstate->rpmstrPool_Type, &p))
 	*pool = p->pool;
     return (p != NULL);
 }

--- a/python/rpmstrpool-py.h
+++ b/python/rpmstrpool-py.h
@@ -4,8 +4,6 @@
 #include <rpm/rpmtypes.h>
 
 typedef struct rpmstrPoolObject_s rpmstrPoolObject;
-
-extern PyTypeObject* rpmstrPool_Type;
 extern PyType_Spec rpmstrPool_Type_Spec;
 
 PyObject * rpmstrPool_Wrap(PyTypeObject *subtype, rpmstrPool pool);

--- a/python/rpmstrpool-py.h
+++ b/python/rpmstrpool-py.h
@@ -8,6 +8,6 @@ extern PyType_Spec rpmstrPool_Type_Spec;
 
 PyObject * rpmstrPool_Wrap(PyTypeObject *subtype, rpmstrPool pool);
 
-int poolFromPyObject(PyObject *item, rpmstrPool *pool);
+int poolFromPyObject(rpmmodule_state_t *modstate, PyObject *item, rpmstrPool *pool);
 
 #endif

--- a/python/rpmsystem-py.h
+++ b/python/rpmsystem-py.h
@@ -31,8 +31,6 @@ typedef struct {
     PyObject* pyrpmError;
 } rpmmodule_state_t;
 
-extern rpmmodule_state_t *modstate;
-
 /* Replacement for Py_Version from Python 3.11+
  * version of the Python runtime, packed into an int.
  * For simplicity this only contains "x.y.z", the final byte is 0.

--- a/python/rpmsystem-py.h
+++ b/python/rpmsystem-py.h
@@ -33,6 +33,12 @@ typedef struct {
 
 extern rpmmodule_state_t *modstate;
 
+/* Replacement for Py_Version from Python 3.11+
+ * version of the Python runtime, packed into an int.
+ * For simplicity this only contains "x.y.z", the final byte is 0.
+ */
+extern unsigned long python_version;
+
 PyObject * utf8FromString(const char *s);
 
 #ifndef Py_TPFLAGS_IMMUTABLETYPE

--- a/python/rpmsystem-py.h
+++ b/python/rpmsystem-py.h
@@ -9,6 +9,30 @@
 #include <Python.h>
 #include <structmember.h>
 
+typedef struct {
+    PyTypeObject* hdr_Type;
+    PyTypeObject* rpmarchive_Type;
+    PyTypeObject* rpmds_Type;
+    PyTypeObject* rpmfd_Type;
+    PyTypeObject* rpmfile_Type;
+    PyTypeObject* rpmfiles_Type;
+    PyTypeObject* rpmii_Type;
+    PyTypeObject* rpmKeyring_Type;
+    PyTypeObject* rpmPubkey_Type;
+    PyTypeObject* rpmmi_Type;
+    PyTypeObject* rpmProblem_Type;
+    PyTypeObject* rpmstrPool_Type;
+    PyTypeObject* rpmte_Type;
+    PyTypeObject* rpmts_Type;
+    PyTypeObject* rpmver_Type;
+    PyTypeObject* spec_Type;
+    PyTypeObject* specPkg_Type;
+
+    PyObject* pyrpmError;
+} rpmmodule_state_t;
+
+extern rpmmodule_state_t *modstate;
+
 PyObject * utf8FromString(const char *s);
 
 #ifndef Py_TPFLAGS_IMMUTABLETYPE

--- a/python/rpmsystem-py.h
+++ b/python/rpmsystem-py.h
@@ -31,6 +31,10 @@ typedef struct {
     PyObject* pyrpmError;
 } rpmmodule_state_t;
 
+rpmmodule_state_t *rpmModState_FromObject(PyObject*);
+rpmmodule_state_t *rpmModState_FromModule(PyObject*);
+rpmmodule_state_t *rpmModState_FromType(PyTypeObject*);
+
 /* Replacement for Py_Version from Python 3.11+
  * version of the Python runtime, packed into an int.
  * For simplicity this only contains "x.y.z", the final byte is 0.

--- a/python/rpmtd-py.c
+++ b/python/rpmtd-py.c
@@ -8,6 +8,8 @@
 #include "rpmtd-py.h"
 #include "header-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 /*
  * Convert single tag data item to python object of suitable type
  */

--- a/python/rpmtd-py.c
+++ b/python/rpmtd-py.c
@@ -8,8 +8,6 @@
 #include "rpmtd-py.h"
 #include "header-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 /*
  * Convert single tag data item to python object of suitable type
  */

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -116,7 +116,7 @@ rpmte_Parent(rpmteObject * s, PyObject * unused)
 {
     rpmte parent = rpmteParent(s->te);
     if (parent)
-	return rpmte_Wrap(rpmte_Type, parent);
+	return rpmte_Wrap(modstate->rpmte_Type, parent);
 
     Py_RETURN_NONE;
 }
@@ -190,7 +190,7 @@ rpmte_DS(rpmteObject * s, PyObject * args, PyObject * kwds)
     if (ds == NULL) {
 	Py_RETURN_NONE;
     }
-    return rpmds_Wrap(rpmds_Type, rpmdsLink(ds));
+    return rpmds_Wrap(modstate->rpmds_Type, rpmdsLink(ds));
 }
 
 static PyObject *
@@ -200,7 +200,7 @@ rpmte_Files(rpmteObject * s, PyObject * args, PyObject * kwds)
     if (files == NULL) {
 	Py_RETURN_NONE;
     }
-    return rpmfiles_Wrap(rpmfiles_Type, files);
+    return rpmfiles_Wrap(modstate->rpmfiles_Type, files);
 }
 
 static PyObject *
@@ -299,8 +299,6 @@ static PyType_Slot rpmte_Type_Slots[] = {
     {Py_tp_methods, rpmte_methods},
     {0, NULL},
 };
-
-PyTypeObject* rpmte_Type;
 PyType_Spec rpmte_Type_Spec = {
     .name = "rpm.te",
     .basicsize = sizeof(rpmteObject),

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -6,8 +6,6 @@
 #include "rpmte-py.h"
 #include "rpmps-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 /** \ingroup python
  * \name Class: Rpmte
  * \class Rpmte
@@ -124,6 +122,10 @@ rpmte_PkgFileSize(rpmteObject * s, PyObject * unused)
 static PyObject *
 rpmte_Parent(rpmteObject * s, PyObject * unused)
 {
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
     rpmte parent = rpmteParent(s->te);
     if (parent)
 	return rpmte_Wrap(modstate->rpmte_Type, parent);
@@ -138,8 +140,12 @@ static PyObject * rpmte_Failed(rpmteObject * s, PyObject * unused)
 
 static PyObject * rpmte_Problems(rpmteObject * s, PyObject * unused)
 {
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
     rpmps ps = rpmteProblems(s->te);
-    PyObject *problems = rpmps_AsList(ps);
+    PyObject *problems = rpmps_AsList(modstate, ps);
     rpmpsFree(ps);
     return problems;
 }
@@ -191,6 +197,10 @@ rpmte_DS(rpmteObject * s, PyObject * args, PyObject * kwds)
     rpmds ds;
     rpmTagVal tag;
     char * kwlist[] = {"tag", NULL};
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&:DS", kwlist,
 				tagNumFromPyObject, &tag))
@@ -206,6 +216,10 @@ rpmte_DS(rpmteObject * s, PyObject * args, PyObject * kwds)
 static PyObject *
 rpmte_Files(rpmteObject * s, PyObject * args, PyObject * kwds)
 {
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
     rpmfiles files = rpmteFiles(s->te);
     if (files == NULL) {
 	Py_RETURN_NONE;

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -45,6 +45,14 @@ struct rpmteObject_s {
     rpmte	te;
 };
 
+static int rpmte_traverse(rpmteObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
+}
+
 static PyObject *
 rpmte_TEType(rpmteObject * s, PyObject * unused)
 {
@@ -293,6 +301,7 @@ static PyObject *disabled_new(PyTypeObject *type,
 
 static PyType_Slot rpmte_Type_Slots[] = {
     {Py_tp_new, disabled_new},
+    {Py_tp_traverse, rpmte_traverse},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
     {Py_tp_doc, rpmte_doc},
@@ -302,7 +311,7 @@ static PyType_Slot rpmte_Type_Slots[] = {
 PyType_Spec rpmte_Type_Spec = {
     .name = "rpm.te",
     .basicsize = sizeof(rpmteObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmte_Type_Slots,
 };
 

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -6,6 +6,8 @@
 #include "rpmte-py.h"
 #include "rpmps-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 /** \ingroup python
  * \name Class: Rpmte
  * \class Rpmte

--- a/python/rpmte-py.h
+++ b/python/rpmte-py.h
@@ -6,8 +6,6 @@
 typedef struct rpmteObject_s rpmteObject;
 extern PyType_Spec rpmte_Type_Spec;
 
-#define rpmteObject_Check(v)	((v)->ob_type == modstate->rpmte_Type)
-
 PyObject * rpmte_Wrap(PyTypeObject *subtype, rpmte te);
 
 #endif

--- a/python/rpmte-py.h
+++ b/python/rpmte-py.h
@@ -4,11 +4,9 @@
 #include <rpm/rpmte.h>
 
 typedef struct rpmteObject_s rpmteObject;
-
-extern PyTypeObject* rpmte_Type;
 extern PyType_Spec rpmte_Type_Spec;
 
-#define rpmteObject_Check(v)	((v)->ob_type == rpmte_Type)
+#define rpmteObject_Check(v)	((v)->ob_type == modstate->rpmte_Type)
 
 PyObject * rpmte_Wrap(PyTypeObject *subtype, rpmte te);
 

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -847,6 +847,8 @@ static void rpmts_dealloc(rpmtsObject * s)
 
 static int rpmts_traverse(rpmtsObject * s, visitproc visit, void *arg)
 {
+    Py_VISIT(s->scriptFd);
+    Py_VISIT(s->keyList);
     if (python_version >= 0x03090000) {
         Py_VISIT(Py_TYPE(s));
     }

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -17,8 +17,6 @@
 #include "rpmte-py.h"
 #include "rpmts-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 /** \ingroup python
  * \name Class: Rpmts
  * \class Rpmts
@@ -411,9 +409,17 @@ rpmts_HdrFromFdno(rpmtsObject * s, PyObject *arg)
     rpmfdObject *fdo = NULL;
     Header h;
     rpmRC rpmrc;
+    PyObject *fdo_source;
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
 
-    if (!PyArg_Parse(arg, "O&:HdrFromFdno", rpmfdFromPyObject, &fdo))
+    if (!PyArg_Parse(arg, "O:HdrFromFdno", &fdo_source))
     	return NULL;
+    if(!rpmfdFromPyObject(modstate, fdo_source, &fdo)) {
+	return NULL;
+    }
 
     Py_BEGIN_ALLOW_THREADS;
     rpmrc = rpmReadPackageFile(s->ts, rpmfdGetFd(fdo), NULL, &h);
@@ -474,8 +480,12 @@ rpmts_PgpImportPubkey(rpmtsObject * s, PyObject * args, PyObject * kwds)
 
 static PyObject *rpmts_setKeyring(rpmtsObject *s, PyObject *arg)
 {
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
     rpmKeyring keyring = NULL;
-    if (arg == Py_None || rpmKeyringFromPyObject(arg, &keyring)) {
+    if (arg == Py_None || rpmKeyringFromPyObject(modstate, arg, &keyring)) {
 	return PyBool_FromLong(rpmtsSetKeyring(s->ts, keyring) == 0);
     } else {
 	PyErr_SetString(PyExc_TypeError, "rpm.keyring or None expected");
@@ -485,6 +495,10 @@ static PyObject *rpmts_setKeyring(rpmtsObject *s, PyObject *arg)
 
 static PyObject *rpmts_getKeyring(rpmtsObject *s, PyObject *args, PyObject *kwds)
 {
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
     rpmKeyring keyring = NULL;
     int autoload = 1;
     char * kwlist[] = { "autoload", NULL };
@@ -515,6 +529,14 @@ rpmtsCallback(const void * arg, const rpmCallbackType what,
 
     PyEval_RestoreThread(cbInfo->_save);
 
+    if (cbInfo->tso == NULL) {
+	PyErr_SetString(PyExc_SystemError, "callback tso not set");
+	return NULL;
+    }
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)cbInfo->tso);
+    if (!modstate) {
+	return NULL;
+    }
 
     if (cbInfo->style == 0) {
 	/* Synthesize a python object for callback (if necessary). */
@@ -578,8 +600,12 @@ rpmtsCallback(const void * arg, const rpmCallbackType what,
 static PyObject *
 rpmts_Problems(rpmtsObject * s)
 {
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
     rpmps ps = rpmtsProblems(s->ts);
-    PyObject *problems = rpmps_AsList(ps);
+    PyObject *problems = rpmps_AsList(modstate, ps);
     rpmpsFree(ps);
     return problems;
 }
@@ -623,6 +649,10 @@ rpmts_iternext(rpmtsObject * s)
 {
     PyObject * result = NULL;
     rpmte te;
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
 
     /* Reset iterator on 1st entry. */
     if (s->tsi == NULL) {
@@ -653,6 +683,10 @@ rpmts_Match(rpmtsObject * s, PyObject * args, PyObject * kwds)
     int len = 0;
     rpmDbiTagVal tag = RPMDBI_PACKAGES;
     char * kwlist[] = {"tagNumber", "key", NULL};
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O:Match", kwlist,
 	    tagNumFromPyObject, &tag, &Key))
@@ -697,6 +731,10 @@ rpmts_index(rpmtsObject * s, PyObject * args, PyObject * kwds)
     rpmDbiTagVal tag;
     PyObject *mio = NULL;
     char * kwlist[] = {"tag", NULL};
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&:Keys", kwlist,
               tagNumFromPyObject, &tag))
@@ -914,9 +952,17 @@ static int rpmts_set_cbstyle(rpmtsObject *s, PyObject *value, void *closure)
 
 static int rpmts_set_scriptFd(rpmtsObject *s, PyObject *value, void *closure)
 {
+    PyObject *fdo_source;
     rpmfdObject *fdo = NULL;
     int rc = 0;
-    if (PyArg_Parse(value, "O&", rpmfdFromPyObject, &fdo)) {
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	return -1;
+    }
+    if (PyArg_Parse(value, "O", &fdo_source)) {
+	if(!rpmfdFromPyObject(modstate, fdo_source, &fdo)) {
+	    return -1;
+	}
 	Py_XDECREF(s->scriptFd);
 	s->scriptFd = fdo;
 	rpmtsSetScriptFd(s->ts, rpmfdGetFd(s->scriptFd));

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -834,12 +834,23 @@ Remove all elements from the transaction set\n" },
 
 static void rpmts_dealloc(rpmtsObject * s)
 {
+    PyObject_GC_UnTrack(s);
 
     s->ts = rpmtsFree(s->ts);
     Py_XDECREF(s->scriptFd);
     Py_XDECREF(s->keyList);
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int rpmts_traverse(rpmtsObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject * rpmts_new(PyTypeObject * subtype, PyObject *args, PyObject *kwds)
@@ -1049,6 +1060,7 @@ static PyGetSetDef rpmts_getseters[] = {
 
 static PyType_Slot rpmts_Type_Slots[] = {
     {Py_tp_dealloc, rpmts_dealloc},
+    {Py_tp_traverse, rpmts_traverse},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
     {Py_tp_doc, rpmts_doc},
@@ -1063,6 +1075,6 @@ static PyType_Slot rpmts_Type_Slots[] = {
 PyType_Spec rpmts_Type_Spec = {
     .name = "rpm.ts",
     .basicsize = sizeof(rpmtsObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmts_Type_Slots,
 };

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -419,7 +419,7 @@ rpmts_HdrFromFdno(rpmtsObject * s, PyObject *arg)
     Py_XDECREF(fdo);
 
     if (rpmrc == RPMRC_OK) {
-	ho = hdr_Wrap(hdr_Type, h);
+	ho = hdr_Wrap(modstate->hdr_Type, h);
     } else {
 	Py_INCREF(Py_None);
 	ho = Py_None;
@@ -493,7 +493,7 @@ static PyObject *rpmts_getKeyring(rpmtsObject *s, PyObject *args, PyObject *kwds
 
     keyring = rpmtsGetKeyring(s->ts, autoload);
     if (keyring) {
-	return rpmKeyring_Wrap(rpmKeyring_Type, keyring);
+	return rpmKeyring_Wrap(modstate->rpmKeyring_Type, keyring);
     } else {
 	Py_RETURN_NONE;
     }
@@ -533,7 +533,7 @@ rpmtsCallback(const void * arg, const rpmCallbackType what,
     } else {
 	PyObject *o;
 	if (arg) {
-	    o = rpmte_Wrap(rpmte_Type, (rpmte) arg);
+	    o = rpmte_Wrap(modstate->rpmte_Type, (rpmte) arg);
 	} else {
 	    o = Py_None;
 	    Py_INCREF(o);
@@ -631,7 +631,7 @@ rpmts_iternext(rpmtsObject * s)
 
     te = rpmtsiNext(s->tsi, 0);
     if (te != NULL) {
-	result = rpmte_Wrap(rpmte_Type, te);
+	result = rpmte_Wrap(modstate->rpmte_Type, te);
     } else {
 	s->tsi = rpmtsiFree(s->tsi);
     }
@@ -677,12 +677,13 @@ rpmts_Match(rpmtsObject * s, PyObject * args, PyObject * kwds)
     if (rpmtsGetRdb(s->ts) == NULL) {
 	int rc = rpmtsOpenDB(s->ts, O_RDONLY);
 	if (rc || rpmtsGetRdb(s->ts) == NULL) {
-	    PyErr_SetString(pyrpmError, "rpmdb open failed");
+	    PyErr_SetString(modstate->pyrpmError, "rpmdb open failed");
 	    goto exit;
 	}
     }
 
-    mio = rpmmi_Wrap(rpmmi_Type, rpmtsInitIterator(s->ts, tag, key, len), (PyObject*)s);
+    mio = rpmmi_Wrap(modstate->rpmmi_Type,
+                     rpmtsInitIterator(s->ts, tag, key, len), (PyObject*)s);
 
 exit:
     Py_XDECREF(str);
@@ -703,7 +704,7 @@ rpmts_index(rpmtsObject * s, PyObject * args, PyObject * kwds)
     if (rpmtsGetRdb(s->ts) == NULL) {
 	int rc = rpmtsOpenDB(s->ts, O_RDONLY);
 	if (rc || rpmtsGetRdb(s->ts) == NULL) {
-	    PyErr_SetString(pyrpmError, "rpmdb open failed");
+	    PyErr_SetString(modstate->pyrpmError, "rpmdb open failed");
 	    goto exit;
 	}
     }
@@ -713,7 +714,7 @@ rpmts_index(rpmtsObject * s, PyObject * args, PyObject * kwds)
         PyErr_SetString(PyExc_KeyError, "No index for this tag");
         return NULL;
     }
-    mio = rpmii_Wrap(rpmii_Type, ii, (PyObject*)s);
+    mio = rpmii_Wrap(modstate->rpmii_Type, ii, (PyObject*)s);
 
 exit:
     return mio;
@@ -1059,8 +1060,6 @@ static PyType_Slot rpmts_Type_Slots[] = {
     {Py_tp_new, rpmts_new},
     {0, NULL},
 };
-
-PyTypeObject* rpmts_Type;
 PyType_Spec rpmts_Type_Spec = {
     .name = "rpm.ts",
     .basicsize = sizeof(rpmtsObject),

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -17,6 +17,8 @@
 #include "rpmte-py.h"
 #include "rpmts-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 /** \ingroup python
  * \name Class: Rpmts
  * \class Rpmts

--- a/python/rpmts-py.h
+++ b/python/rpmts-py.h
@@ -4,11 +4,9 @@
 #include <rpm/rpmts.h>
 
 typedef struct rpmtsObject_s rpmtsObject;
-
-extern PyTypeObject* rpmts_Type;
 extern PyType_Spec rpmts_Type_Spec;
 
-#define rpmtsObject_Check(v)	((v)->ob_type == rpmts_Type)
+#define rpmtsObject_Check(v)	((v)->ob_type == modstate->rpmts_Type)
 
 int rpmtsFromPyObject(PyObject *item, rpmts *ts);
 

--- a/python/rpmts-py.h
+++ b/python/rpmts-py.h
@@ -6,7 +6,14 @@
 typedef struct rpmtsObject_s rpmtsObject;
 extern PyType_Spec rpmts_Type_Spec;
 
-#define rpmtsObject_Check(v)	((v)->ob_type == modstate->rpmts_Type)
+static inline int rpmtsObject_Check(PyObject *v) {
+	rpmmodule_state_t *modstate = rpmModState_FromObject(v);
+    if (!modstate) {
+        PyErr_Clear();
+        return 0;
+    }
+    return (v)->ob_type == modstate->rpmts_Type;
+}
 
 int rpmtsFromPyObject(PyObject *item, rpmts *ts);
 

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -3,8 +3,6 @@
 #include <rpm/rpmver.h>
 #include "rpmver-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 struct rpmverObject_s {
     PyObject_HEAD
     PyObject *md_dict;
@@ -80,7 +78,7 @@ static PyObject *ver_richcmp(rpmverObject *s, rpmverObject *o, int op)
 {
     int v;
 
-    if (!(verObject_Check(s) && verObject_Check(o)))
+    if (!(verObject_Check((PyObject*)s) && verObject_Check((PyObject*)o)))
 	Py_RETURN_NOTIMPLEMENTED;
 
     switch (op) {

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -137,8 +137,6 @@ static PyType_Slot rpmver_Type_Slots[] = {
     {Py_tp_new, ver_new},
     {0, NULL},
 };
-
-PyTypeObject* rpmver_Type;
 PyType_Spec rpmver_Type_Spec = {
     .name = "rpm.ver",
     .basicsize = sizeof(rpmverObject),

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -3,6 +3,8 @@
 #include <rpm/rpmver.h>
 #include "rpmver-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 struct rpmverObject_s {
     PyObject_HEAD
     PyObject *md_dict;

--- a/python/rpmver-py.h
+++ b/python/rpmver-py.h
@@ -6,7 +6,14 @@
 typedef struct rpmverObject_s rpmverObject;
 extern PyType_Spec rpmver_Type_Spec;
 
-#define verObject_Check(v)	PyObject_TypeCheck(v, modstate->rpmver_Type)
+static inline int verObject_Check(PyObject *v) {
+	rpmmodule_state_t *modstate = rpmModState_FromObject(v);
+    if (!modstate) {
+	PyErr_Clear();
+	return 0;
+    }
+    return PyObject_TypeCheck(v, modstate->rpmver_Type);
+}
 
 int verFromPyObject(PyObject *item, rpmver *ver);
 PyObject * rpmver_Wrap(PyTypeObject *subtype, rpmver ver);

--- a/python/rpmver-py.h
+++ b/python/rpmver-py.h
@@ -4,11 +4,9 @@
 #include <rpm/rpmtypes.h>
 
 typedef struct rpmverObject_s rpmverObject;
-
-extern PyTypeObject* rpmver_Type;
 extern PyType_Spec rpmver_Type_Spec;
 
-#define verObject_Check(v)	PyObject_TypeCheck(v, rpmver_Type)
+#define verObject_Check(v)	PyObject_TypeCheck(v, modstate->rpmver_Type)
 
 int verFromPyObject(PyObject *item, rpmver *ver);
 PyObject * rpmver_Wrap(PyTypeObject *subtype, rpmver ver);

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -4,6 +4,8 @@
 #include "header-py.h"
 #include "spec-py.h"
 
+extern rpmmodule_state_t *modstate;  // TODO: Remove
+
 /** \ingroup python
  * \name Class: Rpmspec
  * \class Rpmspec

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -43,7 +43,20 @@ struct specPkgObject_s {
 
 static void specPkg_dealloc(specPkgObject * s)
 {
+    PyObject_GC_UnTrack(s);
     Py_DECREF(s->source_spec);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
+    free(s);
+    Py_DECREF(type);
+}
+
+static int specPkg_traverse(specPkgObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject *pkgGetSection(rpmSpecPkg pkg, int section)
@@ -100,6 +113,7 @@ static PyObject *disabled_new(PyTypeObject *type,
 static PyType_Slot specPkg_Type_Slots[] = {
     {Py_tp_new, disabled_new},
     {Py_tp_dealloc, specPkg_dealloc},
+    {Py_tp_traverse, specPkg_traverse},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
     {Py_tp_doc, specPkg_doc},
@@ -109,7 +123,7 @@ static PyType_Slot specPkg_Type_Slots[] = {
 PyType_Spec specPkg_Type_Spec = {
     .name = "rpm.specpkg",
     .basicsize = sizeof(specPkgObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = specPkg_Type_Slots,
 };
 
@@ -122,11 +136,22 @@ struct specObject_s {
 static void 
 spec_dealloc(specObject * s) 
 {
+    PyObject_GC_UnTrack(s);
     if (s->spec) {
 	s->spec=rpmSpecFree(s->spec);
     }
-    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    PyTypeObject *type = Py_TYPE(s);
+    freefunc free = PyType_GetSlot(type, Py_tp_free);
     free(s);
+    Py_DECREF(type);
+}
+
+static int spec_traverse(specObject * s, visitproc visit, void *arg)
+{
+    if (python_version >= 0x03090000) {
+        Py_VISIT(Py_TYPE(s));
+    }
+    return 0;
 }
 
 static PyObject * getSection(rpmSpec spec, int section)
@@ -274,6 +299,7 @@ static struct PyMethodDef spec_methods[] = {
 
 static PyType_Slot spec_Type_Slots[] = {
     {Py_tp_dealloc, spec_dealloc},
+    {Py_tp_traverse, spec_traverse},
     {Py_tp_doc, spec_doc},
     {Py_tp_methods, spec_methods},
     {Py_tp_getset, spec_getseters},
@@ -283,7 +309,7 @@ static PyType_Slot spec_Type_Slots[] = {
 PyType_Spec spec_Type_Spec = {
     .name = "rpm.spec",
     .basicsize = sizeof(specObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = spec_Type_Slots,
 };
 

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -31,7 +31,7 @@
 
 static PyObject *makeHeader(Header h)
 {
-    return hdr_Wrap(hdr_Type, headerLink(h));
+    return hdr_Wrap(modstate->hdr_Type, headerLink(h));
 }
 
 struct specPkgObject_s {
@@ -106,8 +106,6 @@ static PyType_Slot specPkg_Type_Slots[] = {
     {Py_tp_getset, specpkg_getseters},
     {0, NULL},
 };
-
-PyTypeObject* specPkg_Type;
 PyType_Spec specPkg_Type_Spec = {
     .name = "rpm.specpkg",
     .basicsize = sizeof(specPkgObject),
@@ -216,7 +214,7 @@ static PyObject * spec_get_packages(specObject *s, void *closure)
     iter = rpmSpecPkgIterInit(s->spec);
 
     while ((pkg = rpmSpecPkgIterNext(iter)) != NULL) {
-	PyObject *po = specPkg_Wrap(specPkg_Type, pkg, s);
+	PyObject *po = specPkg_Wrap(modstate->specPkg_Type, pkg, s);
         if (!po) {
             rpmSpecPkgIterFree(iter);
             Py_DECREF(pkgList);
@@ -282,8 +280,6 @@ static PyType_Slot spec_Type_Slots[] = {
     {Py_tp_new, spec_new},
     {0, NULL},
 };
-
-PyTypeObject* spec_Type;
 PyType_Spec spec_Type_Spec = {
     .name = "rpm.spec",
     .basicsize = sizeof(specObject),

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -4,8 +4,6 @@
 #include "header-py.h"
 #include "spec-py.h"
 
-extern rpmmodule_state_t *modstate;  // TODO: Remove
-
 /** \ingroup python
  * \name Class: Rpmspec
  * \class Rpmspec
@@ -31,7 +29,7 @@ extern rpmmodule_state_t *modstate;  // TODO: Remove
  *
  */
 
-static PyObject *makeHeader(Header h)
+static PyObject *makeHeader(rpmmodule_state_t *modstate, Header h)
 {
     return hdr_Wrap(modstate->hdr_Type, headerLink(h));
 }
@@ -78,7 +76,11 @@ static char specPkg_doc[] =
 
 static PyObject * specpkg_get_header(specPkgObject *s, void *closure)
 {
-    return makeHeader(rpmSpecPkgHeader(s->pkg));
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
+    return makeHeader(modstate, rpmSpecPkgHeader(s->pkg));
 }
 
 static PyObject * specpkg_get_fileFile(specPkgObject *s, void *closure)
@@ -232,6 +234,10 @@ static PyObject * spec_get_packages(specObject *s, void *closure)
     rpmSpecPkg pkg;
     PyObject *pkgList;
     rpmSpecPkgIter iter;
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
 
     pkgList = PyList_New(0);
     if (!pkgList) {
@@ -256,7 +262,11 @@ static PyObject * spec_get_packages(specObject *s, void *closure)
 
 static PyObject * spec_get_source_header(specObject *s, void *closure)
 {
-    return makeHeader(rpmSpecSourceHeader(s->spec));
+    rpmmodule_state_t *modstate = rpmModState_FromObject((PyObject*)s);
+    if (!modstate) {
+	    return NULL;
+    }
+    return makeHeader(modstate, rpmSpecSourceHeader(s->spec));
 }
 
 static char spec_doc[] = "RPM Spec file object";

--- a/python/spec-py.h
+++ b/python/spec-py.h
@@ -5,14 +5,11 @@
 
 typedef struct specPkgObject_s specPkgObject;
 typedef struct specObject_s specObject;
-
-extern PyTypeObject* spec_Type;
 extern PyType_Spec spec_Type_Spec;
-extern PyTypeObject* specPkg_Type;
 extern PyType_Spec specPkg_Type_Spec;
 
-#define specObject_Check(v)	((v)->ob_type == spec_Type)
-#define specPkgObject_Check(v)	((v)->ob_type == specPkg_Type)
+#define specObject_Check(v)	((v)->ob_type == modstate->spec_Type)
+#define specPkgObject_Check(v)	((v)->ob_type == modstate->specPkg_Type)
 
 PyObject * spec_Wrap(PyTypeObject *subtype, rpmSpec spec);
 PyObject * specPkg_Wrap(PyTypeObject *subtype, rpmSpecPkg pkg, specObject *source);

--- a/python/spec-py.h
+++ b/python/spec-py.h
@@ -8,9 +8,6 @@ typedef struct specObject_s specObject;
 extern PyType_Spec spec_Type_Spec;
 extern PyType_Spec specPkg_Type_Spec;
 
-#define specObject_Check(v)	((v)->ob_type == modstate->spec_Type)
-#define specPkgObject_Check(v)	((v)->ob_type == modstate->specPkg_Type)
-
 PyObject * spec_Wrap(PyTypeObject *subtype, rpmSpec spec);
 PyObject * specPkg_Wrap(PyTypeObject *subtype, rpmSpecPkg pkg, specObject *source);
 


### PR DESCRIPTION
The request to enable running rpm in multiple subinterpreters was raised in: https://bugzilla.redhat.com/show_bug.cgi?id=2327289
This PR bumps the minimum Python version to 3.10 -- hopefully not too new (Python 3.9 will be soon EOL).
We aimed to keep individual changes separated, it's best to review by commits.