### PR TITLE
Updating rpmbuild(1) man page to the new style

### DIFF
--- a/docs/man/rpmbuild.1.scd
+++ b/docs/man/rpmbuild.1.scd
@@ -1,118 +1,141 @@
 RPMBUILD(1)
 
 # NAME
-
 rpmbuild - Build RPM Package(s)
 
 # SYNOPSIS
+*rpmbuild* *-b*​_STAGE_ [options] _SPEC_FILE_ ...
 
-The general form of *rpmbuild* command is
+*rpmbuild* *-r*​_STAGE_ [options] _SOURCE_PACKAGE_ ...
 
-*rpmbuild* {*-b*|*-r*|*-t*}_STAGE_ [options] [build-options] _FILE_ ...
+*rpmbuild* *-t*​_STAGE_ [options] _TAR_ARCHIVE_ ...
 
-*rpmbuild* {*--rebuild*|*--recompile*} [options] [build-options] _SOURCEPKG_ ...
+*rpmbuild* {*--rebuild*|*--recompile*} [options] _SOURCE_PACKAGE_ ...
 
 # DESCRIPTION
+*rpmbuild* is used to build software packages in the RPM format, in
+an automated and repeatable manner.
 
-*rpmbuild* is used to build both binary and source software packages.
-A *package* consists of an archive of files and meta-data used to
+A _package_ consists of an archive of files and meta-data used to
 install and erase the archive files. The meta-data includes helper
 scripts, file attributes, and descriptive information about the package.
-*Packages* come in two varieties: binary packages, used to encapsulate
+
+Packages come in two varieties: binary packages, used to encapsulate
 software to be installed, and source packages, containing the source
 code and recipe necessary to produce binary packages.
 
-One of the following basic modes must be selected: *Build Package*,
-*Build Package from Tarball*, *Recompile Package*, *Show
-Configuration*.
+; scdoc doesn't currently render underline adjacent to bolding, so we need
+; a little unicode hack to put something invisible between the operation
+; letter and STAGE: the U200b character works nicely for the purpose.
+; vim shows this as <200b> with other editors, YMMV.
+# OPERATIONS
+*-b*​_STAGE_
+	Build _STAGE_ from a spec file.
 
-# OPTIONS
+*-r*​_STAGE_
+	Build _STAGE_ from a source RPM package.
 
-See *rpm-common*(8) for the options common to all operations.
+*-t*​_STAGE_
+	Build _STAGE_ from a *tar*(5) archive.
 
-# BUILD OPTIONS
+*--rebuild*,
+*--recompile*
+	Compatibility aliases for *-ra*.
 
-The general form of an *rpm*(8) build command is
+Packages are built in four phases: parse, build, assembly and cleanup. The
+middle two are further divided into _stages_, listed below, which can be built
+separately. Building a _STAGE_ means executing all the preceding stages up to
+(and including) the one specified, unless stated otherwise.
 
-*rpmbuild* {*-b*|*-r*|*-t*}_STAGE_ [build-options] _FILE_ ...
+## Assembly stages
+The assembly stages produce packages and are the primary way of interacting with
+*rpmbuild*. If in doubt, choose one of these.
 
-The argument used is *-b* if a spec file is being used to build the
-package, *-r* if a source package is to be rebuilt and *-t* if
-*rpmbuild* should look inside of a (possibly compressed) tar file for
-the spec file to use.
+*a*
+	Build both source and binary packages.
+	This is not an actual stage but a combination of *b* and *s*,
+	with the difference that packages built this way carry a "cookie" to
+	indicate they came from the same build.
+	On success, the build directory is removed.
 
-Packages are built in a number of stages. The first six correspond to
-the following sections in a spec file: *%prep*,
-*%generate_buildrequires*, *%build*, *%install*, *%check* and
-*%clean*. Finally, binary and source packages are created in an
-assembly stage.
+*b*
+	Build just the binary packages.
+	On success, the build directory is removed.
 
-The _STAGE_ character specifies the stage to finish with (after doing
-all the stages preceding it), and is one of:
+*r*
+	Build just the source package, checking for dynamic build dependencies.
+	Executes the *%prep* and *%generate_buildrequires* stages before
+	creating a package. See the *DYNAMIC BUILD DEPENDENCIES* section for
+	details.
 
-*-ba*
-	Perform a full build - executes up to and including the assembly
-	stage. In most cases, this is the option to choose.
+*s*
+	Build just the source package. No build stages are executed.
 
