### PR TITLE
Refactor rpmds internals to use STL vectors and strings instead of C dynamic allocations

### DIFF
--- a/lib/rpmds.cc
+++ b/lib/rpmds.cc
@@ -710,7 +710,6 @@ static int doFind(rpmds ds, const rpmds ods, unsigned int *he)
 
 	comparison = strcmp(ON, N);
 
-	/* XXX rpm prior to 3.0.2 did not always supply EVR and Flags. */
 	if (comparison == 0 && OEVR && EVR)
 	    comparison = strcmp(OEVR, EVR);
 	if (comparison == 0)


### PR DESCRIPTION
Details in commit messages but there isn't all that much to say, this is pretty straightforward refactoring in all. This is a pretty nice stat though:

 lib/rpmds.cc | 277 +++++++++++++++++++++--------------------------------------
 1 file changed, 100 insertions(+), 177 deletions(-)
