### PR TITLE
Reflect all scriptlet errors in rpmtsRun() return code

### DIFF
--- a/lib/rpmts_internal.hh
+++ b/lib/rpmts_internal.hh
@@ -101,6 +101,7 @@ struct rpmts_s {
     int min_writes;             /*!< macro minimize_writes used */
 
     time_t overrideTime;	/*!< Time value used when overriding system clock. */
+    int scriptError;		/*!< scriptlet error tracking */
 };
 
 /** \ingroup rpmts

--- a/lib/transaction.cc
+++ b/lib/transaction.cc
@@ -1724,6 +1724,7 @@ rpmRC runScript(rpmts ts, rpmte te, Header h, ARGV_const_t prefixes,
      * (which is only happens with %prein and %preun scriptlets) or not.
      */
     if (rc != RPMRC_OK) {
+	ts->scriptError = 1;
 	if (warn_only) {
 	    rc = RPMRC_OK;
 	}
@@ -1879,7 +1880,7 @@ int rpmtsRun(rpmts ts, rpmps okProbs, rpmprobFilterFlags ignoreSet)
 	runTransScripts(ts, PKG_TRANSFILETRIGGERIN);
     }
     /* Final exit code */
-    rc = nfailed ? -1 : 0;
+    rc = (nfailed || ts->scriptError) ? -1 : 0;
 
 exit:
     /* Run post transaction hook for all plugins */

--- a/tests/data/SPECS/ftrigfail.spec
+++ b/tests/data/SPECS/ftrigfail.spec
@@ -1,0 +1,28 @@
+%{!?ver:%define ver 1.0}
+%{!?trigpath:%define trigpath /usr/bin}
+
+Name:           ftrigfail
+Version:        %{ver}
+Release:        1
+Summary:        Testing file trigger error behavior
+
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+%{lua:
+t = { "filetriggerin", "filetriggerun", "filetriggerpostun",
+      "transfiletriggerin", "transfiletriggerun", "transfiletriggerpostun" }
+for i, s in ipairs(t) do
+   print(string.format('%%%s -e -- %s\n', s, macros.trigpath))
+   print(string.format('echo %s\n', s:upper()))
+   print(string.format('cat\n'))
+   print(string.format('%%{?fail%s:exit 1}\n\n', s))
+end
+}
+
+%files
+%defattr(-,root,root,-)

--- a/tests/data/SPECS/triggers.spec
+++ b/tests/data/SPECS/triggers.spec
@@ -12,15 +12,19 @@ BuildArch:	noarch
 %files
 %defattr(-,root,root,-)
 
-%triggerprein -- %{trigpkg}
+%triggerprein -e -- %{trigpkg}
 echo %{name}-%{version}-%{release} TRIGGERPREIN $*
+%%{?failtriggerprein:exit 1}
 
-%triggerin -- %{trigpkg}
+%triggerin -e -- %{trigpkg}
 echo %{name}-%{version}-%{release} TRIGGERIN $*
+%%{?failtriggerin:exit 1}
 
-%triggerun -- %{trigpkg}
+%triggerun -e -- %{trigpkg}
 echo %{name}-%{version}-%{release} TRIGGERUN $*
+%%{?failtriggerun:exit 1}
 
-%triggerpostun -- %{trigpkg}
+%triggerpostun -e -- %{trigpkg}
 echo %{name}-%{version}-%{release} TRIGGERPOSTUN $*
