### PR TITLE
Fix doubled words in man pages

### DIFF
--- a/docs/man/rpm-common.8.scd
+++ b/docs/man/rpm-common.8.scd
@@ -78,7 +78,7 @@ options and operations documented in this manual:
 
 *--target* _PLATFORM_
 	Use _PLATFORM_ configuration instead of detecting automatically.
-	_PLATFORM_ is is formed as _arch_[-_os_].
+	_PLATFORM_ is formed as _arch_[-_os_].
 
 *--quiet*
 	Print as little as possible - normally only error messages will be

--- a/docs/man/rpm-config.5.scd
+++ b/docs/man/rpm-config.5.scd
@@ -111,7 +111,7 @@ opposed to just package building) parts:
 	A colon separated list of hash algorithms to calculate digests on the
 	entire package files during verification. The calculated digests
 	are stored in the *Packagedigests* tag of packages in the rpmdb,
-	and the corresponding algorithms in in the *Packagedigestalgos* tag.
+	and the corresponding algorithms in the *Packagedigestalgos* tag.
 	No package digests are calculated or stored if *--noverify* is
 	used during package installation.
 

--- a/docs/man/rpm-lua.7.scd
+++ b/docs/man/rpm-lua.7.scd
@@ -46,7 +46,7 @@ for _, v in ipairs(v) do
 end
 ```
 
-All macros share the the same global Lua execution environment.
+All macros share the same global Lua execution environment.
 
 ## Calling parametric macros
 Parametric macros (including all built-in macros) can be called in a Lua
@@ -71,7 +71,7 @@ macros.dostuff({'one', 'two', 'three'})
 
 ## Returning data
 By definition, anything *print()*'ed in Lua will end up in the macro
-expansion. Lua macros can also also *return* their output, which makes
+expansion. Lua macros can also *return* their output, which makes
 programming helper macros look more natural.
 
 Example:

--- a/docs/man/rpmspec.1.scd
+++ b/docs/man/rpmspec.1.scd
@@ -14,7 +14,7 @@ rpmspec - RPM Spec Tool
 *rpmspec* is a tool for querying a spec file. More specifically for
 querying hypothetical packages which would be created from the given
 spec file. So querying a spec file with *rpmspec* is similar to
-querying a package built from that spec file. But is is not identical.
+querying a package built from that spec file. But it is not identical.
 With *rpmspec* you can't query all fields which you can query from a
 built package. E. g. you can't query BUILDTIME with *rpmspec* for
 obvious reasons. You also cannot query other fields automatically


### PR DESCRIPTION
Saw a doubled word in the original man page text when checking the Swedish translation, so ran a script to find some more.