### PR TITLE
Add support for %check as a specific build stage in rpmbuild (-bk/-tk/-rk)

### DIFF
--- a/docs/man/rpmbuild.1.scd
+++ b/docs/man/rpmbuild.1.scd
@@ -96,9 +96,15 @@ applicable.
 *c* (%build)
 	Compile the sources. This generally involves the equivalent of *make*.
 
-*i* (%install and %check)
+*i* (%install)
 	Install the binaries into the build root. This generally involves the
-	equivalent of a *make install* and *make check*.
+	equivalent of a *make install*.
+
+	For historical reasons, this also includes the %check stage by default.
+
+*k* (%check)
+	Run any checks specified in the spec. This generally involves the
+	equivalent of *make check*.
 
 *l*
 	Do a "list check" - the *%files* section from the spec file is macro

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -391,6 +391,28 @@ Executing(%check)
 [])
 
 RPMTEST_CHECK([
+runroot rpmbuild -bk /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%mkbuilddir)
+Executing(%prep)
+Executing(%generate_buildrequires)
+Executing(%conf)
+Executing(%build)
+Executing(%install)
+Executing(%check)
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bk --short-circuit /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%check)
+],
+[])
+
+RPMTEST_CHECK([
 runroot rpmbuild -bb --short-circuit /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],

--- a/tools/rpmbuild.cc
+++ b/tools/rpmbuild.cc
@@ -34,6 +34,7 @@ static struct rpmBuildArguments_s rpmBTArgs;
 #define	POPT_BD			0x6264
 #define	POPT_BF			0x6266
 #define	POPT_BI			0x6269
+#define	POPT_BK			0x626b
 #define	POPT_BL			0x626c
 #define	POPT_BP			0x6270
 #define	POPT_BS			0x6273
@@ -44,6 +45,7 @@ static struct rpmBuildArguments_s rpmBTArgs;
 #define	POPT_RD			0x4264
 #define	POPT_RF			0x4266
 #define	POPT_RI			0x4269
+#define	POPT_RK			0x426b
 #define	POPT_RL			0x426c
 #define	POPT_RP			0x4270
 #define	POPT_RS			0x4273
@@ -54,6 +56,7 @@ static struct rpmBuildArguments_s rpmBTArgs;
 #define	POPT_TD			0x7464
 #define	POPT_TF			0x7466
 #define	POPT_TI			0x7469
+#define	POPT_TK			0x746b
 #define	POPT_TL			0x746c
 #define	POPT_TP			0x7470
 #define	POPT_TS			0x7473
@@ -93,6 +96,7 @@ static void buildArgCallback( poptContext con,
     case POPT_BD:
     case POPT_BF:
     case POPT_BI:
+    case POPT_BK:
     case POPT_BL:
     case POPT_BP:
     case POPT_RA:
@@ -101,6 +105,7 @@ static void buildArgCallback( poptContext con,
     case POPT_RD:
     case POPT_RF:
     case POPT_RI:
+    case POPT_RK:
     case POPT_RL:
     case POPT_RP:
     case POPT_TA:
@@ -109,6 +114,7 @@ static void buildArgCallback( poptContext con,
     case POPT_TD:
     case POPT_TF:
     case POPT_TI:
+    case POPT_TK:
     case POPT_TL:
     case POPT_TP:
 	if (opt->val == POPT_BS || opt->val == POPT_TS)
@@ -160,6 +166,9 @@ static struct poptOption rpmBuildPoptTable[] = {
  { "bi", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_BI,
 	N_("build through %install (%prep, %conf, %build, then install) from <specfile>"),
 	N_("<specfile>") },
+ { "bk", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_BK,
+	N_("build through %check (%prep, %conf, %build, %install, then check) from <specfile>"),
+	N_("<specfile>") },
  { "bl", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_BL,
 	N_("verify %files section from <specfile>"),
 	N_("<specfile>") },
@@ -191,6 +200,9 @@ static struct poptOption rpmBuildPoptTable[] = {
  { "ri", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_RI,
 	N_("build through %install (%prep, %conf, %build, then install) from <source package>"),
 	N_("<source package>") },
+ { "rk", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_RK,
+	N_("build through %check (%prep, %conf, %build, %install, then check) from <source package>"),
+	N_("<source package>") },
  { "rl", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_RL,
 	N_("verify %files section from <source package>"),
 	N_("<source package>") },
@@ -221,6 +233,9 @@ static struct poptOption rpmBuildPoptTable[] = {
 	N_("<tarball>") },
  { "ti", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_TI,
 	N_("build through %install (%prep, %conf, %build, then install) from <tarball>"),
+	N_("<tarball>") },
+ { "tk", 0, POPT_ARGFLAG_ONEDASH, 0, POPT_TK,
+	N_("build through %check (%prep, %conf, %build, %install, then check) from <tarball>"),
 	N_("<tarball>") },
  { "tl", 0, POPT_ARGFLAG_ONEDASH|POPT_ARGFLAG_DOC_HIDDEN, 0, POPT_TL,
 	N_("verify %files section from <tarball>"),
@@ -646,6 +661,11 @@ int main(int argc, char *argv[])
 	    break;
 	ba->buildAmount |= RPMBUILD_RMBUILD;
 	/* fallthrough */
+    case 'k':
+	ba->buildAmount |= RPMBUILD_CHECK;
+	if ((buildChar == 'k') && shortCircuit)
+	    break;
+	/* fallthrough */
     case 'i':
 	ba->buildAmount |= RPMBUILD_INSTALL;
 	ba->buildAmount |= RPMBUILD_CHECK;
@@ -706,6 +726,7 @@ int main(int argc, char *argv[])
 	    buildChar != 'f' &&
 	    buildChar != 'c' &&
 	    buildChar != 'i' &&
+	    buildChar != 'k' &&
 	    buildChar != 'l')
 	{
 	    ba->buildAmount |= RPMBUILD_RMSOURCE;


### PR DESCRIPTION
Historically -bi/-ti/-ri runs %check in addition to %install and we cannot change that as people might be using -bi specifically to test. So the newly added -bk/-tk/-rk is alias for -bk/-ti/-ri except when short-circuiting, allowing standalone execution of %check. This wasn't possible before with the rpmbuild executable.

The last commit is the actual change, the earlier ones are just related prep-work, and fixing a bug discovered while doing that prep-work.

Fixes: #3015