+%%{?failtriggerpostun:exit 1}
 

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1509,7 +1509,7 @@ deptest-test-obsoletes-1.0-1.noarch
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpm -i create user])
-AT_KEYWORDS([install])
+AT_KEYWORDS([install sysusers])
 RPMTEST_CHECK([
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser u myuser 876 - /home/myuser /bin/sh}"\
@@ -1526,7 +1526,7 @@ runroot rpm -V --root /alt ${VERIFYOPTS} deptest-user
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpm -i create group])
-AT_KEYWORDS([install])
+AT_KEYWORDS([install sysusers])
 RPMTEST_CHECK([
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser g mygroup 678}"\

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1515,6 +1515,19 @@ RPMTEST_CHECK([
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser u myuser 876 - /home/myuser /bin/sh}"\
   /data/SPECS/deptest.spec
 runroot rpmkeys --import --root /alt /root/.config/rpm/*.asc
+# --root produces a warning from unshare plugin, disable
+runroot rpm -U --define "__systemd_sysusers /bin/false" \
+		--define "__transaction_unshare %{nil}" \
+		--root /alt \
+		/build/RPMS/noarch/deptest-user-1.0-1.noarch.rpm
+],
+[1],
+[],
+[error: %sysusers(deptest-user-1.0-1.noarch) scriptlet failed, exit status 1
+error: deptest-user-1.0-1.noarch: install failed
+])
+
+RPMTEST_CHECK([
 runroot rpm -U --root /alt /build/RPMS/noarch/deptest-user-1.0-1.noarch.rpm 2> /dev/null
 runroot tail -1 /alt/etc/passwd
 runroot rpm -V --root /alt ${VERIFYOPTS} deptest-user

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -19,209 +19,252 @@ pkgfile1="/build/RPMS/noarch/${pkg1}.noarch.rpm"
 pkgfile2="/build/RPMS/noarch/${pkg2}.noarch.rpm"
 
 RPMTEST_CHECK([
-echo PRETRANSFAIL
-runroot rpm -U --define "exitpretrans 1" ${pkgfile1} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
+runroot rpm -U --define "exitpretrans 1" ${pkgfile1}
 ],
 [1],
-[PRETRANSFAIL
-error: %pretrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
+[],
+[error: %pretrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
 error: scriptfail-1.0-1.noarch: install skipped
-1
-package scriptfail is not installed
-],
-[])
+])
 
 RPMTEST_CHECK([
-echo PRETRANS
-runroot rpm -U --define "exitpretrans 0" ${pkgfile1} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
-],
-[0],
-[PRETRANS
-0
-scriptfail-1.0-1.noarch
-],
-[])
-
-RPMTEST_CHECK([
-echo PREFAIL
-runroot rpm -U --define "exitpre 1" ${pkgfile1} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
+runroot rpm -q ${pkgname}
 ],
 [1],
-[PREFAIL
-error: %prein(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
+[package scriptfail is not installed
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U --define "exitpretrans 0" ${pkgfile1}
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
+runroot rpm -e ${pkgname}
+],
+[0],
+[scriptfail-1.0-1.noarch
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U --define "exitpre 1" ${pkgfile1}
+],
+[1],
+[],
+[error: %prein(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
 error: scriptfail-1.0-1.noarch: install failed
-1
-package scriptfail is not installed
-],
-[])
+])
 
 RPMTEST_CHECK([
-echo PRE
-runroot rpm -U --define "exitpre 0" ${pkgfile1} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-],
-[0],
-[PRE
-0
-scriptfail-1.0-1.noarch
-],
-[])
-
-RPMTEST_CHECK([
-echo PREUNFAIL
-runroot rpm -e --define "exitpreun 1" ${pkgname} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-],
-[0],
-[PREUNFAIL
-error: %preun(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
-error: scriptfail-1.0-1.noarch: erase failed
-1
-scriptfail-1.0-1.noarch
-],
-[])
-
-RPMTEST_CHECK([
-echo PREUNTRANSFAIL
-runroot rpm -e --define "exitpreuntrans 1" ${pkgname} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-],
-[0],
-[PREUNTRANSFAIL
-error: %preuntrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
-error: scriptfail-1.0-1.noarch: erase skipped
-1
-scriptfail-1.0-1.noarch
-],
-[])
-
-RPMTEST_CHECK([
-echo PREUN
-runroot rpm -e --define "exitpreun 0" ${pkgname} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
+runroot rpm -q ${pkgname}
 ],
 [1],
-[PREUN
-0
-package scriptfail is not installed
+[package scriptfail is not installed
 ],
 [])
 
 RPMTEST_CHECK([
-echo POSTFAIL
-runroot rpm -U ${pkgfile1} 2>&1
-runroot rpm -U --define "exitpost 1" ${pkgfile2} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
+runroot rpm -U --define "exitpre 0" ${pkgfile1}
 ],
 [0],
-[POSTFAIL
-warning: %post(scriptfail-2.0-1.noarch) scriptlet failed, exit status 1
-0
-scriptfail-2.0-1.noarch
-],
+[],
 [])
 
 RPMTEST_CHECK([
-echo POST
-runroot rpm -U ${pkgfile1} 2>&1
-runroot rpm -U --define "exitpost 0" ${pkgfile2} 2>&1; echo $?
 runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
 ],
 [0],
-[POST
-0
-scriptfail-2.0-1.noarch
+[scriptfail-1.0-1.noarch
 ],
 [])
 
 RPMTEST_CHECK([
-echo POSTTRANSFAIL
-runroot rpm -U --define "exitposttrans 1" ${pkgfile1} 2>&1; echo $?
+runroot rpm -e --define "exitpreun 1" ${pkgname}
+],
+[1],
+[],
+[error: %preun(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
+error: scriptfail-1.0-1.noarch: erase failed
+])
+
+RPMTEST_CHECK([
 runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
 ],
 [0],
-[POSTTRANSFAIL
-warning: %posttrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
-0
-scriptfail-1.0-1.noarch
+[scriptfail-1.0-1.noarch
 ],
 [])
 
 RPMTEST_CHECK([
-echo POSTTRANS
-runroot rpm -U --define "exitposttrans 0" ${pkgfile1} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
+runroot rpm -e --define "exitpreuntrans 1" ${pkgname}
+],
+[1],
+[],
+[error: %preuntrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
+error: scriptfail-1.0-1.noarch: erase skipped
+])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
 ],
 [0],
-[POSTTRANS
-0
-scriptfail-1.0-1.noarch
+[scriptfail-1.0-1.noarch
 ],
 [])
 
 RPMTEST_CHECK([
-echo POSTUNFAIL
-runroot rpm -U ${pkgfile1} 2>&1
-runroot rpm -U --define "exitpostun 1" ${pkgfile2} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
+runroot rpm -e --define "exitpreun 0" ${pkgname}
 ],
 [0],
-[POSTUNFAIL
-warning: %postun(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
-0
-scriptfail-2.0-1.noarch
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
+],
+[1],
+[package scriptfail is not installed
 ],
 [])
 
 RPMTEST_CHECK([
-echo POSTUNTRANSFAIL
-runroot rpm -U ${pkgfile1} 2>&1
-runroot rpm -U --define "exitpostuntrans 1" ${pkgfile2} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
+runroot rpm -U ${pkgfile1}
+runroot rpm -U --define "exitpost 1" ${pkgfile2}
 ],
 [0],
-[POSTUNTRANSFAIL
-warning: %postuntrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
-0
-scriptfail-2.0-1.noarch
-],
-[])
+[],
+[warning: %post(scriptfail-2.0-1.noarch) scriptlet failed, exit status 1
+])
 
 RPMTEST_CHECK([
-echo POSTUN
-runroot rpm -U ${pkgfile1} 2>&1
-runroot rpm -U --define "exitpostun 0" ${pkgfile2} 2>&1; echo $?
-runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
+runroot rpm -q ${pkgname}
 ],
 [0],
-[POSTUN
-0
-scriptfail-2.0-1.noarch
+[scriptfail-2.0-1.noarch
 ],
 [])
 
 RPMTEST_CHECK([
-echo POSTUNTRANS
-runroot rpm -U ${pkgfile1} 2>&1
-runroot rpm -U --define "exitpostuntrans 0" ${pkgfile2} 2>&1; echo $?
+runroot rpm -e ${pkgname}
+runroot rpm -U ${pkgfile1}
+runroot rpm -U --define "exitpost 0" ${pkgfile2}
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
 runroot rpm -q ${pkgname} 2>&1
-runroot rpm -e ${pkgname} 2>&1
+],
+[0],
+[scriptfail-2.0-1.noarch
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -e ${pkgname}
+runroot rpm -U --define "exitposttrans 1" ${pkgfile1}
+],
+[0],
+[],
+[warning: %posttrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
+],
+[0],
+[scriptfail-1.0-1.noarch
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -e ${pkgname}
+runroot rpm -U --define "exitposttrans 0" ${pkgfile1}
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
+],
+[0],
+[scriptfail-1.0-1.noarch
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -e ${pkgname}
+runroot rpm -U ${pkgfile1}
+runroot rpm -U --define "exitpostun 1" ${pkgfile2}
+],
+[0],
+[],
+[warning: %postun(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
+],
+[0],
+[scriptfail-2.0-1.noarch
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -e ${pkgname}
+runroot rpm -U ${pkgfile1}
+runroot rpm -U --define "exitpostuntrans 1" ${pkgfile2}
+],
+[0],
+[],
+[warning: %postuntrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
+],
+[0],
+[scriptfail-2.0-1.noarch
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -e ${pkgname}
+runroot rpm -U ${pkgfile1}
+runroot rpm -U --define "exitpostun 0" ${pkgfile2}
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
+],
+[0],
+[scriptfail-2.0-1.noarch
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -e ${pkgname}
+runroot rpm -U ${pkgfile1}
+runroot rpm -U --define "exitpostuntrans 0" ${pkgfile2}
 ],
 [],
-[POSTUNTRANS
-0
-scriptfail-2.0-1.noarch
+[])
+
+RPMTEST_CHECK([
+runroot rpm -q ${pkgname}
+],
+[0],
+[scriptfail-2.0-1.noarch
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -136,7 +136,7 @@ RPMTEST_CHECK([
 runroot rpm -U ${pkgfile1}
 runroot rpm -U --define "exitpost 1" ${pkgfile2}
 ],
-[0],
+[1],
 [],
 [warning: %post(scriptfail-2.0-1.noarch) scriptlet failed, exit status 1
 ])
@@ -170,7 +170,7 @@ RPMTEST_CHECK([
 runroot rpm -e ${pkgname}
 runroot rpm -U --define "exitposttrans 1" ${pkgfile1}
 ],
-[0],
+[1],
 [],
 [warning: %posttrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
 ])
@@ -204,7 +204,7 @@ runroot rpm -e ${pkgname}
 runroot rpm -U ${pkgfile1}
 runroot rpm -U --define "exitpostun 1" ${pkgfile2}
 ],
-[0],
+[1],
 [],
 [warning: %postun(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
 ])
@@ -222,7 +222,7 @@ runroot rpm -e ${pkgname}
 runroot rpm -U ${pkgfile1}
 runroot rpm -U --define "exitpostuntrans 1" ${pkgfile2}
 ],
-[0],
+[1],
 [],
 [warning: %postuntrans(scriptfail-1.0-1.noarch) scriptlet failed, exit status 1
 ])
@@ -425,7 +425,7 @@ runroot rpm -U \
 	--nosignature \
 	/data/RPMS/foo-1.0-1.noarch.rpm
 ],
-[0],
+[1],
 [triggers-1.0-1 TRIGGERPREIN 1 0
 triggers-1.0-1 TRIGGERIN 1 1
 ],
@@ -437,7 +437,7 @@ runroot rpm -e \
 	--define "failtriggerun 1" \
 	foo
 ],
-[0],
+[1],
 [triggers-1.0-1 TRIGGERUN 1 0
 triggers-1.0-1 TRIGGERPOSTUN 1 0
 ],
@@ -450,7 +450,7 @@ runroot rpm -U \
 	--nosignature \
 	/data/RPMS/foo-1.0-1.noarch.rpm
 ],
-[0],
+[1],
 [triggers-1.0-1 TRIGGERPREIN 1 0
 triggers-1.0-1 TRIGGERIN 1 1
 ],
@@ -462,7 +462,7 @@ runroot rpm -e \
 	--define "failtriggerpostun 1" \
 	foo
 ],
-[0],
+[1],
 [triggers-1.0-1 TRIGGERUN 1 0
 triggers-1.0-1 TRIGGERPOSTUN 1 0
 ],
@@ -675,7 +675,7 @@ runroot rpm -U \
 	--define "failfiletriggerin 1" \
 	/build/RPMS/noarch/testdoc-1.0-1.noarch.rpm
 ],
-[0],
+[1],
 [FILETRIGGERIN
 /usr/share/doc/testdoc/examples/example1
 /usr/share/doc/testdoc/examples/example2
@@ -691,7 +691,7 @@ runroot rpm -e \
 	--define "failtransfiletriggerun 1" \
 	testdoc
 ],
-[0],
+[1],
 [TRANSFILETRIGGERUN
 /usr/share/doc/testdoc/examples/example1
 /usr/share/doc/testdoc/examples/example2
@@ -711,7 +711,7 @@ runroot rpm -U \
 	--define "failtransfiletriggerin 1" \
 	/build/RPMS/noarch/testdoc-1.0-1.noarch.rpm
 ],
-[0],
+[1],
 [FILETRIGGERIN
 /usr/share/doc/testdoc/examples/example1
 /usr/share/doc/testdoc/examples/example2
@@ -727,7 +727,7 @@ runroot rpm -e \
 	--define "failtransfiletriggerun 1" \
 	testdoc
 ],
-[0],
+[1],
 [TRANSFILETRIGGERUN
 /usr/share/doc/testdoc/examples/example1
 /usr/share/doc/testdoc/examples/example2
@@ -748,7 +748,7 @@ runroot rpm -e \
 	--define "failfiletriggerun 1" \
 	testdoc
 ],
-[0],
+[1],
 [TRANSFILETRIGGERUN
 /usr/share/doc/testdoc/examples/example1
 /usr/share/doc/testdoc/examples/example2
@@ -769,7 +769,7 @@ runroot rpm -e \
 	--define "failfiletriggerpostun 1" \
 	testdoc
 ],
-[0],
+[1],
 [TRANSFILETRIGGERUN
 /usr/share/doc/testdoc/examples/example1
 /usr/share/doc/testdoc/examples/example2
@@ -790,7 +790,7 @@ runroot rpm -e \
 	--define "failtransfiletriggerpostun 1" \
 	testdoc
 ],
-[0],
+[1],
 [TRANSFILETRIGGERUN
 /usr/share/doc/testdoc/examples/example1
 /usr/share/doc/testdoc/examples/example2

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -404,6 +404,72 @@ triggers-1.0-1 TRIGGERUN 0 1
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([basic trigger scripts: failures])
+AT_KEYWORDS([trigger script])
+
+runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
+runroot rpmbuild --quiet -bb --define "rel 1" --define "trigpkg foo" /data/SPECS/triggers.spec
+
+RPMTEST_CHECK([
+runroot rpm -U \
+	/build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm \
+	/build/RPMS/noarch/triggers-1.0-1.noarch.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U \
+	--define "failtriggerprein 1" \
+	--nosignature \
+	/data/RPMS/foo-1.0-1.noarch.rpm
+],
+[0],
+[triggers-1.0-1 TRIGGERPREIN 1 0
+triggers-1.0-1 TRIGGERIN 1 1
+],
+[warning: %triggerprein(triggers-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -e \
+	--define "failtriggerun 1" \
+	foo
+],
+[0],
+[triggers-1.0-1 TRIGGERUN 1 0
+triggers-1.0-1 TRIGGERPOSTUN 1 0
+],
+[warning: %triggerun(triggers-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -U \
+	--define "failtriggerin 1" \
+	--nosignature \
+	/data/RPMS/foo-1.0-1.noarch.rpm
+],
+[0],
+[triggers-1.0-1 TRIGGERPREIN 1 0
+triggers-1.0-1 TRIGGERIN 1 1
+],
+[warning: %triggerin(triggers-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -e \
+	--define "failtriggerpostun 1" \
+	foo
+],
+[0],
+[triggers-1.0-1 TRIGGERUN 1 0
+triggers-1.0-1 TRIGGERPOSTUN 1 0
+],
+[warning: %triggerpostun(triggers-1.0-1.noarch) scriptlet failed, exit status 1
+])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([basic trigger scripts: runtime args])
 AT_KEYWORDS([trigger script])
 
@@ -582,6 +648,162 @@ transfiletriggerpostun(/foo*):
 
 ],
 [])
+RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([basic file triggers: failures])
+AT_KEYWORDS([filetrigger script])
+
+runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
+runroot rpmbuild --quiet -bb \
+	--define "_datadir /usr/share" \
+	/data/SPECS/testdoc.spec
+runroot rpmbuild --quiet -bb \
+	--define "trigpath /usr/share/doc/testdoc/examples/" \
+	/data/SPECS/ftrigfail.spec
+
+RPMTEST_CHECK([
+runroot rpm -U \
+	/build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm \
+	/build/RPMS/noarch/ftrigfail-1.0-1.noarch.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -U \
+	--define "failfiletriggerin 1" \
+	/build/RPMS/noarch/testdoc-1.0-1.noarch.rpm
+],
+[0],
+[FILETRIGGERIN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+TRANSFILETRIGGERIN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+],
+[warning: %filetriggerin(ftrigfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -e \
+	--define "failtransfiletriggerun 1" \
+	testdoc
+],
+[0],
+[TRANSFILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERPOSTUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+TRANSFILETRIGGERPOSTUN
+],
+[warning: %transfiletriggerun(ftrigfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -U \
+	--define "failtransfiletriggerin 1" \
+	/build/RPMS/noarch/testdoc-1.0-1.noarch.rpm
+],
+[0],
+[FILETRIGGERIN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+TRANSFILETRIGGERIN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+],
+[warning: %transfiletriggerin(ftrigfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -e \
+	--define "failtransfiletriggerun 1" \
+	testdoc
+],
+[0],
+[TRANSFILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERPOSTUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+TRANSFILETRIGGERPOSTUN
+],
+[warning: %transfiletriggerun(ftrigfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/testdoc-1.0-1.noarch.rpm &> /dev/null
+runroot rpm -e \
+	--define "failfiletriggerun 1" \
+	testdoc
+],
+[0],
+[TRANSFILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERPOSTUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+TRANSFILETRIGGERPOSTUN
+],
+[warning: %filetriggerun(ftrigfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/testdoc-1.0-1.noarch.rpm &> /dev/null
+runroot rpm -e \
+	--define "failfiletriggerpostun 1" \
+	testdoc
+],
+[0],
+[TRANSFILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERPOSTUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+TRANSFILETRIGGERPOSTUN
+],
+[warning: %filetriggerpostun(ftrigfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/testdoc-1.0-1.noarch.rpm &> /dev/null
+runroot rpm -e \
+	--define "failtransfiletriggerpostun 1" \
+	testdoc
+],
+[0],
+[TRANSFILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+FILETRIGGERPOSTUN
+/usr/share/doc/testdoc/examples/example1
+/usr/share/doc/testdoc/examples/example2
+TRANSFILETRIGGERPOSTUN
+],
+[warning: %transfiletriggerpostun(ftrigfail-1.0-1.noarch) scriptlet failed, exit status 1
+])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([basic file triggers: prefix args])


### PR DESCRIPTION
The first commits are just prepwork for the actual change - add tests for all the possible scripts that can fail etc, the last one is the one with the actual change:

In rpm 4.4.x and earlier, scriptlet failures often caused duplicate packages to be left in the database: for example a %post scriptlet failing in an update would cause canceling the corresponding erasure element of the old version, but the files of the newer version are already on disk at this point. This caused all sorts of annoyances to the users, including missed security updates and having to periodically mop any failures out of the rpmdb. There was an entire ecosystem of tooling and documentation around this phenomena...

In 4.6.0 we started filtering out such "post" scriptlet errors in commit 9cfb380cc4529ea6b9314cc67819069c8e9c1a23 - behavior we've done ever since. This solved the duplicate syndrome and was good enough for the average system out there, but there are use-cases where one needs to know exactly whether things went 100% correctly or not. This has been raised several times in the intevening years, enough that I now think the implementation in 4.6.0 was a mistake.

6.0 seems like a better time than most to change such a fundamental behavior again. Duplicates were useful for the one person actually troubleshooting it, but an annoying pain for the vast majority of users.  Thus, we're not bringing duplicates back, just reflecting ANY scriptlet errors in the transaction result code. The simplest way to achieve this is to just have a central "there was some failure" flag in the transaction set and base the final return code on that.

In other words, this is a middle ground between the old and current behavior: pre-scriptlets are logged as hard errors that cancel the element and its dependents (ie on upgrade, erasure element).  Post-scriptlets are still logged as warnings as the files have already been laid out and there's no going back, but it IS a sign that not all was well, and so we reflect it with a non-zero status from the transaction.

Update the tests to reflect the new expected return code.

Fixes: #2581