### PR TITLE
Docs: Link to %setup from %autosetup

### DIFF
--- a/docs/manual/autosetup.md
+++ b/docs/manual/autosetup.md
@@ -47,8 +47,8 @@ natural than with gendiff.
 
 ## %autosetup options
 
-Generally `%autosetup` accepts the same arguments as %setup does. The notable
-exceptions are
+Generally `%autosetup` accepts the same arguments as [`%setup`](spec.md#setup)
+does. The notable exceptions are
 
 * `%autosetup` defaults to quiet operation, so `-q` is not needed or accepted.
   Use `-v` to enable verbose source unpacking if needed.


### PR DESCRIPTION
I have no idea if this builds. I tried following the instructions in docs/README.md, but cmake insisted on more and more dependencies, I eventually gave up.