### PR TITLE
Add _find_debuginfo_extra_opts

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -148,8 +148,8 @@
 #	A spec file can %%define _find_debuginfo_opts to pass options to
 #	the script.  See the script for details.
 #
-#	Other macro files can %%define _find_debuginfo_extra_opts to pass
-#       options to the script.  See redhat-rpm-config/macros for an example.
+#	Other macro files can %%define _find_debuginfo_vendor_opts to pass
+#       options to the script.
 #
 %__debug_install_post   \
     %{__find_debuginfo} \\\
@@ -163,7 +163,7 @@
     %{?_unique_debug_srcs:--unique-debug-src-base "%{name}-%{VERSION}-%{RELEASE}.%{_arch}"} \\\
     %{?_find_debuginfo_dwz_opts} \\\
     %{?_find_debuginfo_opts} \\\
-    %{?_find_debuginfo_extra_opts} \\\
+    %{?_find_debuginfo_vendor_opts} \\\
     %{?_debugsource_packages:-S debugsourcefiles.list} \\\
     "%{builddir}/%{?buildsubdir}"\
 %{nil}


### PR DESCRIPTION
This PR adds a new variable: _find_debuginfo_extra_opts to the list of options that are passed to the find_debuginfo script.

It can be used by other macro files to pass extra options to find_debuginfo.  (As opposed to the _find_debuginfo_opts variable which is used by individual spec files).

An an example of the use of this variable is in the macro file supplied as part of the redhat-rpm-config package used by Fedora, CentOS and RHEL.  The macro file there defines _find_debuginfo_extra_opts like this:

  %_find_debuginfo_extra_opts %{?_annotated_build:--remove-section .gnu.build.attributes}

This is used to reduce the size of binaries by removing an unneeded section.

Ready for inclusion.