### PR TITLE
Fix broken redirects to man pages

### DIFF
--- a/docs/manual/dependency_generators.md
+++ b/docs/manual/dependency_generators.md
@@ -1,5 +1,5 @@
 ---
 layout: redirected
 sitemap: false
-redirect_to: /man/rpm-dependency-generators.7
+redirect_to: ../man/rpm-dependency-generators.7
 ---

--- a/docs/manual/lua.md
+++ b/docs/manual/lua.md
@@ -1,5 +1,5 @@
 ---
 layout: redirected
 sitemap: false
-redirect_to: /man/rpm-lua.7
+redirect_to: ../man/rpm-lua.7
 ---

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -1,5 +1,5 @@
 ---
 layout: redirected
 sitemap: false
-redirect_to: /man/rpm-macros.7
+redirect_to: ../man/rpm-macros.7
 ---

--- a/docs/manual/queryformat.md
+++ b/docs/manual/queryformat.md
@@ -1,5 +1,5 @@
 ---
 layout: redirected
 sitemap: false
-redirect_to: /man/rpm-queryformat.7
+redirect_to: ../man/rpm-queryformat.7
 ---


### PR DESCRIPTION
When the site is deployed, whether on rpm-software-management.github.io for the upstream version or rpm.org for the stable versions, its root is never /, it's either /rpm or /docs/<version>, respectively. So no wonder the absolute /man/... redirects never worked in either case...

They did work when rendering the site locally with "make site" where the site's root is /, though, which is why I happily used that in commit ca6a6b1b40acb2e48b5c6eb337676f9c7d18d44d, with the same pattern being repeated (naturally) for later man page conversions as well.

Fix by simply using a relative path instead. This also makes sure we actually redirect to the correct version of the man page on rpm.org.

Fixes: #3964