### PR TITLE
Toolbox integration with `make check`

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -1,5 +1,6 @@
 # Supported Fedora releases: 41 42
 FROM registry.fedoraproject.org/fedora:42 AS base
+LABEL com.github.containers.toolbox="true"
 MAINTAINER rpm-maint@lists.rpm.org
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
@@ -61,7 +62,22 @@ RUN dnf -y install \
 RUN rm -f /usr/lib/rpm/macros.d/macros.transaction_ima
 # If updates to specific packages are needed, do it here
 RUN dnf -y --enablerepo=rawhide install "sequoia-sq >= 1.3" "rpm-sequoia >= 1.9" "crypto-policies >= 20250402"
+
+# Install some development tools
+RUN dnf -y install \
+    flatpak-spawn \
+    gdb \
+    strace \
+    valgrind
+
 RUN dnf clean all
+
+# Install podman shim for use in toolbox containers
+RUN cat <<EOF > /usr/local/bin/podman
+#!/bin/bash
+exec flatpak-spawn --host podman "\$@"
+EOF
+RUN chmod +x /usr/local/bin/podman
 
 # Workaround for pkgconf(1)'s unlisted dependency on rpm.
 # This is needed for cmake to work without an rpm installation.

--- a/tests/mktree.common
+++ b/tests/mktree.common
@@ -15,12 +15,12 @@ make_install()
 
     mkdir -p $DESTDIR/usr/bin
     cp @TESTPROG_NAMES@ $DESTDIR/usr/bin/
+    cp @CMAKE_CURRENT_SOURCE_DIR@/prpm.py $DESTDIR/usr/bin/
     ln -s $script_dir/rpmtests.sh $DESTDIR/usr/bin/rpmtests
 
     mkdir -p $DESTDIR/$script_dir
     cp rpmtests atlocal mktree.common setup.sh $DESTDIR/$script_dir/
     cp @CMAKE_CURRENT_SOURCE_DIR@/rpmtests.sh $DESTDIR/$script_dir/
-    cp @CMAKE_CURRENT_SOURCE_DIR@/prpm.py $DESTDIR/@CMAKE_INSTALL_BINDIR@
 
     touch $DESTDIR/.rpmtestsuite
 }

--- a/tests/mktree.oci
+++ b/tests/mktree.oci
@@ -25,6 +25,7 @@ else
     FROM=
 fi
 
+DEST_DIR="$PWD/mktree.destdir"
 CACHE_DIR="mktree.cache"
 IID_FILE="$CACHE_DIR/image-id"
 IMAGE_ID=$(cat $IID_FILE 2>/dev/null || echo "")
@@ -68,15 +69,8 @@ clean()
     $PODMAN rmi $IMAGE_ID >/dev/null
 }
 
-unshared()
-{
-    [ $(id -u) != 0 ] && [ $NATIVE == yes ] || return 0
-    $PODMAN unshare $0 $CMD "$@"
-    exit
-}
-
 case $CMD in
-    build) unshared
+    build)
         # Build base image
         $PODMAN build --target base -t $BASE_TAG $ARGS
 
@@ -87,7 +81,9 @@ case $CMD in
             id=$($PODMAN create -t $BASE_TAG)
             trap "$PODMAN kill $id >/dev/null; $PODMAN rm $id > /dev/null" EXIT
             $PODMAN start $id
-            make_install $($PODMAN mount $id)
+            rm -rf "$DEST_DIR"
+            make_install $DEST_DIR
+            $PODMAN cp $DEST_DIR/. $id:/
             $PODMAN exec $id /usr/share/mktree/setup.sh
             $PODMAN commit -q $id --iidfile=$IID_FILE
         else


### PR DESCRIPTION
Enable `make check` to work from inside a [toolbox](https://containertoolbx.org/) container, and adjust Dockerfile so that it can be used to build a toolbox-ready image.

Fixes: #3850