### PR TITLE
Don't segfault on dependency generator output

### DIFF
--- a/build/rpmfc.cc
+++ b/build/rpmfc.cc
@@ -632,7 +632,7 @@ static int genDeps(const char *mname, int multifile, rpmTagVal tagN,
 		fx++;
 		if (rstreq(pav[px]+1, paths[fx]))
 		    found = 1;
-	    } while (!found && fx < nfn);
+	    } while (!found && fx < nfn-1);
 
 	    if (!found) {
 		rpmlog(RPMLOG_ERR,

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1656,6 +1656,19 @@ done
 [0],
 [expout],
 [])
+
+RPMTEST_CHECK([[
+cat << EOF > "${RPMTEST}"/tmp/bar.req
+#!/bin/sh
+echo ";foobar"
+EOF
+
+runroot ${RPM_CONFIGDIR_PATH}/rpmdeps --requires /file{1..5}
+]],
+[1],
+[],
+[error: invalid or out of order path from generator: ;foobar
+])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([Local dependency generator])


### PR DESCRIPTION
Fix loop overrun while looking for the matching file name.

Add test case that triggeres the error message instead of segfault

Resolves: #3821