### PR TITLE
Fix incorrect comparison of `sigalgo` and `hashalgo` fields

### DIFF
--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -518,9 +518,9 @@ static int sinfoCmp(const void *a, const void *b)
 	rc = sb->type - sa->type;
     /* strongest (in the "newer is better" sense) algos first */
     if (rc == 0)
-	rc = sb->sigalgo - sb->sigalgo;
+	rc = sb->sigalgo - sa->sigalgo;
     if (rc == 0)
-	rc = sb->hashalgo - sb->hashalgo;
+	rc = sb->hashalgo - sa->hashalgo;
     /* last resort, these only makes sense from consistency POV */
     if (rc == 0)
 	rc = sb->id - sa->id;

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -259,7 +259,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps --nodigest --noverify \
 error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 INSTALL 2
-	package hello-2.0-1.x86_64 does not verify: Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
+	package hello-2.0-1.x86_64 does not verify: no digest
 INSTALL 3
 	package hello-2.0-1.x86_64 does not verify: no digest
 INSTALL 4
@@ -296,7 +296,7 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [1],
 [],
 [warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: no signature
 ])
 RPMTEST_CLEANUP
 
@@ -424,7 +424,7 @@ error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 INSTALL 3
 warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
-	package hello-2.0-1.x86_64 does not verify: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: no signature
 INSTALL 4
 	package hello-2.0-1.x86_64 does not verify: no signature
 INSTALL 5

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -54,13 +54,13 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/data/RPMS/hello-2.0-1.x86_64.rpm:
-    Header OpenPGP signature: NOTFOUND
-    Header OpenPGP RSA signature: NOTFOUND
     Header OpenPGP DSA signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 ],
 [])
 
@@ -82,12 +82,12 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-1.0-1.i386.rpm
     Header SHA3-256 digest: NOTFOUND
     Header SHA256 digest: NOTFOUND
     Header SHA1 digest: NOTFOUND
-    Payload SHA256 digest: NOTFOUND
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
+    Payload SHA256 digest: NOTFOUND
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -111,12 +111,12 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [1],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
     Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
-    Header OpenPGP signature: NOTFOUND
     Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 ],
 [])
 
@@ -259,12 +259,12 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [1],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
     Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
-    Header OpenPGP signature: NOTFOUND
     Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 ],
 [])
 
@@ -354,12 +354,12 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm
 [1],
 [/data/RPMS/hello-2.0-1.x86_64-signed-with-new-subkey.rpm:
     Header OpenPGP V4 EdDSA/SHA512 signature, key ID 6323c42711450b6c: NOKEY
-    Header OpenPGP signature: NOTFOUND
     Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 ],
 [])
 
@@ -533,8 +533,8 @@ runroot rpmkeys -Kv --nosignature /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
-    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA3-256 digest: NOTFOUND
+    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
     Legacy MD5 digest: NOTFOUND
@@ -557,12 +557,12 @@ runroot rpmkeys -Kv --nosignature /tmp/${pkg}
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
     Header SHA256 digest: OK
