### PR TITLE
Rename rpm-macroproc(7) (back to) rpm-macros(7)

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -3,7 +3,7 @@ set(core
 	rpm.8 rpmbuild.1 rpmdb.8 rpmkeys.8 rpmsign.1 rpmspec.1
 	rpmdeps.1 rpmgraph.1 rpmlua.1 rpm-common.8 rpmsort.1
 	rpm-macrofile.5 rpm-config.5 rpm-rpmrc.5 rpm-setup-autosign.1
-	rpm-payloadflags.5 rpmbuild-config.5 rpm-queryformat.7 rpm-macroproc.7
+	rpm-payloadflags.5 rpmbuild-config.5 rpm-queryformat.7 rpm-macros.7
 )
 set(extra
 	rpm-plugins.8 rpm-plugin-prioreset.8 rpm-plugin-syslog.8

--- a/docs/man/rpm-common.8.scd
+++ b/docs/man/rpm-common.8.scd
@@ -50,7 +50,7 @@ options and operations documented in this manual:
 
 *-E* '_EXPR_',
 *--eval*='_EXPR_'
-	Prints *rpm-macroproc*(7) expansion of _EXPR_.
+	Prints *rpm-macros*(7) expansion of _EXPR_.
 
 *--load* _FILE_
 	Load an individual *rpm-macrofile*(5).
@@ -170,4 +170,4 @@ On success, 0 is returned, a non-zero failure code otherwise.
 ```
 
 # SEE ALSO
-*popt*(3), *rpm*(8) *rpm-config*(5), *rpm-rpmrc*(5), *rpm-macroproc*(7)
+*popt*(3), *rpm*(8) *rpm-config*(5), *rpm-rpmrc*(5), *rpm-macros*(7)

--- a/docs/man/rpm-config.5.scd
+++ b/docs/man/rpm-config.5.scd
@@ -18,7 +18,7 @@ _/etc/rpm/%{\_target}/macros_++
 _~/.config/rpm/macros_
 
 # DESCRIPTION
-The primary configuration mechanism in *rpm* is *rpm-macroproc*(7).
+The primary configuration mechanism in *rpm* is *rpm-macros*(7).
 On startup, *rpm* reads a set of *rpm-macrofile*(5) files determined
 by the _macro path_.
 
@@ -236,4 +236,4 @@ If *XDG_CONFIG_HOME* environment variable is set, it replaces _~/.config_
 in the _macro path_.
 
 # SEE ALSO
-*rpm*(8), *rpm-common*(8), *rpm-macrofile*(5), *rpm-rpmrc*(5), *rpm-macroproc*(7)
+*rpm*(8), *rpm-common*(8), *rpm-macrofile*(5), *rpm-rpmrc*(5), *rpm-macros*(7)

--- a/docs/man/rpm-macrofile.5.scd
+++ b/docs/man/rpm-macrofile.5.scd
@@ -7,7 +7,7 @@ RPM-MACROFILE(5)
 %_NAME_[([_OPTS_]) _BODY_
 
 # DESCRIPTION
-Rpm macro files are used to define *rpm-macroproc*(7) in the global macro context.
+Rpm macro files are used to define *rpm-macros*(7) in the global macro context.
 The two primary uses of macros are assisting packaging work, and configuring rpm
 behavior. A pre-determined set of macro files is read upon *rpm* library
 initialization as described in *rpm-config*(5) but they can also be loaded via
@@ -56,6 +56,6 @@ Multiline parametric Lua macro:
 
 # SEE ALSO
 *rpm-config*(5) *rpmbuild-config*(5)
-*rpm-macroproc*(7)
+*rpm-macros*(7)
 
 *https://rpm-software-management.github.io/rpm/manual/macros.html*

--- a/docs/man/rpm-macros.7.scd
+++ b/docs/man/rpm-macros.7.scd
@@ -1,7 +1,7 @@
-RPM-MACROPROC(7)
+RPM-MACROS(7)
 
 # NAME
-rpm-macroproc - RPM macro processor
+rpm-macros - RPM macro processor
 
 # SYNOPSIS
 ## Defining

--- a/docs/man/rpm-rpmrc.5.scd
+++ b/docs/man/rpm-rpmrc.5.scd
@@ -97,4 +97,4 @@ If *XDG_CONFIG_HOME* environment variable is set, it replaces _~/.config_
 in the _rpmrc path_.
 
 # SEE ALSO
-*rpm*(8), *rpm-common*(8), *rpm-config*(5), *rpm-macroproc*(7)
+*rpm*(8), *rpm-common*(8), *rpm-config*(5), *rpm-macros*(7)

--- a/docs/man/rpmbuild-config.5.scd
+++ b/docs/man/rpmbuild-config.5.scd
@@ -7,7 +7,7 @@ RPMBUILD-CONFIG(5)
 _NAME_ _VALUE_
 
 # DESCRIPTION
-The primary configuration mechanism in *rpmbuild* is *rpm-macroproc*(7).
+The primary configuration mechanism in *rpmbuild* is *rpm-macros*(7).
 See *rpm-config*(5) for the description of the general mechanism,
 this manual only describes the configurables affecting *rpmbuild*
 operation.
@@ -302,4 +302,4 @@ Sometimes also useful for temporarily working around issues while packaging.
 # SEE ALSO
 *rpmbuild*(1), *rpm-common*(8), *rpm-macrofile*(5),
 *rpm-rpmrc*(5), *rpm-config*(5), *rpm-payloadflags*(5)
-*rpm-macroproc*(7)
+*rpm-macros*(7)

--- a/docs/man/rpmbuild.1.scd
+++ b/docs/man/rpmbuild.1.scd
@@ -202,7 +202,7 @@ See *rpm-common*(8)
 
 *gendiff*(1), *popt*(3), *rpm*(8), *rpm-common*(8), *rpmbuild-config*(5),
 *rpm2cpio*(1), *rpmkeys*(8), *rpmspec*(1), *rpmsign*(1),
-*rpm-setup-autosign*(1) *rpm-macroproc*(7)
+*rpm-setup-autosign*(1) *rpm-macros*(7)
 
 *rpmbuild --help* - as rpm supports customizing the options via popt
 aliases it's impossible to guarantee that what's described in the

--- a/docs/man/rpmspec.1.scd
+++ b/docs/man/rpmspec.1.scd
@@ -124,7 +124,7 @@ On success, 0 is returned, a non-zero failure code otherwise.
 	```
 
 # SEE ALSO
-*popt*(3), *rpm*(8), *rpmbuild*(1), *rpm-queryformat*(7), *rpm-macroproc*(7)
+*popt*(3), *rpm*(8), *rpmbuild*(1), *rpm-queryformat*(7), *rpm-macros*(7)
 
 *rpmspec --help* - as rpm supports customizing the options via popt
 aliases it's impossible to guarantee that what's described in the

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -1,5 +1,5 @@
 ---
 layout: redirected
 sitemap: false
-redirect_to: /man/rpm-macroproc.7
+redirect_to: /man/rpm-macros.7
 ---

--- a/macros.in
+++ b/macros.in
@@ -1,7 +1,7 @@
 # This is a global RPM configuration file. All changes made here will
 # be lost when the rpm package is upgraded.
 #
-# See rpm-macroproc(7), rpm-macrofile(5) and rpm-config(5) rpmbuild-config(5)
+# See rpm-macros(7), rpm-macrofile(5) and rpm-config(5) rpmbuild-config(5)
 # for more information.
 
 #==============================================================================


### PR DESCRIPTION
It was initially called rpm-macros(7) but got renamed to rpm-macroproc(7) during the review process. But, after a couple of days of use, turns out we all want rpm-macros(7) afterall. Oh well.
