### PR TITLE
Specify overridden member functions as `override`

### DIFF
--- a/lib/keystore.hh
+++ b/lib/keystore.hh
@@ -20,30 +20,30 @@ public:
 
 class keystore_fs : public keystore {
 public:
-    virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
-    virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
-    virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
-    virtual rpmRC delete_store(rpmtxn txn);
+    rpmRC load_keys(rpmtxn txn, rpmKeyring keyring) override;
+    rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0) override;
+    rpmRC delete_key(rpmtxn txn, rpmPubkey key) override;
+    rpmRC delete_store(rpmtxn txn) override;
 private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, const std::string & newname = "");
 };
 
 class keystore_rpmdb : public keystore {
 public:
-    virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
-    virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
-    virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
-    virtual rpmRC delete_store(rpmtxn txn);
+    rpmRC load_keys(rpmtxn txn, rpmKeyring keyring) override;
+    rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0) override;
+    rpmRC delete_key(rpmtxn txn, rpmPubkey key) override;
+    rpmRC delete_store(rpmtxn txn) override;
 private:
     rpmRC delete_key(rpmtxn txn, const std::string & keyid, unsigned int newinstance = 0);
 };
 
 class keystore_openpgp_cert_d : public keystore {
 public:
-    virtual rpmRC load_keys(rpmtxn txn, rpmKeyring keyring);
-    virtual rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0);
-    virtual rpmRC delete_key(rpmtxn txn, rpmPubkey key);
-    virtual rpmRC delete_store(rpmtxn txn);
+    rpmRC load_keys(rpmtxn txn, rpmKeyring keyring) override;
+    rpmRC import_key(rpmtxn txn, rpmPubkey key, int replace = 1, rpmFlags flags = 0) override;
+    rpmRC delete_key(rpmtxn txn, rpmPubkey key) override;
+    rpmRC delete_store(rpmtxn txn) override;
 };
 
 RPM_GNUC_INTERNAL


### PR DESCRIPTION
[Virtual functions should specify exactly one of `virtual`, `override`, or `final`](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final). In this case, they all could be marked as `final`, but this is a design decision and I do not want to take it here.