### PR TITLE
It is safe to call `delete` on `nullptr`

### DIFF
--- a/lib/cpio.cc
+++ b/lib/cpio.cc
@@ -460,7 +460,7 @@ rpmcpio_t rpmcpioFree(rpmcpio_t cpio)
     if (cpio) {
 	if (cpio->fd)
 	    (void) rpmcpioClose(cpio);
-	delete cpio;
     }
+    delete cpio;
     return NULL;
 }


### PR DESCRIPTION
Cf. 6.7.5.4.2.4 in the C++ standard.

The aim of this change is to resolve [readability-delete-null-pointer](https://clang.llvm.org/extra/clang-tidy/checks/readability/delete-null-pointer.html).