### PR TITLE
Fix rpmsign possibly adding multiple legacy tags

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1880,8 +1880,7 @@ runroot ${RPM_CONFIGDIR_PATH}/rpmdump test.rpm | grep 'Dsa' | xargs -n3
 exit $rc
 ],
 [0],
-[ECDSA/SHA512, Key ID 7f1c21f95f65bbe8
-tagno: 267 (Dsa)
+[EdDSA/SHA512, Key ID b0645aec757bf69e
 tagno: 267 (Dsa)
 ],
 [])
@@ -1897,8 +1896,7 @@ exit $rc
 ],
 [0],
 [RSA/SHA512, Key ID 4344591e1964c5fc
-ECDSA/SHA512, Key ID 7f1c21f95f65bbe8
-tagno: 267 (Dsa)
+(none)
 tagno: 268 (Rsa)
 ],
 [])
@@ -1962,8 +1960,9 @@ exit $rc
 ],
 [0],
 [RSA/SHA512, Key ID 4344591e1964c5fc
-(none)
+ECDSA/SHA512, Key ID 7f1c21f95f65bbe8
 tagno: 268 (Rsa)
+tagno: 1005 (Gpg)
 ],
 [])
 
@@ -1981,8 +1980,8 @@ exit $rc
 [0],
 [RSA/SHA512, Key ID 4344591e1964c5fc
 tagno: 268 (Rsa)
-(none)
-
+ECDSA/SHA512, Key ID 7f1c21f95f65bbe8
+tagno: 267 (Dsa)
 ],
 [])
 RPMTEST_CLEANUP
@@ -2009,8 +2008,7 @@ exit $rc
 ],
 [0],
 [RSA/SHA512, Key ID 4344591e1964c5fc
-ECDSA/SHA512, Key ID 7f1c21f95f65bbe8
-tagno: 267 (Dsa)
+(none)
 tagno: 268 (Rsa)
 ],
 [])


### PR DESCRIPTION
See the commit messages for details.

The patch to make a repeated `--addsign` fail will be done later (in a new PR). I was going to include it [initially](https://github.com/dmnks/rpm/tree/v4err) here but then realized it would break the `--rpmv3` use case, so it needs more thought.