### PR TITLE
doc: Deprecate rpmkeys --delete

### DIFF
--- a/docs/man/rpmkeys.8.scd
+++ b/docs/man/rpmkeys.8.scd
@@ -37,6 +37,7 @@ For all available operations, see *OPERATIONS*.
 *-e*,
 *--erase*
 	Erase the key(s) designated by _FINGERPRINT_.
+	The *--delete* and *-d* options are deprecated.
 
 *-x*,
 *--export*


### PR DESCRIPTION
rpmkeys program now has both --erase and --delete option doing the same thing. (See commit abb6ab1c43a946eb36a36227e39918580390a8e4 "Rename rpmkeys --delete to rpmkeys --erase".) According to Michal Domonkos and that commit, --delete is an deprecated alias.

This patch documents that so that users know which of the options to prefer.