### PR TITLE
Fail package install/erase on %triggerprein/%triggerun failure

### DIFF
--- a/lib/rpmscript.cc
+++ b/lib/rpmscript.cc
@@ -78,10 +78,10 @@ static const struct scriptInfo_s scriptInfo[] = {
 	0, },
     { RPMSCRIPT_TRIGGERPREIN, "triggerprein", RPMSENSE_TRIGGERPREIN,
 	RPMTAG_TRIGGERPREIN, 0, 0,
-	0, },
+	RPMSCRIPT_FLAG_CRITICAL, },
     { RPMSCRIPT_TRIGGERUN, "triggerun", RPMSENSE_TRIGGERUN,
 	RPMTAG_TRIGGERUN, 0, 0,
-	0, },
+	RPMSCRIPT_FLAG_CRITICAL, },
     { RPMSCRIPT_TRIGGERIN, "triggerin", RPMSENSE_TRIGGERIN,
 	RPMTAG_TRIGGERIN, 0, 0,
 	0, },
@@ -669,6 +669,9 @@ rpmScript rpmScriptFromTriggerTag(Header h, rpmTagVal triggerTag,
 	script->args[0] = (char *)(script->args + 2);
 	script->args[1] = NULL;
 	strcpy(script->args[0], prog);
+	/* XXX File triggers never fail the transaction element */
+	if (tm == RPMSCRIPT_TRANSFILETRIGGER || tm == RPMSCRIPT_FILETRIGGER)
+	    script->flags &= ~RPMSCRIPT_FLAG_CRITICAL;
     }
 
     rpmtdFreeData(&tscripts);

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -427,21 +427,9 @@ runroot rpm -U \
 ],
 [1],
 [triggers-1.0-1 TRIGGERPREIN 1 0
-triggers-1.0-1 TRIGGERIN 1 1
 ],
-[warning: %triggerprein(triggers-1.0-1.noarch) scriptlet failed, exit status 1
-])
-
-RPMTEST_CHECK([
-runroot rpm -e \
-	--define "failtriggerun 1" \
-	foo
-],
-[1],
-[triggers-1.0-1 TRIGGERUN 1 0
-triggers-1.0-1 TRIGGERPOSTUN 1 0
-],
-[warning: %triggerun(triggers-1.0-1.noarch) scriptlet failed, exit status 1
+[error: %triggerprein(triggers-1.0-1.noarch) scriptlet failed, exit status 1
+error: foo-1.0-1.noarch: install failed
 ])
 
 RPMTEST_CHECK([
@@ -455,6 +443,18 @@ runroot rpm -U \
 triggers-1.0-1 TRIGGERIN 1 1
 ],
 [warning: %triggerin(triggers-1.0-1.noarch) scriptlet failed, exit status 1
+])
+
+RPMTEST_CHECK([
+runroot rpm -e \
+	--define "failtriggerun 1" \
+	foo
+],
+[1],
+[triggers-1.0-1 TRIGGERUN 1 0
+],
+[error: %triggerun(triggers-1.0-1.noarch) scriptlet failed, exit status 1
+error: foo-1.0-1.noarch: erase failed
 ])
 
 RPMTEST_CHECK([


### PR DESCRIPTION
%triggerprein and %triggerun are "pre" scriptlets that occur before package install and uninstall, respectively. We fail the install/erase on other such pre-scriptlets, so for consistency's sake it seems we should do so for these as well.

File triggers are too asymmetric to have sane failure modes for pre-thingies so we leave them alone here. Unfortunately file triggers don't have scriptlet types of their own and can't afford to stop for a big refactor just now, so manually filter them out in rpmScriptFromTriggerTag().

Fixes: #3815