### PR TITLE
Pull support for salted signatures in OpenPGP and adjust tests

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -42,7 +42,7 @@ The scdoc manual page generator, available from
     https://git.sr.ht/~sircmpwn/scdoc
 
 You will need a cryptographic library to support digests and an OpenPGP
-implementation to support signatures. rpm-sequoia (>= 1.3.0 required) is
+implementation to support signatures. rpm-sequoia (>= 1.9.0 required) is
 the most complete option, covering both, and also the default:
     https://github.com/rpm-software-management/rpm-sequoia
 

--- a/include/rpm/rpmcrypto.h
+++ b/include/rpm/rpmcrypto.h
@@ -145,6 +145,17 @@ int rpmDigestBundleAddID(rpmDigestBundle bundle, int algo, int id,
 int rpmDigestBundleUpdate(rpmDigestBundle bundle, const void *data, size_t len);
 
 /** \ingroup rpmcrypto
+ * Update context of an individual ID within bundle with next plain text buffer.
+ * @param bundle	digest bundle
+ * @param id		id of digest (arbitrary, must be > 0)
+ * @param data		next data buffer
+ * @param len		no. bytes of data
+ * @return		0 on success
+ */
+int rpmDigestBundleUpdateID(rpmDigestBundle bundle, int id,
+			const void *data, size_t len);
+
+/** \ingroup rpmcrypto
  * Return digest from a bundle and destroy context, see rpmDigestFinal().
  *
  * @param bundle	digest bundle

--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -489,6 +489,8 @@ int pgpDigParamsVersion(pgpDigParams digp);
  */
 uint32_t pgpDigParamsCreationTime(pgpDigParams digp);
 
+int pgpDigParamsSalt(pgpDigParams digp, const uint8_t **datap, size_t *lenp);
+
 /** \ingroup rpmpgp
  * Destroy parsed OpenPGP packet parameter(s).
  * @param digp		parameter container

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -22,7 +22,7 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/rpmio/rpmpgp_legacy/CMakeLists.txt)
 endif()
 
 if (WITH_SEQUOIA)
-	pkg_check_modules(RPMSEQUOIA REQUIRED IMPORTED_TARGET rpm-sequoia>=1.8.0)
+	pkg_check_modules(RPMSEQUOIA REQUIRED IMPORTED_TARGET rpm-sequoia>=1.9.0)
 	target_sources(librpmio PRIVATE rpmpgp_sequoia.cc)
 	target_link_libraries(librpmio PRIVATE PkgConfig::RPMSEQUOIA)
 else()

--- a/rpmio/digest.cc
+++ b/rpmio/digest.cc
@@ -66,8 +66,19 @@ int rpmDigestBundleUpdate(rpmDigestBundle bundle, const void *data, size_t len)
     return rc;
 }
 
+int rpmDigestBundleUpdateID(rpmDigestBundle bundle, int id,
+			    const void *data, size_t len)
+{
+    int rc = -1;
+    if (bundle && data && len > 0 && id > 0) {
+	auto it = bundle->digs.find(id);
+	if (it != bundle->digs.end())
+	    rc = rpmDigestUpdate(it->second, data, len);
+    }
+    return rc;
+}
 int rpmDigestBundleFinal(rpmDigestBundle bundle, int id,
-			 void ** datap, size_t * lenp, int asAscii)
+			void ** datap, size_t * lenp, int asAscii)
 {
     int rc = -1;
     if (bundle) {

--- a/rpmio/rpmpgp_sequoia.cc
+++ b/rpmio/rpmpgp_sequoia.cc
@@ -37,6 +37,9 @@ W(const uint8_t *, pgpDigParamsSignID, (pgpDigParams digp), (digp))
 W(const char *, pgpDigParamsUserID, (pgpDigParams digp), (digp))
 W(int, pgpDigParamsVersion, (pgpDigParams digp), (digp))
 W(uint32_t, pgpDigParamsCreationTime, (pgpDigParams digp), (digp))
+W(int, pgpDigParamsSalt,
+  (pgpDigParams digp, const uint8_t **datap, size_t *lenp),
+  (digp, datap, lenp))
 W(rpmRC, pgpVerifySignature,
   (pgpDigParams key, pgpDigParams sig, DIGEST_CTX hashctx),
   (key, sig, hashctx))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(at ${TESTSUITE_AT})
 	FILE(APPEND ${CMAKE_CURRENT_BINARY_DIR}/rpmtests.at "m4_include([${at}])\n")
 endforeach()
 
-set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint readpkgnullts)
+set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint readpkgnullts rpmdig)
 foreach(prg ${TESTPROGS})
 	add_executable(${prg} EXCLUDE_FROM_ALL ${prg}.c)
 	target_link_libraries(${prg} PRIVATE librpm)

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -60,7 +60,7 @@ RUN dnf -y install \
 # Incapacitate IMA, needed until #3234 lands in fedora
 RUN rm -f /usr/lib/rpm/macros.d/macros.transaction_ima
 # If updates to specific packages are needed, do it here
-RUN dnf -y --enablerepo=rawhide install "sequoia-sq >= 1.3" "rpm-sequoia >= 1.8" "crypto-policies >= 20250402"
+RUN dnf -y --enablerepo=rawhide install "sequoia-sq >= 1.3" "rpm-sequoia >= 1.9" "crypto-policies >= 20250402"
 RUN dnf clean all
 
 # Workaround for pkgconf(1)'s unlisted dependency on rpm.

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3887,7 +3887,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([file digests sha3])
 AT_KEYWORDS([build digest])
-RPMTEST_SKIP_IF([test x$PGP = xsequoia])
 RPMTEST_CHECK([[
 runroot rpmbuild -bs --quiet \
 		--define "_source_filedigest_algorithm 12" \

--- a/tests/rpmdig.c
+++ b/tests/rpmdig.c
@@ -1,0 +1,40 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rpm/rpmcrypto.h>
+
+static void printID(rpmDigestBundle b, int id)
+{
+    char *s = NULL;
+    if (rpmDigestBundleFinal(b, id, (void **)&s, NULL, 1) == 0) {
+	printf("%d: %s\n", id, s);
+	free(s);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    const char *AAA = "AAA";
+    const char *BBB = "BBB";
+
+    if (rpmInitCrypto())
+	return EXIT_FAILURE;
+
+    rpmDigestBundle b = rpmDigestBundleNew();
+    rpmDigestBundleAddID(b, RPM_HASH_SHA256, 1, 0);
+    rpmDigestBundleAddID(b, RPM_HASH_SHA256, 2, 0);
+    rpmDigestBundleAddID(b, RPM_HASH_SHA256, 3, 0);
+    rpmDigestBundleAddID(b, RPM_HASH_SHA512, 4, 0);
+    
+    rpmDigestBundleUpdateID(b, 2, BBB, strlen(BBB));
+    rpmDigestBundleUpdate(b, AAA, strlen(AAA));
+
+    for (int i = 1; i < 5; ++i)
+	printID(b, i);
+
+    rpmDigestBundleFree(b);
+    rpmFreeCrypto();
+    return 0;
+}

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -7,6 +7,20 @@ m4_define([RPMOUTPUT_SEQUOIA], [m4_if(RPM_PGP, [sequoia], [$1
 m4_define([RPMOUTPUT_LEGACY], [m4_if(RPM_PGP, [legacy], [$1
 ])])
 
+RPMTEST_SETUP([Digest bundle])
+AT_KEYWORDS([digest])
+RPMTEST_CHECK([
+rpmdig
+],
+[0],
+[1: cb1ad2119d8fafb69566510ee712661f9f14b83385006ef92aec47f523a38358
+2: e6c9f16ad216ab08c2511d9e67b450dbef6e0522a735ae2b0a61cef453fbcaa2
+3: cb1ad2119d8fafb69566510ee712661f9f14b83385006ef92aec47f523a38358
+4: 8d708d18b54df3962d696f069ad42dad7762b5d4d3c97ee5fa2dae0673ed46545164c078b8db3d59c4b96020e4316f17bb3d91bf1f6bc0896bbe75416eb8c385
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP([seen signer id tracking])
 AT_KEYWORDS([query signature])
 RPMTEST_CHECK([
@@ -2455,3 +2469,4 @@ runroot rpmkeys --delete 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa
 [],
 [])
 RPMTEST_CLEANUP
+

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2408,28 +2408,20 @@ runroot rpmsign --addsign --rpmv6 /tmp/hello-2.0-1.x86_64.rpm
 [],
 [])
 
-# The test reflects what I *assume* this should return as v6 key ids are the
-# first 64 bits of the fingerprint, but this is very cursory skim through
-# rfc-9580 and might not be right. What we're currently getting as the
-# signer key is the last 64bit as with v4 keys, and when this doesn't match
-# with what we get from the subkey ids, rpm does not find the key.
-# In addition, rpm-sequoia 1.8 doesn't handle the v6 trailer so it's BAD
-# instead of NOKEY.
-# Header OpenPGP V6 Ed25519/SHA512 signature, key ID 0e00df3ed2d7b65e: BAD
-#RPMTEST_CHECK([
-#runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
-#],
-#[0],
-#[/tmp/hello-2.0-1.x86_64.rpm:
-#    Header OpenPGP V6 Ed25519/SHA512 signature, key ID 6118abe481c41473: NOKEY
-#    Header OpenPGP RSA signature: NOTFOUND
-#    Header OpenPGP DSA signature: NOTFOUND
-#    Header SHA256 digest: OK
-#    Payload SHA256 digest: OK
-#    Legacy OpenPGP RSA signature: NOTFOUND
-#    Legacy OpenPGP DSA signature: NOTFOUND
-#],
-#[])
+RPMTEST_CHECK([
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[1],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP V6 Ed25519/SHA512 signature, key ID 6118abe481c41473: NOKEY
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
+],
+[])
 
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-v6-ed25519-test.asc
@@ -2446,21 +2438,16 @@ runroot rpmkeys --list 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03
 ],
 [])
 
-# This is currently failing, see the NOKEY case above
-#RPMTEST_CHECK([
-#runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
-#],
-#[0],
-#[/tmp/hello-2.0-1.x86_64.rpm:
-#    Header OpenPGP V6 Ed25519/SHA512 signature, key fingerprint 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3 OK
-#    Header OpenPGP RSA signature: NOTFOUND
-#    Header OpenPGP DSA signature: NOTFOUND
-#    Header SHA256 digest: OK
-#    Payload SHA256 digest: OK
-#    Legacy OpenPGP RSA signature: NOTFOUND
-#    Legacy OpenPGP DSA signature: NOTFOUND
-#],
-#[])
+RPMTEST_CHECK([
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[0],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP V6 Ed25519/SHA512 signature, key fingerprint: 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3: OK
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+],
+[])
 
 RPMTEST_CHECK([
 runroot rpmkeys --delete 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3


### PR DESCRIPTION
Enable and adjusts OpenPGP v6 signatures tests outputs to match expected behavior based on https://github.com/rpm-software-management/rpm-sequoia/pull/91

Opening as draft as the code is not yet released.