### PR TITLE
Fix regression on signature size reservation not being used

### DIFF
--- a/tests/data/misc/rpmdump4-addsign-v6.txt
+++ b/tests/data/misc/rpmdump4-addsign-v6.txt
@@ -2,8 +2,8 @@ Signature:
 File offset: 96
 Header magic: 1e8ad8e (reserved: 0)
 Index entries: 9 (144 bytes)
-Data size: 5172 bytes
-Header size: 5316 bytes
+Data size: 4244 bytes
+Header size: 4388 bytes
 Padding: 4 bytes
 Region entries 9
 Region size 160
@@ -12,7 +12,7 @@ Dribbles: 0
 Tag #0 [region]
 	tagno:    62 (Headersignatures)
 	type:      7 (blob)
-	offset: 5156
+	offset: 4228
 	count:    16
 
 	region trailer
@@ -67,6 +67,6 @@ Tag #8 [region]
 	tagno:  1008 (Reservedspace)
 	type:      7 (blob)
 	offset: 1028
-	count:  4128
+	count:  3200
 
 Header:

--- a/tests/data/misc/rpmdump6-addsign-v6.txt
+++ b/tests/data/misc/rpmdump6-addsign-v6.txt
@@ -2,9 +2,9 @@ Signature:
 File offset: 96
 Header magic: 1e8ad8e (reserved: 0)
 Index entries: 5 (80 bytes)
-Data size: 4787 bytes
-Header size: 4867 bytes
-Padding: 5 bytes
+Data size: 4258 bytes
+Header size: 4338 bytes
+Padding: 6 bytes
 Region entries 5
 Region size 96
 Dribbles: 0
@@ -12,7 +12,7 @@ Dribbles: 0
 Tag #0 [region]
 	tagno:    62 (Headersignatures)
 	type:      7 (blob)
-	offset: 4771
+	offset: 4242
 	count:    16
 
 	region trailer
@@ -43,6 +43,6 @@ Tag #4 [region]
 	tagno:   999 (Reserved)
 	type:      7 (blob)
 	offset:  643
-	count:  4128
+	count:  3599
 
 Header:

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1770,7 +1770,6 @@ runroot rpmbuild -bb --quiet \
 [],
 [])
 
-# XXX the reserve tag size is currently WRONG here due to #3768
 RPMTEST_CHECK([
 cp /data/misc/rpmdump6-addsign-v6.txt expout
 runroot ${RPM_CONFIGDIR_PATH}/rpmdump /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm| sed -n '/^Signature:$/,/^Header:$/p'


### PR DESCRIPTION
The signature reservation adjustment is one of those whack-a-mole bugs where fixes keep making new bugs appear: the signature reservation was broken by 1847fd6bea41f96ca545e744ee9ecc2896f6378a which came from be950eabb84a88e5773e096435c37b92e3d47ebb which came from 5c279fb149a44a1bc4d19e11c3c01942732b8486 and so on.

This seemingly simple thing is pretty tricksy, especially when needing to deal with 3rd party signed packages that don't always follow our expectations. What 1847fd6bea41f96ca545e744ee9ecc2896f6378a got wrong is that the header size before unloadImmutableRegion() will include the the region index and data entries, totalling 32 bytes, whereas the other calculations are lacking it. And without adjusting for it, the difference either causes the mechanism not to work or corrupted packages. It also made a mess of the sanity check.

Always take the signature size before the grabbing the immutable region, just adjust for the region entry size difference. This handles the misplaced IMA signatures in #3469 and other similar quirks with minimum fuss. Simplify the reservation adjustment: the diff is for the reservation size. If it's negative, the reservation needs to shrink, if positive then it needs to grow. This is easier to follow than substracting negative numbers to grow it. And now we just need to check that the shrink operation doesn't wrap around, otherwise the math takes care of itself. Famous last words.

Adjust the post-addsign rpmdump values to match the expected behavior rather than the broken one.

Fixes: #3768