### PR TITLE
Realize rpm-payloadflags is not section 5 material

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -3,7 +3,7 @@ set(core
 	rpm.8 rpmbuild.1 rpmdb.8 rpmkeys.8 rpmsign.1 rpmspec.1
 	rpmdeps.1 rpmgraph.1 rpmlua.1 rpm-common.8 rpmsort.1
 	rpm-macrofile.5 rpm-config.5 rpm-rpmrc.5 rpm-setup-autosign.1
-	rpm-payloadflags.5 rpmbuild-config.5 rpm-queryformat.7 rpm-macros.7
+	rpm-payloadflags.7 rpmbuild-config.5 rpm-queryformat.7 rpm-macros.7
 	rpm-lua.7
 )
 set(extra

--- a/docs/man/rpm-payloadflags.7.scd
+++ b/docs/man/rpm-payloadflags.7.scd
@@ -1,4 +1,4 @@
-RPM-PAYLOADFLAGS(5)
+RPM-PAYLOADFLAGS(7)
 
 # NAME
 *rpm-payloadflags* - RPM payload flags

--- a/docs/man/rpmbuild-config.5.scd
+++ b/docs/man/rpmbuild-config.5.scd
@@ -150,7 +150,7 @@ packages.
 
 *%\_binary_payload* _IOFLAGS_
 	The IO method and compression to use for generating the payload
-	of binary packages. See *rpm-payloadflags*(5).
+	of binary packages. See *rpm-payloadflags*(7).
 
 *%\_buildhost* _HOSTNAME_
 	Use _HOSTNAME_ as the package buildhost instead of acquiring
@@ -193,7 +193,7 @@ packages.
 
 *%\_source_payload*
 	The IO method and compression to use for generating the payload
-	of source packages. See *rpm-payloadflags*(5).
+	of source packages. See *rpm-payloadflags*(7).
 
 *%\_\_gpg_reserved_space* _NUMBER_
 	The number of bytes to reserve for signatures in the signature header.
@@ -301,5 +301,5 @@ Sometimes also useful for temporarily working around issues while packaging.
 
 # SEE ALSO
 *rpmbuild*(1), *rpm-common*(8), *rpm-macrofile*(5),
-*rpm-rpmrc*(5), *rpm-config*(5), *rpm-payloadflags*(5)
+*rpm-rpmrc*(5), *rpm-config*(5), *rpm-payloadflags*(7)
 *rpm-macros*(7)

--- a/docs/manual/tags.md
+++ b/docs/manual/tags.md
@@ -93,8 +93,8 @@ Filedigestalgo    | 5011 | int32        | ID of file digest algorithm. If missin
 Longarchivesize   | 271  | int64        | (Uncompressed) payload size when > 4GB.
 Longsize          | 5009 | int64        | Installed package size when > 4GB.
 Mimedict          | 5116 | int32        | Dictionary of MIME types, only >= v6.
-Payloadcompressor | 1125 | string       | Payload compressor name (see `rpm-payloadflags`(5))
-Payloadflags      | 1126 | string       | Payload compressor level (see `rpm-payloadflags`(5))
+Payloadcompressor | 1125 | string       | Payload compressor name (see `rpm-payloadflags`(7))
+Payloadflags      | 1126 | string       | Payload compressor level (see `rpm-payloadflags`(7))
 Payloadformat     | 1124 | string       | Payload format (`cpio`)
 Prefixes          | 1098 | string array | Relocatable prefixes (on relocatable packages).
 Size              | 1009 | int32        | Installed package size.

--- a/include/rpm/rpmio.h
+++ b/include/rpm/rpmio.h
@@ -66,7 +66,7 @@ FD_t	Fdopen(FD_t ofd, const char * fmode);
  *
  * The `fmode` parameter is based on that of `fopen(3)`, but may also include a
  * compression method (`type` and `flags`) to use when opening the stream.
- * See `rpm-payloadflags`(5) manual for details.
+ * See `rpm-payloadflags`(7) manual for details.
  */
 FD_t	Fopen(const char * path,
 			const char * fmode);

--- a/macros.in
+++ b/macros.in
@@ -364,7 +364,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #%packager
 
 #	Compression type and level for source/binary package payloads.
-#	See rpm-payloadflags(5).
+#	See rpm-payloadflags(7).
 #
 #%_source_payload	w9.gzdio
 %_binary_payload	%[ %_rpmformat >=6 ? "w19.zstdio" : "w9.gzdio" ]


### PR DESCRIPTION
This is neither a file format nor a configuration file, but more of this misc API thing that ... belongs to section 7.