### PR TITLE
Add rpm-manifest(5) man page for the rpm package manifest file format

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -4,7 +4,7 @@ set(core
 	rpmdeps.1 rpmgraph.1 rpmlua.1 rpm-common.8 rpmsort.1
 	rpm-macrofile.5 rpm-config.5 rpm-rpmrc.5 rpm-setup-autosign.1
 	rpm-payloadflags.7 rpmbuild-config.5 rpm-queryformat.7 rpm-macros.7
-	rpm-lua.7
+	rpm-lua.7 rpm-manifest.5
 )
 set(extra
 	rpm-plugins.8 rpm-plugin-prioreset.8 rpm-plugin-syslog.8

--- a/docs/man/rpm-manifest.5.scd
+++ b/docs/man/rpm-manifest.5.scd
@@ -1,0 +1,57 @@
+RPM-MANIFEST(5)
+
+# NAME
+*rpm-manifest* - rpm package manifest file format
+
+# SYNOPSIS
+_GLOB_ ...
+
+\# _COMMENT_
+
+# DESCRIPTION
+RPM package manifest files are plaintext files containing one or
+more *glob*(7) entries that are expected to match either RPM package files
+or other package manifests.
+
+Package manifests can be used as a way to document installation of large
+package sets in an RPM-native way, without having to set up repositories
+and configure external dependency resolver programs to use them.
+For end-user purposes manifests are clumsy, but for example to quickly
+install a base image from a pre-determined set of package versions from
+local directory, a manifest may well be easier and faster than using
+a depsolver for the task. A manifest can be also used to work around
+command line length limitations.
+
+Relative globs are interpreted relative to the user's current directory.
+Multiple globs per line are permitted, but for readability it's
+recommended to use one per line instead.
+
+Lines beginning with *#* are considered comments. Empty lines and
+lines consisting of only whitespace are ignored.
+
+# EXAMPLES
+Manifest of *myproj-1.0-* and it's dependency *mylib-2.1* packages
+for the *x86_64* architecture.
+
+```
+/mnt/myproj/rpm/myproj-1.0-*.x86_64.rpm
+/mnt/deplib/rpm/mylib-2.1-*.x86_64.rpm
+```
+
+Manifest of all *noarch* packages in the default *rpmbuild*(1) location.
+
+```
+~/rpmbuild/RPMS/noarch/*.rpm
+```
+
+Create a manifest called *mymanifest.mft* of currently installed packages,
+assuming a base path of */mnt/Packages* for the RPM package files.
+Then install the manifest to an alternative system root at */srv/test*.
+
+```
+# rpm -qa --qf '/mnt/Packages/%{nevra}.rpm\n' > mymanifest.mft
+# rpm -Uv --root /srv/test mymanifest.mft
+```
+
+# SEE ALSO
+*rpm*(8) *rpm-common*(8)

--- a/docs/man/rpm.8.scd
+++ b/docs/man/rpm.8.scd
@@ -86,8 +86,7 @@ See *rpm-common*(8) for the operations common to all rpm executables.
 
 # ARGUMENTS
 _PACKAGE_FILE_
-	Either *rpm* binary file or ASCII package manifest
-	(see *PACKAGE SELECTION OPTIONS*), and may be
+	Either an *rpm* package or an *rpm-manifest*(5) file. May also be
 	specified as an *ftp* or *http* URL, in which case the package will
 	be downloaded before being installed. See *FTP/HTTP OPTIONS* for
 	information on *rpm*'s *ftp* and *http* client support.
@@ -297,21 +296,10 @@ selection and information selection.
 	Do not glob arguments when installing package files.
 
 *--nomanifest*
-	Don't process non-package files as manifests.
+	Don't process non-package files as *rpm-manifest*(5) files.
 
 *-p*, *--package* _PACKAGE_FILE_
-	Query an (uninstalled) package _PACKAGE_FILE_. The _PACKAGE_FILE_
-	may be specified as an *ftp* or *http* style URL, in which case
-	the package header will be downloaded and queried. See *FTP/HTTP
-	OPTIONS* for information on *rpm*'s *ftp* and *http* client
-	support. The _PACKAGE_FILE_ argument(s), if not a binary package,
-	will be interpreted as an ASCII package manifest unless
-	*--nomanifest* option is used. In manifests, comments are
-	permitted, starting with a '*#*', and each line of a package
-	manifest file may include white space separated glob expressions,
-	including URL's, that will be expanded to paths that are
-	substituted in place of the package manifest as additional
-	_PACKAGE_FILE_ arguments to the query.
+	Query an (uninstalled) package _PACKAGE_FILE_.
 
 *--path* _PATH_
 	Query package(s) owning _PATH_, whether the file is installed or not.
@@ -454,8 +442,8 @@ selection and information selection.
 # VERIFY OPTIONS
 
 The package and file selection options are the same as for package
-querying (including package manifest files as arguments). Other options
-unique to verify mode are:
+querying (including *rpm-manifest*(5) files as arguments).
+Other options unique to verify mode are:
 
 *--nodeps*
 	Don't verify dependencies of packages.
@@ -555,6 +543,7 @@ See *rpm-common*(8), *rpm-config*(5) and *rpm-rpmrc*(5).
 # SEE ALSO
 *rpm-common*(8), *popt*(3), *rpm2cpio*(1), *rpmbuild*(1), *rpmdb*(8),
 *rpmkeys*(8), *rpmsign*(1), *rpmspec*(1), *rpm-queryformat*(7)
+*rpm-manifest*(5)
 
 *rpm --help* - as *rpm* supports customizing the options via popt
 aliases it's impossible to guarantee that what's described in the


### PR DESCRIPTION
The documentation for this little known feature has been lost in the noise of the gigantic rpm(8) manpage. Lift it to a man page of it's own, eliminating some duplication in the process. Explain some actual use-cases and add examples as well.

Fixes: #3650