### PR TITLE
Document that --rmsource does not affect NoSource and NoPatch

### DIFF
--- a/docs/man/rpmbuild.1.scd
+++ b/docs/man/rpmbuild.1.scd
@@ -151,6 +151,8 @@ _TAR_ARCHIVE_
 *--rmsource*
 	Remove the sources after the build (may also be used standalone,
 	e.g. *rpmbuild* *--rmsource foo.spec*).
+	Note that by definition, *NoSource* and *NoPatch* files are not
+	sources and so, are not affected by this option.
 
 *--rmspec*
 	Remove the spec file after the build (may also be used standalone,


### PR DESCRIPTION
NoSource and NoPatch are by their own declaration not sources, so it's logical they are not affected by --rmsource, but this wasn't explicitly documented anywhere.

Fixes: #3037