### PR TITLE
Add a test-case for %buildsubdir in Buildsystem, expected to fail now

### DIFF
--- a/tests/data/SPECS/reproducer-buildsubdir.spec
+++ b/tests/data/SPECS/reproducer-buildsubdir.spec
@@ -1,0 +1,17 @@
+Name:           reproducer-buildsubdir
+Version:        0
+Release:        0
+Summary:        ...
+License:        ...
+BuildArch:	noarch
+Buildsystem:	buildsubdir
+
+# or any other archive
+Source:         hello-2.0.tar.gz
+
+%description
+...
+
+%conf
+echo CONF: %buildsubdir
+

--- a/tests/data/macros.buildsystem
+++ b/tests/data/macros.buildsystem
@@ -8,3 +8,7 @@
 %buildsystem_cmake_conf() cmake %* -B __rpmbuild -S .
 %buildsystem_cmake_build() cmake --build __rpmbuild %{?smp_mflags} %{?verbose:-v} -- %*
 %buildsystem_cmake_install() DESTDIR=${RPM_BUILD_ROOT} cmake --install __rpmbuild %{?verbose:-v} %*
+
+%buildsystem_buildsubdir_conf() echo BSCONF %buildsubdir
+%buildsystem_buildsubdir_build() echo BSBUILD %buildsubdir
+%buildsystem_buildsubdir_install() echo BSINST %buildsubdir

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -440,6 +440,26 @@ runroot find /build/BUILD|sort
 [ignore])
 RPMTEST_CLEANUP
 
+# There might be workarounds that make build work while leaving parse broken
+# the way it is, but this is the proper outcome from #3890:
+RPMTEST_SETUP_RW([rpmbuild -b buildsystem wrt %buildsubdir])
+AT_KEYWORDS([build buildsystem])
+AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
+
+cp "${RPMTEST}/data/macros.buildsystem" "${RPMTEST}/${RPM_CONFIGDIR_PATH}/macros.d/"
+
+RPMTEST_CHECK([
+runroot rpmspec --parse /data/SPECS/reproducer-buildsubdir.spec | grep ^echo
+],
+[0],
+[echo CONF: reproducer-buildsubdir-0
+echo BSBUILD reproducer-buildsubdir-0
+echo BSINST reproducer-buildsubdir-0
+],
+[])
+
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
 RPMTEST_CHECK([


### PR DESCRIPTION
Based on a reproducer by Miro Hrončok.

Related: #3890