-*-bb*
-	Build just the binary packages - executes up to and including the
-	assembly stage, but without creating the source package.
-	On success, the build directory is removed (as in *--clean*).
+## Build stages
+The build stages produce the artifacts to be packaged, typically by patching and
+compiling the sources, and installing the binaries into the buildroot. These
+stages generally correspond to spec sections such as *%prep*, *%build* or
+*%install*, but there are some which are implicit.
 
-*-bp*
-	Unpack the sources and apply any patches - executes the *%prep* stage
-	only.
+Building these stages separately is generally only useful when packaging new
+software in RPM format and/or troubleshooting. They are listed below in the
+order of execution, with the corresponding spec section in parenthesis where
+applicable.
 
-*-bf*
-	Configure the sources - executes up to and including the %conf stage.
-	This generally involves the equivalent of a "*./configure*".
+*p* (%prep)
+	Unpack the sources and apply any patches.
 
-*-bc*
-	Compile the sources - executes up to and including the *%build* stage.
-	This generally involves the equivalent of "*make*".
-
-*-bi*
-	Install the binaries into the build root - executes up to and
-	including the *%check* stage. This generally involves the equivalent
-	of a "*make install*" and "*make check*".
-
-*-bl*
-	Do a "list check" - the *%files* section from the spec file is macro
-	expanded, and checks are made to verify that each file exists.
-
-*-bs*
-	Build just the source package - skips straight to the assembly
-	stage, without executing any of the preceding stages or creating
-	binary packages.
-
-*-br*
-	Build just the source package, but also parse and include dynamic
-	build dependencies - executes up to and including the
-	*%generate_buildrequires* stage and then skips straight to the
-	assembly stage, without creating binary packages. This option can
-	be used to fully resolve dynamic build dependencies. See the
-	*DYNAMIC BUILD DEPENDENCIES* section for details.
-
-*-bd*
-	Check dynamic build dependencies and build the .buildreqs.nosrc.rpm
+*d* (%generate_buildrequires)
+	Check dynamic build dependencies and build the _buildreqs.nosrc.rpm_
 	package if any are missing. Don't build anything else.
 
-The following options may also be used:
+*f* (%conf)
+	Configure the sources. This generally involves the equivalent of
+	*./configure*.
+
+*c* (%build)
+	Compile the sources. This generally involves the equivalent of *make*.
+
+*i* (%install and %check)
+	Install the binaries into the build root. This generally involves the
+	equivalent of a *make install* and *make check*.
+
+*l*
+	Do a "list check" - the *%files* section from the spec file is macro
+	expanded, and checks are made to verify that each file exists.
+	This requires a previous build up to the *%install* stage to have
+	taken place.
+
+# ARGUMENTS
+_SPEC_FILE_
+	An RPM spec file.
+
+_SOURCE_PACKAGE_
+	An RPM source package (with a _.src.rpm_ extension)
+
+_TAR_ARCHIVE_
+	A *tar*(5) archive, optionally compressed. To be directly buildable
+	with *rpmbuild*, an archive must contain a spec file either by
+	the name _Specfile_ or one with a _.spec_ extension.
+
+# OPTIONS
+*--build-in-place*
+	Build from locally checked out sources in the current working
+	directory. The build tree is set up as if *%setup* was used,
+	but *%builddir*/*%buildsubdir* points back to the current working
+	directory. *%prep* is skipped entirely.
 
 *--clean*
-	Remove the build tree after the packages are made.
+	Remove the build tree after the packages are made (default).
 
 *--nobuild*
 	Do not execute any build stages. Useful for testing out spec files.
 
-*--noprep*
-	Do not execute *%prep* build stage even if present in spec.
+*--nocheck*
+	Do not execute *%check* build stage even if present in spec.
 
 *--noclean*
 	Do not execute *%clean* build stage even if present in spec.
-
-*--nocheck*
-	Do not execute *%check* build stage even if present in spec.
 
 *--nodebuginfo*
 	Do not generate debuginfo packages.
@@ -120,13 +143,18 @@ The following options may also be used:
 *--nodeps*
 	Do not verify build dependencies.
 
+*--noprep*
+	Do not execute *%prep* build stage even if present in spec.
+	This assumes there has been another *rpmbuild* run in which
+	*%prep* has been already executed.
+
 *--rmsource*
 	Remove the sources after the build (may also be used standalone,
-	e.g. "*rpmbuild* *--rmsource foo.spec*").
+	e.g. *rpmbuild* *--rmsource foo.spec*).
 
 *--rmspec*
 	Remove the spec file after the build (may also be used standalone,
-	e.g. "*rpmbuild* *--rmspec foo.spec*").
+	e.g. *rpmbuild* *--rmspec foo.spec*).
 
 *--rpmfcdebug*
 	Print debug information on file classification and dependency
@@ -146,35 +174,15 @@ The following options may also be used:
 	be marked with an unsatisfiable dependency to prevent their
 	accidental use.
 
-*--build-in-place*
-	Build from locally checked out sources in the current working
-	directory. The build tree is set up as if *%setup* was used,
-	but *%builddir*/*%buildsubdir* points back to the current working
-	directory. *%prep* is skipped entirely.
-
 *--with* _OPTION_
 	Enable configure _OPTION_ for build.
 
 *--without* _OPTION_
 	Disable configure _OPTION_ for build.
 
