### PR TITLE
Use .cpio suffix for cpio output files

### DIFF
--- a/docs/man/rpm2archive.1.scd
+++ b/docs/man/rpm2archive.1.scd
@@ -1,7 +1,7 @@
 RPM2ARCHIVE(1)
 
 # NAME
-rpm2archive - Create tar archive from RPM Package Manager (RPM) package
+rpm2archive - Create tar or cpio archive from RPM Package Manager (RPM) package
 
 # SYNOPSIS
 *rpm2archive* [options] _PACKAGE_FILE_ ...
@@ -13,8 +13,9 @@ rpm2archive - Create tar archive from RPM Package Manager (RPM) package
 
 If the standard output is a regular file or a pipe, the archive is written
 to the standard output. If the standard output is a terminal, the output
-is written to a file by the same name, appended with a _.tgz_ suffix.
-In both cases, the output is compressed in the *gzip*(1) format by default.
+is written to a file by the same name, appended with a _.tgz_ or _.cpio.gz_
+suffix when compressed or _.tar_ or _.cpio_ otherwise depending on the format.
+The output is compressed in the *gzip*(1) format by default.
 
 *rpm2archive* does not verify package-level signatures or checksums, but
 it does verify the per-file checksums.

--- a/tools/rpm2archive.cc
+++ b/tools/rpm2archive.cc
@@ -216,11 +216,21 @@ static int process_package(rpmts ts, const char * filename)
 	} else {
 	    outname = rstrscat(NULL, filename, NULL);
 	}
-	if (compress) {
-	    outname = rstrscat(&outname, ".tgz", NULL);
-	} else {
-	    outname = rstrscat(&outname, ".tar", NULL);
+
+	if (rstreq(format, "pax")) {
+	    if (compress) {
+		outname = rstrscat(&outname, ".tgz", NULL);
+	    } else {
+		outname = rstrscat(&outname, ".tar", NULL);
+	    }
+	} else if (rstreq(format, "cpio")) {
+	    if (compress) {
+		outname = rstrscat(&outname, ".cpio.gz", NULL);
+	    } else {
+		outname = rstrscat(&outname, ".cpio", NULL);
+	    }
 	}
+
 	if (archive_write_open_filename(a, outname) != ARCHIVE_OK) {
 	    fprintf(stderr, "Error: Can't open output file: %s\n", outname);
 	    exit(EXIT_FAILURE);


### PR DESCRIPTION
When creating cpio(5) archives, the generated file name should reflect that.

Tested manually as the test suite redirects stdout whihc makes this a bit difficult to test. rpm2archive tries to output to stdout in this case.

Resolves: #3922