### PR TITLE
Ignore macrofiles directives in rpmrc

### DIFF
--- a/lib/rpmrc.cc
+++ b/lib/rpmrc.cc
@@ -489,6 +489,11 @@ static rpmRC doReadRC(rpmrcCtx ctx, const char * urlfn)
 		continue;
 	    }
 
+	    if (option->var == RPMVAR_MACROFILES) {
+		rpmlog(RPMLOG_WARNING, _("Ignoring %s at %s:%d\n"), option->name, fn, linenum);
+		continue;
+	    }
+
 	    if (option->archSpecific) {
 		arch = se;
 		while (*se && !risspace(*se)) se++;

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -110,6 +110,20 @@ RPMRC VALUES:
 archcolor             : 2
 optflags              : -O2 -g
 ])
+
+RPMTEST_CHECK([
+cat << EOF > ${RPMTEST}/root/.config/rpm/rpmrc
+macrofiles: /usr/lib/rpm/macros:/usr/lib/rpm/%{_target}/macros:/etc/rpm/macros.*:/etc/rpm/macros:/etc/rpm/%{_target}/macros:~/.rpmmacros
+EOF
+
+runroot rpm --showrc > /dev/null
+],
+[0],
+[],
+[warning: Ignoring macrofiles at /root/.config/rpm/rpmrc:1
+])
+
+
 RPMTEST_CLEANUP
 
 # ------------------------------


### PR DESCRIPTION
macrofiles directives have been ignored since 4.6 but re-emerged as an error as result of 4d621e48e07ccf7aac68b4ceabf14b2fd827b2a4

Now issue an warning and explicitly do nothing else if encountered.

Resolves: #3901