-    Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
+    Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -732,13 +732,13 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [[Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -753,14 +753,14 @@ Checking package after importing key:
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: OK
-    Payload SHA256 digest: NOTFOUND
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
-    Legacy OpenPGP RSA signature: NOTFOUND
+    Payload SHA256 digest: NOTFOUND
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -794,13 +794,13 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -813,13 +813,13 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 1
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -828,11 +828,11 @@ RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 invalid: key is not alive])dnl
 RPMOUTPUT_SEQUOIA([      because: The subkey is not live])dnl
 RPMOUTPUT_SEQUOIA([      because: Expired on 2022-04-12T00:00:15Z])dnl
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -866,13 +866,13 @@ runroot rpmkeys --define '_pkgverify_level all' -Kv --nosignature /data/RPMS/hel
 [0],
 [Checking package before importing key:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA512 signature, key ID 1f71177215217ee0: NOKEY
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 1
 Importing key:
 0
@@ -883,24 +883,24 @@ Checking package after importing key:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 1
 Checking package after importing key, no digest:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
 RPMOUTPUT_LEGACY([error: Subkey 1f71177215217ee0 of key b3a771bfeb04e625 (Alice <alice@example.org>) has been revoked])dnl
 RPMOUTPUT_SEQUOIA([error: Verifying a signature using certificate B6542F92F30650C36B6F41BCB3A771BFEB04E625 (Alice <alice@example.org>):])dnl
 RPMOUTPUT_SEQUOIA([  Key 1F71177215217EE0 is invalid: key is revoked])dnl
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: b6542f92f30650c36b6f41bcb3a771bfeb04e625: NOTTRUSTED
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 1
 Checking package after importing key, no signature:
 /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm:
@@ -1073,22 +1073,22 @@ runroot rpmkeys -Kv --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo
 ],
 [0],
 [/data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 1
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 1
 0
 /data/RPMS/hello-2.0-1.x86_64-v3-signed.rpm:
@@ -1141,17 +1141,17 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
-    Header OpenPGP signature: NOTFOUND
+    Header OpenPGP DSA signature: NOTFOUND
 RPMOUTPUT_LEGACY([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
 RPMOUTPUT_SEQUOIA([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
 RPMOUTPUT_SEQUOIA([  Failed to parse Signature Packet])dnl
 RPMOUTPUT_SEQUOIA([      because: Signature appears to be created by a non-conformant OpenPGP implementation, see <https://github.com/rpm-software-management/rpm/issues/2351>.])dnl
 RPMOUTPUT_SEQUOIA([      because: Malformed MPI: leading bit is not set: expected bit 1 to be set in        0 (0))])dnl
-    Header OpenPGP DSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 /tmp/hello-2.0-1.x86_64-signed.rpm:
 RPMOUTPUT_LEGACY([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: signature without creation time)])dnl
 RPMOUTPUT_SEQUOIA([    Header OpenPGP RSA signature: BAD (package tag 268: invalid OpenPGP signature: Parsing an OpenPGP packet:])dnl
@@ -1183,26 +1183,26 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-v3-signed.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
-    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA3-256 digest: NOTFOUND
+    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    Legacy OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V3 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-v3-signed.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
-    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA3-256 digest: NOTFOUND
+    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 63a0502eb7f5eaa07d43fe8fa805665b86e58d53db38ccf625bbbf01e3cd67ab)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    Legacy OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V3 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -1225,26 +1225,26 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
-    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA3-256 digest: NOTFOUND
+    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
-    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA3-256 digest: NOTFOUND
+    Header SHA256 digest: BAD (Expected ef920781af3bf072ae9888eec3de1c589143101dff9cc0b561468d395fb766d9 != 29fdfe92782fb0470a9a164a6c94af87d3b138c63b39d4c30e0223ca1202ba82)
     Header SHA1 digest: NOTFOUND
     Payload SHA256 digest: OK
-    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -1268,30 +1268,30 @@ runroot rpmkeys -Kv /tmp/${pkg}
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64-signed.rpm:
+    Header OpenPGP DSA signature: NOTFOUND
     Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
     Header OpenPGP signature: NOTFOUND
-    Header OpenPGP DSA signature: NOTFOUND
     Header SHA256 digest: OK
-    Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
-    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
+    Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
     Legacy MD5 digest: NOTFOUND
 /tmp/hello-2.0-1.x86_64-signed.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
-    Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
-    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
+    Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: BAD
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -1327,14 +1327,14 @@ dorpm -Kv
 /data/RPMS/hello-2.0-1.x86_64-corrupted.rpm:
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
-    Payload SHA256 digest: NOTFOUND
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
-    Legacy OpenPGP RSA signature: NOTFOUND
+    Payload SHA256 digest: NOTFOUND
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy MD5 digest: OK
 ]],
 [])
@@ -1473,14 +1473,14 @@ runroot rpmkeys -Kv --define "_pkgverify_flags 0" /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
-    Header OpenPGP signature: NOTFOUND
-    Header OpenPGP RSA signature: NOTFOUND
     Header OpenPGP DSA signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
 ],
 [])
@@ -1497,7 +1497,7 @@ runroot rpmsign --key-id 1964C5FC --digest-algo sha256 --addsign "/tmp/${pkg}"
 ],
 [1],
 [],
