### PR TITLE
Support OpenPGP v6 signature pre-salting

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -42,7 +42,7 @@ The scdoc manual page generator, available from
     https://git.sr.ht/~sircmpwn/scdoc
 
 You will need a cryptographic library to support digests and an OpenPGP
-implementation to support signatures. rpm-sequoia (>= 1.3.0 required) is
+implementation to support signatures. rpm-sequoia (>= 1.9.0 required) is
 the most complete option, covering both, and also the default:
     https://github.com/rpm-software-management/rpm-sequoia
 

--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -489,6 +489,8 @@ int pgpDigParamsVersion(pgpDigParams digp);
  */
 uint32_t pgpDigParamsCreationTime(pgpDigParams digp);
 
+int pgpDigParamsSalt(pgpDigParams digp, const uint8_t **datap, size_t *lenp);
+
 /** \ingroup rpmpgp
  * Destroy parsed OpenPGP packet parameter(s).
  * @param digp		parameter container

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -22,7 +22,7 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/rpmio/rpmpgp_legacy/CMakeLists.txt)
 endif()
 
 if (WITH_SEQUOIA)
-	pkg_check_modules(RPMSEQUOIA REQUIRED IMPORTED_TARGET rpm-sequoia>=1.8.0)
+	pkg_check_modules(RPMSEQUOIA REQUIRED IMPORTED_TARGET rpm-sequoia>=1.9.0)
 	target_sources(librpmio PRIVATE rpmpgp_sequoia.cc)
 	target_link_libraries(librpmio PRIVATE PkgConfig::RPMSEQUOIA)
 else()

--- a/rpmio/rpmpgp_sequoia.cc
+++ b/rpmio/rpmpgp_sequoia.cc
@@ -37,6 +37,9 @@ W(const uint8_t *, pgpDigParamsSignID, (pgpDigParams digp), (digp))
 W(const char *, pgpDigParamsUserID, (pgpDigParams digp), (digp))
 W(int, pgpDigParamsVersion, (pgpDigParams digp), (digp))
 W(uint32_t, pgpDigParamsCreationTime, (pgpDigParams digp), (digp))
+W(int, pgpDigParamsSalt,
+  (pgpDigParams digp, const uint8_t **datap, size_t *lenp),
+  (digp, datap, lenp))
 W(rpmRC, pgpVerifySignature,
   (pgpDigParams key, pgpDigParams sig, DIGEST_CTX hashctx),
   (key, sig, hashctx))

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -60,7 +60,7 @@ RUN dnf -y install \
 # Incapacitate IMA, needed until #3234 lands in fedora
 RUN rm -f /usr/lib/rpm/macros.d/macros.transaction_ima
 # If updates to specific packages are needed, do it here
-RUN dnf -y --enablerepo=rawhide install "sequoia-sq >= 1.3" "rpm-sequoia >= 1.8" "crypto-policies >= 20250402"
+RUN dnf -y --enablerepo=rawhide install "sequoia-sq >= 1.3" "rpm-sequoia >= 1.9" "crypto-policies >= 20250402"
 RUN dnf clean all
 
 # Workaround for pkgconf(1)'s unlisted dependency on rpm.

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -3887,7 +3887,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([file digests sha3])
 AT_KEYWORDS([build digest])
-RPMTEST_SKIP_IF([test x$PGP = xsequoia])
 RPMTEST_CHECK([[
 runroot rpmbuild -bs --quiet \
 		--define "_source_filedigest_algorithm 12" \

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2408,28 +2408,20 @@ runroot rpmsign --addsign --rpmv6 /tmp/hello-2.0-1.x86_64.rpm
 [],
 [])
 
-# The test reflects what I *assume* this should return as v6 key ids are the
-# first 64 bits of the fingerprint, but this is very cursory skim through
-# rfc-9580 and might not be right. What we're currently getting as the
-# signer key is the last 64bit as with v4 keys, and when this doesn't match
-# with what we get from the subkey ids, rpm does not find the key.
-# In addition, rpm-sequoia 1.8 doesn't handle the v6 trailer so it's BAD
-# instead of NOKEY.
-# Header OpenPGP V6 Ed25519/SHA512 signature, key ID 0e00df3ed2d7b65e: BAD
-#RPMTEST_CHECK([
-#runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
-#],
-#[0],
-#[/tmp/hello-2.0-1.x86_64.rpm:
-#    Header OpenPGP V6 Ed25519/SHA512 signature, key ID 6118abe481c41473: NOKEY
-#    Header OpenPGP RSA signature: NOTFOUND
-#    Header OpenPGP DSA signature: NOTFOUND
-#    Header SHA256 digest: OK
-#    Payload SHA256 digest: OK
-#    Legacy OpenPGP RSA signature: NOTFOUND
-#    Legacy OpenPGP DSA signature: NOTFOUND
-#],
-#[])
+RPMTEST_CHECK([
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[1],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP V6 Ed25519/SHA512 signature, key ID 6118abe481c41473: NOKEY
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+    Legacy OpenPGP RSA signature: NOTFOUND
+    Legacy OpenPGP DSA signature: NOTFOUND
+],
+[])
 
 RPMTEST_CHECK([
 runroot rpmkeys --import /data/keys/rpm.org-v6-ed25519-test.asc
@@ -2446,21 +2438,16 @@ runroot rpmkeys --list 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03
 ],
 [])
 
-# This is currently failing, see the NOKEY case above
-#RPMTEST_CHECK([
-#runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
-#],
-#[0],
-#[/tmp/hello-2.0-1.x86_64.rpm:
-#    Header OpenPGP V6 Ed25519/SHA512 signature, key fingerprint 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3 OK
-#    Header OpenPGP RSA signature: NOTFOUND
-#    Header OpenPGP DSA signature: NOTFOUND
-#    Header SHA256 digest: OK
-#    Payload SHA256 digest: OK
-#    Legacy OpenPGP RSA signature: NOTFOUND
-#    Legacy OpenPGP DSA signature: NOTFOUND
-#],
-#[])
+RPMTEST_CHECK([
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[0],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP V6 Ed25519/SHA512 signature, key fingerprint: 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3: OK
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+],
+[])
 
 RPMTEST_CHECK([
 runroot rpmkeys --delete 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3


### PR DESCRIPTION
This has the necessary rpm-side bits to support v6 signature verification with the aid of rpm-sequoia + https://github.com/rpm-software-management/rpm-sequoia/pull/92

Draft for now as there's no rpm-sequoia release that we can use in CI.