### PR TITLE
Default to v6 package format

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -257,11 +257,8 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	(legacy).
 %_rpmfilename		%{_build_name_fmt}
 
-#	EXPERIMENTAL
-#	This does NOT generate actual v6 format, the exact format
-#	hasn't been finalized yet.
 #	Which rpm format go generate (4 or 6)
-%_rpmformat 4
+%_rpmformat 6
 
 #	The directory where sources/patches from a source package will be
 #	installed. This is also where sources/patches are found when building.

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2811,6 +2811,7 @@ runroot rpm -qpR /build/SRPMS/buildrequires-1.0-1.src.rpm
 [rpmlib(CompressedFileNames) <= 3.0.4-1
 rpmlib(DynamicBuildRequires) <= 4.15.0-1
 rpmlib(FileDigests) <= 4.6.0-1
+rpmlib(LargeFiles) <= 4.12.0-1
 ],
 [ignore])
 RPMTEST_CLEANUP
@@ -2939,6 +2940,7 @@ auto: foo-bar = 2.0
 rpmlib: rpmlib(CompressedFileNames) <= 3.0.4-1
 rpmlib,missingok: rpmlib(DynamicBuildRequires) <= 4.15.0-1
 rpmlib: rpmlib(FileDigests) <= 4.6.0-1
+rpmlib: rpmlib(LargeFiles) <= 4.12.0-1
 rpmlib: rpmlib(RichDependencies) <= 4.12.0-1
 ],
 [ignore])

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -1190,7 +1190,7 @@ import json
 s = open('stdout').read()
 print(len(json.loads(s)))
 ],
-[60
+[61
 ],
 [])
 RPMTEST_CLEANUP


### PR DESCRIPTION
With the SHA3 digests in, we're close enough to final v6 format to make it the default. Update the handful of tests that are affected and drop the experimental note from macros.in.

We fully expect distros to override this locally for a while, but upstream needs to make this change now.

Fixes: #3455