### PR TITLE
Fix typos in man pages

### DIFF
--- a/docs/man/rpm-lua.7.scd
+++ b/docs/man/rpm-lua.7.scd
@@ -523,7 +523,7 @@ calls refer to the system manual, eg *access*(3) for *posix.access()*.
 
 *chmod(*_path_, _mode_*)*
 	Change file/directory mode. Mode can be either an octal number as for
-	*chmod*(2) system call, or a string presenation similar to *chmod*(1).
+	*chmod*(2) system call, or a string presentation similar to *chmod*(1).
 
 	Example:
 	```

--- a/docs/man/rpm-macros.7.scd
+++ b/docs/man/rpm-macros.7.scd
@@ -197,7 +197,7 @@ The most powerful of the macro expansion methods is using RPM's embedded Lua
 interpreter:
 
 *%{lua:*_LUA-CODE_*}*
-	Execute _LUA-CODE_ using RPM's embedded Lua interpeter, expanding
+	Execute _LUA-CODE_ using RPM's embedded Lua interpreter, expanding
 	to the code's *print()*'ed output.
 
 See *rpm-lua*(7) for the details.
@@ -235,9 +235,9 @@ automatic macros are available:
 |  *%#*
 :  the number of arguments
 |  *%{-f}*
-:  if present at invocation, the last occurence of flag *f* (flag and argument)
+:  if present at invocation, the last occurrence of flag *f* (flag and argument)
 |  *%{-f\*}*
-:  if present at invocation, the argument to the last occurence of flag *f*
+:  if present at invocation, the argument to the last occurrence of flag *f*
 |  *%1*, *%2*, ...
 :  the arguments themselves (after *getopt*(3) processing)
 

--- a/docs/man/rpm-payloadflags.7.scd
+++ b/docs/man/rpm-payloadflags.7.scd
@@ -29,7 +29,7 @@ vary depending on how RPM was compiled.
 |  *xzdio*
 :  xz
 |  *lzdio*
-:  legazy lzma
+:  legacy lzma
 |  *zstdio*
 :  zstd
 

--- a/docs/man/rpm-plugin-prioreset.8.scd
+++ b/docs/man/rpm-plugin-prioreset.8.scd
@@ -3,7 +3,7 @@ RPM-PLUGIN-PRIORESET(8)
 # NAME
 
 rpm-plugin-prioreset - Plugin for the RPM Package Manager to fix issues
-with priorities of deamons on SysV init
+with priorities of daemons on SysV init
 
 # DESCRIPTION
 

--- a/docs/man/rpm-plugins.8.scd
+++ b/docs/man/rpm-plugins.8.scd
@@ -29,7 +29,7 @@ to *%{nil}* will prevent the plugin from being run.
 
 This can be done on the RPM command line e.g. with
 *--undefine=\_\_transaction_syslog*. To disable a plugin
-permantently, place a _macros.\*_ file in _/etc/rpm/_ that contains
+permanently, place a _macros.\*_ file in _/etc/rpm/_ that contains
 
 ```
 %__transaction_NAME %{nil}

--- a/docs/man/rpm-version.7.scd
+++ b/docs/man/rpm-version.7.scd
@@ -69,7 +69,7 @@ to *abc0123*, *abc.123* and *abc.000123* despite difference in appearance.
 
 Numeric segments are considered newer than alphabetic segments regardless
 of the actual content. When otherwise equal, the component with more
-segments is considered newer, and similarly an _EVR_ with more compoments
+segments is considered newer, and similarly an _EVR_ with more components
 is considered newer. For example, *0.0* is newer than *0* and *1.xyz* is
 older than *1.0* but newer than *1*.
 

--- a/docs/man/rpm2cpio.1.scd
+++ b/docs/man/rpm2cpio.1.scd
@@ -10,7 +10,7 @@ rpm2cpio - Extract cpio archive from RPM Package Manager (RPM) package
 
 # DESCRIPTION
 *rpm2cpio* converts the specified *rpm* package to a *cpio*(1) archive
-on the standard ouput.
+on the standard output.
 
 *Note:* the *cpio*(5) format cannot host individual files over 4GB in size,
 and so this tool is considered obsolete.  Use *rpm2archive*(1) instead.

--- a/docs/man/rpmdb.8.scd
+++ b/docs/man/rpmdb.8.scd
@@ -39,7 +39,7 @@ The *rpmdb* is used for *rpm* database maintenance operations.
 
 *--importdb*
 	Imports a database from a header-list format as created
-	by *--exportdb*. The data is reaad from standard input.
+	by *--exportdb*. The data is read from standard input.
 
 # OPTIONS
 See *rpm-common*(8) for the options common to all *rpm* executables.

--- a/docs/man/rpmuncompress.1.scd
+++ b/docs/man/rpmuncompress.1.scd
@@ -9,7 +9,7 @@ RPMUNCOMPRESS(1)
 *rpmuncompress* [options] [extract-options] {*-x*|*--extract*} _ARCHIVE_
 
 # DESCRIPTION
-*rpmuncompress* is a utility for transparently outputing compressed
+*rpmuncompress* is a utility for transparently outputting compressed
 and uncompressed files, and extracting archives.
 
 It's normally invoked internally by *rpmbuild*(1) to handle *%setup*


### PR DESCRIPTION
After #3960 I got the idea of running aspell on the man folder, this is what I found when going through that output.