### PR TITLE
Support updating individual IDs in a digest bundle

### DIFF
--- a/include/rpm/rpmcrypto.h
+++ b/include/rpm/rpmcrypto.h
@@ -145,6 +145,17 @@ int rpmDigestBundleAddID(rpmDigestBundle bundle, int algo, int id,
 int rpmDigestBundleUpdate(rpmDigestBundle bundle, const void *data, size_t len);
 
 /** \ingroup rpmcrypto
+ * Update context of an individual ID within bundle with next plain text buffer.
+ * @param bundle	digest bundle
+ * @param id		id of digest (arbitrary, must be > 0)
+ * @param data		next data buffer
+ * @param len		no. bytes of data
+ * @return		0 on success
+ */
+int rpmDigestBundleUpdateID(rpmDigestBundle bundle, int id,
+			const void *data, size_t len);
+
+/** \ingroup rpmcrypto
  * Return digest from a bundle and destroy context, see rpmDigestFinal().
  *
  * @param bundle	digest bundle

--- a/rpmio/digest.cc
+++ b/rpmio/digest.cc
@@ -66,6 +66,17 @@ int rpmDigestBundleUpdate(rpmDigestBundle bundle, const void *data, size_t len)
     return rc;
 }
 
+int rpmDigestBundleUpdateID(rpmDigestBundle bundle, int id,
+			    const void *data, size_t len)
+{
+    int rc = -1;
+    if (bundle && data && len > 0 && id > 0) {
+	auto it = bundle->digs.find(id);
+	if (it != bundle->digs.end())
+	    rc = rpmDigestUpdate(it->second, data, len);
+    }
+    return rc;
+}
 int rpmDigestBundleFinal(rpmDigestBundle bundle, int id,
 			 void ** datap, size_t * lenp, int asAscii)
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(at ${TESTSUITE_AT})
 	FILE(APPEND ${CMAKE_CURRENT_BINARY_DIR}/rpmtests.at "m4_include([${at}])\n")
 endforeach()
 
-set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint readpkgnullts)
+set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint readpkgnullts rpmdig)
 foreach(prg ${TESTPROGS})
 	add_executable(${prg} EXCLUDE_FROM_ALL ${prg}.c)
 	target_link_libraries(${prg} PRIVATE librpm)

--- a/tests/rpmdig.c
+++ b/tests/rpmdig.c
@@ -1,0 +1,40 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rpm/rpmcrypto.h>
+
+static void printID(rpmDigestBundle b, int id)
+{
+    char *s = NULL;
+    if (rpmDigestBundleFinal(b, id, (void **)&s, NULL, 1) == 0) {
+	printf("%d: %s\n", id, s);
+	free(s);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    const char *AAA = "AAA";
+    const char *BBB = "BBB";
+
+    if (rpmInitCrypto())
+	return EXIT_FAILURE;
+
+    rpmDigestBundle b = rpmDigestBundleNew();
+    rpmDigestBundleAddID(b, RPM_HASH_SHA256, 1, 0);
+    rpmDigestBundleAddID(b, RPM_HASH_SHA256, 2, 0);
+    rpmDigestBundleAddID(b, RPM_HASH_SHA256, 3, 0);
+    rpmDigestBundleAddID(b, RPM_HASH_SHA512, 4, 0);
+    
+    rpmDigestBundleUpdateID(b, 2, BBB, strlen(BBB));
+    rpmDigestBundleUpdate(b, AAA, strlen(AAA));
+
+    for (int i = 1; i < 5; ++i)
+	printID(b, i);
+
+    rpmDigestBundleFree(b);
+    rpmFreeCrypto();
+    return 0;
+}

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -7,6 +7,20 @@ m4_define([RPMOUTPUT_SEQUOIA], [m4_if(RPM_PGP, [sequoia], [$1
 m4_define([RPMOUTPUT_LEGACY], [m4_if(RPM_PGP, [legacy], [$1
 ])])
 
+RPMTEST_SETUP([Digest bundle])
+AT_KEYWORDS([digest])
+RPMTEST_CHECK([
+rpmdig
+],
+[0],
+[1: cb1ad2119d8fafb69566510ee712661f9f14b83385006ef92aec47f523a38358
+2: e6c9f16ad216ab08c2511d9e67b450dbef6e0522a735ae2b0a61cef453fbcaa2
+3: cb1ad2119d8fafb69566510ee712661f9f14b83385006ef92aec47f523a38358
+4: 8d708d18b54df3962d696f069ad42dad7762b5d4d3c97ee5fa2dae0673ed46545164c078b8db3d59c4b96020e4316f17bb3d91bf1f6bc0896bbe75416eb8c385
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP([seen signer id tracking])
 AT_KEYWORDS([query signature])
 RPMTEST_CHECK([
@@ -2455,3 +2469,4 @@ runroot rpmkeys --delete 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa
 [],
 [])
 RPMTEST_CLEANUP
+


### PR DESCRIPTION
Up to now, rpm digest bundles have only needed to support data from a single stream - just covering different ranges and algorithms. But OpenPGP v6 signature salt is a random per-signature thing that we need to feed into the digest before the actual data, so we need to be able to update each ID in a bundle individually too.

Luckily this is easy to do. Add a small test-program to exercise it, we can't yet actually use it for testing a real-world V6 scenario anyway.

Fixes: #3845