### PR TITLE
Fix two trivial documentation mistakes

### DIFF
--- a/docs/man/rpm-lua.7.scd
+++ b/docs/man/rpm-lua.7.scd
@@ -684,7 +684,7 @@ calls refer to the system manual, eg *access*(3) for *posix.access()*.
 	- *gid*: group id
 	- *uid*: user id
 	- *pgrp*: parent group id
-	- *pid*: parent user id
+	- *pid*: process id
 	- *ppid*: parent pid
 
 	If omitted, a table with all these fields is returned.


### PR DESCRIPTION
The description of Lua's `posix.getcwd()` referred to **getenv**(3) while it obviously should be **getcwd**(3).

The value returned as _pid_ from `posix.getprocessid()` is a process id, not any user id.