### PR TITLE
Remove `md_dict` from all rpmfoo_Type's

### DIFF
--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -11,7 +11,6 @@
 
 struct rpmarchiveObject_s {
     PyObject_HEAD
-    PyObject *md_dict;
     rpmfi archive;
     rpmfiles files;
 };

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -10,7 +10,6 @@
 
 struct rpmdsObject_s {
     PyObject_HEAD
-    PyObject *md_dict;		/*!< to look like PyModuleObject */
     int		active;
     rpmds	ds;
 };

--- a/python/rpmfd-py.c
+++ b/python/rpmfd-py.c
@@ -6,7 +6,6 @@
 
 struct rpmfdObject_s {
     PyObject_HEAD
-    PyObject *md_dict;
     FD_t fd;
     char *mode;
     char *flags;

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -12,7 +12,6 @@
 /* A single file from rpmfiles set, can't be independently instanciated */
 struct rpmfileObject_s {
     PyObject_HEAD
-    PyObject *md_dict;
     rpmfiles files;		/* reference to rpmfiles */
     int ix;			/* index to rpmfiles */
 };
@@ -362,7 +361,6 @@ PyObject * rpmfile_Wrap(rpmfiles files, int ix)
 /* The actual rpmfiles info set */
 struct rpmfilesObject_s {
     PyObject_HEAD
-    PyObject *md_dict;		/*!< to look like PyModuleObject */
     rpmfiles files;
 };
 

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -35,7 +35,6 @@
 
 struct rpmiiObject_s {
     PyObject_HEAD
-    PyObject *md_dict;		/*!< to look like PyModuleObject */
     PyObject *ref;		/* for db/ts refcounting */
     rpmdbIndexIterator ii;
     rpmtd keytd;

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -4,7 +4,6 @@
 
 struct rpmPubkeyObject_s {
     PyObject_HEAD
-    PyObject *md_dict;
     rpmPubkey pubkey;
 };
 
@@ -77,7 +76,6 @@ PyType_Spec rpmPubkey_Type_Spec = {
 
 struct rpmKeyringObject_s {
     PyObject_HEAD
-    PyObject *md_dict;
     rpmKeyring keyring;
 };
 

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -61,7 +61,6 @@
 
 struct rpmmiObject_s {
     PyObject_HEAD
-    PyObject *md_dict;		/*!< to look like PyModuleObject */
     PyObject *ref;		/* for db/ts refcounting */
     rpmdbMatchIterator mi;
 } ;

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -4,7 +4,6 @@
 
 struct rpmProblemObject_s {
     PyObject_HEAD
-    PyObject *md_dict;
     rpmProblem	prob;
 };
 

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -4,7 +4,6 @@
 
 struct rpmstrPoolObject_s {
     PyObject_HEAD
-    PyObject *md_dict;
     rpmstrPool pool;
 };
 

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -41,7 +41,6 @@
 
 struct rpmteObject_s {
     PyObject_HEAD
-    PyObject *md_dict;		/*!< to look like PyModuleObject */
     rpmte	te;
 };
 

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -137,7 +137,6 @@
 
 struct rpmtsObject_s {
     PyObject_HEAD
-    PyObject *md_dict;		/*!< to look like PyModuleObject */
     rpmfdObject *scriptFd;
     PyObject *keyList;
     rpmts	ts;

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -5,7 +5,6 @@
 
 struct rpmverObject_s {
     PyObject_HEAD
-    PyObject *md_dict;
     rpmver ver;
 };
 


### PR DESCRIPTION
Remove the `PyObject *md_dict` members that were added to make RPM's Python types "look like PyModuleObject" in 2002 in 8681309f1a19ebe597464aa3d1304bef06d3790e (CVS patchset 5936).

Note that PyModuleObject is an internal implementation detail of Python, and subject to change. Also, accessing the same object as both `rpmFoo_s*` and `PyModuleObject*` can run afoul of C pointer aliasing rules.

The struct member is undocumented and unused in the rest of the repository.

---

This is yet another atomic change coming from the Python module isolation work.