### PR TITLE
Fix man page index filtering

### DIFF
--- a/docs/man/index.md
+++ b/docs/man/index.md
@@ -3,7 +3,8 @@ layout: default
 title: rpm.org - RPM Manual Pages
 ---
 
-{% assign manpages = site.pages | where: 'topic', 'manpage' %}
+{% assign manpages = site.pages | where: 'topic', 'manpage'
+                                | where: 'dir', page.dir %}
 {% assign tools = manpages      | where: 'type', 'tool' %}
 {% assign progs = manpages      | where: 'type', 'program' %}
 {% assign configs = manpages    | where: 'type', 'config' %}


### PR DESCRIPTION
Only list man pages in the current directory. This is needed for the per-version docs on rpm.org to work properly and should've been part of commit 0b30b126393e120999a3bf4bddde4c4153ea1b75.

Note that this issue is currently not visible since we only publish one version with the new man page layout (6.0.x), but as soon as we add more, duplicate entries would be listed without this filter.