### PR TITLE
Fix wrong macro in rpmsign(1) example

### DIFF
--- a/docs/man/rpmsign.1.scd
+++ b/docs/man/rpmsign.1.scd
@@ -140,7 +140,7 @@ _~/.config/rpm/macros_):
 
 ```
 %\_openpgp_sign sq
-%\_openpgp_signer 7B36C3EE0CCE86EDBC3EFF2685B274E29F798E08
+%\_openpgp_sign_id 7B36C3EE0CCE86EDBC3EFF2685B274E29F798E08
 ```
 
 ## Example 2. Basic operations


### PR DESCRIPTION
Commit d99186f2ef6fc0dfaaefe599a98492a84fd18940 mentioned this "signer" variant, however it's probably just an artifact of an earlier, WIP version of that patch, which was simply forgotten. Use the correct one, which is "sign_id".