-[error: not signing corrupt package /tmp/hello-2.0-1.x86_64.rpm: Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
+[error: not signing corrupt package /tmp/hello-2.0-1.x86_64.rpm: Payload SHA3-256 digest: NOTFOUND
 ])
 
 RPMTEST_CHECK([
@@ -1505,18 +1505,18 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
-    Header OpenPGP signature: NOTFOUND
-    Header OpenPGP RSA signature: NOTFOUND
     Header OpenPGP DSA signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
-    Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
-    Legacy OpenPGP RSA signature: NOTFOUND
+    Payload SHA256 digest: BAD (Expected 84a7338287bf19715c4eed0243f5cdb447eeb0ade37b2af718d4060aefca2f7c != bea903609dceac36e1f26a983c493c98064d320fdfeb423034ed63d649b2c8dc)
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 ],
 [])
@@ -1578,12 +1578,12 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
     Header OpenPGP V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOKEY
-    Header OpenPGP signature: NOTFOUND
     Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 ],
 [])
 RPMTEST_CLEANUP
@@ -1737,13 +1737,13 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
-    Header OpenPGP signature: NOTFOUND
-    Header OpenPGP RSA signature: NOTFOUND
     Header OpenPGP DSA signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 ],
 [])
 
@@ -2609,13 +2609,13 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
-    Header OpenPGP V6 Ed25519/SHA512 signature, key ID 6118abe481c41473: NOKEY
-    Header OpenPGP RSA signature: NOTFOUND
     Header OpenPGP DSA signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP V6 Ed25519/SHA512 signature, key ID 6118abe481c41473: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 ],
 [])
 
@@ -2691,13 +2691,13 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
-    Header OpenPGP V6 RSA/SHA512 signature, key ID 0a25ec5925ee7635: NOKEY
-    Header OpenPGP RSA signature: NOTFOUND
     Header OpenPGP DSA signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP V6 RSA/SHA512 signature, key ID 0a25ec5925ee7635: NOKEY
     Header SHA256 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
 ],
 [])
 

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -110,12 +110,12 @@ nopl
 /data/RPMS/hello-2.0-1.x86_64.rpm:
     Header SHA256 digest: OK
     Header SHA1 digest: OK
-    Payload SHA256 digest: NOTFOUND
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
+    Payload SHA256 digest: NOTFOUND
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy MD5 digest: NOTFOUND
 1
 nosha1
@@ -381,14 +381,14 @@ noplds
     Header OpenPGP V4 RSA/SHA256 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Header SHA1 digest: OK
-    Payload SHA256 digest: NOTFOUND
-    Payload SHA256 ALT digest: NOTFOUND
     Payload SHA3-256 digest: NOTFOUND
     Payload SHA3-256 ALT digest: NOTFOUND
     Payload SHA512 digest: NOTFOUND
     Payload SHA512 ALT digest: NOTFOUND
-    Legacy OpenPGP RSA signature: NOTFOUND
+    Payload SHA256 digest: NOTFOUND
+    Payload SHA256 ALT digest: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy MD5 digest: OK
 1
 nohdrs
@@ -401,14 +401,14 @@ nohdrs
 0
 nosig
 /data/RPMS/hello-2.0-1.x86_64-signed.rpm:
-    Header OpenPGP signature: NOTFOUND
-    Header OpenPGP RSA signature: NOTFOUND
     Header OpenPGP DSA signature: NOTFOUND
+    Header OpenPGP RSA signature: NOTFOUND
+    Header OpenPGP signature: NOTFOUND
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 digest: OK
-    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy OpenPGP DSA signature: NOTFOUND
+    Legacy OpenPGP RSA signature: NOTFOUND
     Legacy MD5 digest: OK
 1
 ],


### PR DESCRIPTION
Previously `sinfoCmp` ignored the `sigalgo` and `hashalgo` fields.



Remarks:
- at first I did not expect that so many tests need to be updated (I should have create an issue...),
- the changes in the tests are _minimal_,
- I am open for any suggestions.