### PR TITLE
Fix build regression on WITH_SEQUOIA=OFF

### DIFF
--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -489,6 +489,13 @@ int pgpDigParamsVersion(pgpDigParams digp);
  */
 uint32_t pgpDigParamsCreationTime(pgpDigParams digp);
 
+/** \ingroup rpmpgp
+ * Return salt of a signature (OpenPGP v6 signatures)
+ * @param digp		parameter container
+ * @param[out] datap	salt data
+ * @param[out] lenp	length of the salt
+ * @return		0 on success
+ */
 int pgpDigParamsSalt(pgpDigParams digp, const uint8_t **datap, size_t *lenp);
 
 /** \ingroup rpmpgp

--- a/rpmio/rpmpgp_dummy.cc
+++ b/rpmio/rpmpgp_dummy.cc
@@ -121,3 +121,8 @@ rpmRC pgpPubkeyMerge(const uint8_t *pkts1, size_t pkts1len, const uint8_t *pkts2
 {
     return RPMRC_FAIL;
 }
+
+int pgpDigParamsSalt(pgpDigParams digp, const uint8_t **datap, size_t *lenp)
+{
+    return -1;
+}


### PR DESCRIPTION
Commit c36c717f41683953b9c23e447a8df0d0ac7c845c neglected to add the stub for non-sequoia builds.

Fixes: #3970