### PR TITLE
Fix missing delimiter in tags page

### DIFF
--- a/docs/manual/tags.md
+++ b/docs/manual/tags.md
@@ -1,3 +1,4 @@
+---
 layout: default
 title: rpm.org - RPM Tags
 ---


### PR DESCRIPTION
Commit 2a136bcf73204dd564a6ead975bd2934c684b9f0 accidentally removed the
top --- delimiter, causing jekyll to skip it when rendering the pages.
