### PR TITLE
scripts/sysusers: Make sure $ROOT is passed to usermod

### DIFF
--- a/scripts/sysusers.sh
+++ b/scripts/sysusers.sh
@@ -93,7 +93,7 @@ user() {
 	fi
 
 	if [[ $expire ]]; then
-	    usermod -e 1 "${user}"
+	    usermod -R "$ROOT" -e 1 "${user}"
 	fi
 }
 


### PR DESCRIPTION
There's one call to usermod in the sysusers script to which we don't pass $ROOT. Let's fix that.