### PR TITLE
Remove dot from docs

### DIFF
--- a/docs/manual/philosophy.md
+++ b/docs/manual/philosophy.md
@@ -60,7 +60,7 @@ never actually interact with RPM directly.
 * Reproducibility of builds and installs
 * Verifiability of packages and installed software
 
-### Rolling out (security) updates quickly.
+### Rolling out (security) updates quickly
 
 Getting updates installed quickly is one of the main design
 goals. Many features and following design decisions are supporting


### PR DESCRIPTION
Other headings don't have trailing dots. And heading generally should not have trailing dots in the first place.