-# REBUILD AND RECOMPILE OPTIONS
-
-There are two other ways to invoke building with *rpmbuild*(1):
-
-*rpmbuild* *--rebuild|--recompile* _SOURCEPKG_ ...
-
-When invoked this way, *rpmbuild* installs the named source package,
-and does a prep, compile and install. In addition, *--rebuild* builds
-a new binary package. When the build has completed, the build directory
-is removed (as in *--clean*) and the the sources and spec file for
-the package are removed.
-
-These options are now superseded by the *-r\** options which allow
-much more fine control over what stages of the build to run.
+See *rpm-common*(8) for the options common to all operations.
 
 # DYNAMIC BUILD DEPENDENCIES
-
 When the *%generate_buildrequires* stage runs and some of the newly
 generated BuildRequires are not satisfied, *rpmbuild* creates an
 intermediate source package ending in _buildreqs.nosrc.rpm_, which has
@@ -194,18 +202,48 @@ procedure until *rpmbuild* no longer exits with code 11.
 If the *-br* option is coupled with *--nodeps*, exit code 11 is
 always returned and a _buildreqs.nosrc.rpm_ package is always created.
 
-# FILES
+# ENVIRONMENT
+*RPM_BUILD_NCPUS*
+	Overrides autodetection for the number of CPUs to use for
+	parallelized sections of the build.
 
+# EXIT STATUS
+On success, 0 is returned, a non-zero failure code otherwise.
+
+Packages with a *%generate_buildrequires* section will return with code 11
+when there are unmet *DYNAMIC BUILD DEPENDENCIES*.
+
+# EXAMPLES
+*rpmbuild --rebuild hello-1.0-1.src.rpm*
+	Build binary and source packages from the _hello-1.0-1.src.rpm_
+	source package.
+
+*rpmbuild -bb --nocheck --with openssl hello.spec*
+	Build binary packages from the _hello.spec_ spec file,
+	skipping the *%check* stage if present and enabling support for
+	*openssl* build conditional (assuming one is specified in the spec).
+
+*rpmbuild -ta hello-2.0.tar.gz*
+	Build binary and source packages from the compressed
+	_hello-2.0.tar.gz_ tarball, assuming the archive contains a
+	legitimate spec file (see _TAR_ARCHIVE_ for details).
+
+*rpmbuild -bc hello.spec*
+	Build _hello.spec_ up to and including the *%build* stage,
+	ie. without producing actual packages.
+
+*rpmbuild -bi --short-circuit hello.spec*
+	Only execute the *%install* stage of _hello.spec_, skipping all
+	previous stages. This assumes a preceding run of at least up to
+	the *%build* stage, see previous example. Useful to avoid full
+	rebuilds when working on the *%files* section of a package.
+
+# FILES
 See *rpm-common*(8)
 
 # SEE ALSO
-
 *gendiff*(1), *popt*(3), *rpm*(8), *rpm-common*(8), *rpmbuild-config*(5),
 *rpm2cpio*(1), *rpmkeys*(8), *rpmspec*(1), *rpmsign*(1),
 *rpm-setup-autosign*(1) *rpm-macros*(7)
-
-*rpmbuild --help* - as rpm supports customizing the options via popt
-aliases it's impossible to guarantee that what's described in the
-manual matches what's available.
 
 *http://www.rpm.org/*


### PR DESCRIPTION
This is a fairly substantial rework of the man page to try and make more sense out of all the different stages and modes and who they are aimed at.

Related: #3669
Fixes: #3629