### PR TITLE
Fix a relocation related crash in fingerprinting

### DIFF
--- a/lib/transaction.cc
+++ b/lib/transaction.cc
@@ -528,6 +528,9 @@ static void handleOverlappedFiles(rpmts ts, fingerPrintCache fpc, rpmte p, rpmfi
 	 * files will be sorted in exactly the same order.
 	 */
 	fiFps = fpCacheGetByFp(fpc, fpList, i, recs);
+	/* We may not *have* records on everything, eg due to relocation. */
+	if (fiFps == NULL)
+	    continue;
 
 	/*
 	 * If this package is being added, look only at other packages

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1135,6 +1135,29 @@ runroot rpm -U --relocate /opt/bin=/bin \
 2: /opt/lib
 ],
 [])
+
+RPMTEST_CHECK([
+runroot rpm -U --relocate /opt/bin=/rbin \
+	--root /srv --nodeps --noplugins --nosignature --noscripts \
+	/build/RPMS/noarch/reloc-1.0-1.noarch.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm --root /srv -ql reloc
+],
+[0],
+[/opt
+/rbin
+/rbin/typo
+/opt/etc
+/opt/etc/conf
+/opt/lib
+/opt/lib/notlib
+],
+[])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpm -i relocatable package 2])


### PR DESCRIPTION
When relocation changes the directory structure, we might end up skipping rpmfi entries entirely, in which case there can be uninitialized entries in the fingerprint array which we then operate on. Oops.

It doesn't seem chroot specific, but triggers more easily that way.

Ensure the whole array is zeroed on allocation (should use STL here but that's a job for another day), and skip fingerprints with NULL entries everywhere we come across them. Add a test to go.

This bug may well be as old as the fingerprinting system itself.

Fixes: #3499