### PR TITLE
Only ever call pgpDigParamsSalt() on signatures

### DIFF
--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -462,7 +462,7 @@ void rpmvsInitRange(struct rpmvs_s *sis, int range)
 
 	    rpmDigestBundleAddID(sis->bundle, sinfo->hashalgo, sinfo->id, 0);
 	    /* OpenPGP v6 signatures need a grain of salt to go */
-	    if (sinfo->sig) {
+	    if (sinfo->type == RPMSIG_SIGNATURE_TYPE && sinfo->sig) {
 		const uint8_t *salt = NULL;
 		size_t slen = 0;
 		if (pgpDigParamsSalt(sinfo->sig, &salt, &slen) == 0 && salt) {

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -89,6 +89,13 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-1.0-1.i386.rpm
     Legacy MD5 digest: NOTFOUND
 ],
 [])
+
+RPMTEST_CHECK([
+RPM_TRACE=1 rpmkeys -K --nosignature /data/RPMS/hello-2.0-1.x86_64.rpm 2>&1 | grep -q pgpDigParamsSalt
+],
+[1],
+[],
+[])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmkeys key update and delete (rpmdb)])


### PR DESCRIPTION
Ensure the verification item is a signature before calling pgpDigParamsSalt(). Otherwise we can end up calling it with the character array of a digest instead, which may not end well.

The test relies on debug output from rpm-sequoia so it's a bit feeble, but it's the best we can do here.

Should've been in c36c717f41683953b9c23e447a8df0d0ac7c845c.