### PR TITLE
Lua: Return empty result for no matches for glob()

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1009,6 +1009,7 @@ RPMTEST_SETUP([lua glob])
 RPMTEST_CHECK([
 mkdir -p aaa/{123,223,323,322,321}
 rpm --eval "%{lua:for i,p in ipairs(rpm.glob('aaa/3*')) do print(p..'\\n') end}"
+rpm --eval "%{lua:for i,p in ipairs(rpm.glob('aaa/b*')) do print(p..'\\n') end}"
 rpm --eval "%{lua:for i,p in ipairs(rpm.glob('aaa/b*', 'c')) do print(p..'\\n') end}"
 ],
 [0],


### PR DESCRIPTION
If "c" is not given in the a second parameter glob should not return any results if the pattern doesn't match any files.

Fix the condition that checks this parameter. Also don't error out if rpmGlob returns GLOB_NOMATCH which is expected in this case.

Add a test case.

Resolves: #3794