### PR TITLE
Fix CMake 3.31 normalized path warning

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -9,13 +9,15 @@ endif()
 if(WITH_DBUS)
 	pkg_check_modules(DBUS REQUIRED IMPORTED_TARGET dbus-1)
 	pkg_get_variable(dbus-1_DATADIR dbus-1 datadir)
+	# Comply with CMP0177
+	cmake_path(SET DBUS_DATADIR NORMALIZE "${dbus-1_DATADIR}")
 	add_library(systemd_inhibit MODULE systemd_inhibit.c)
 	target_link_libraries(systemd_inhibit PRIVATE PkgConfig::DBUS)
 	add_library(dbus_announce MODULE dbus_announce.c)
 	target_link_libraries(dbus_announce PRIVATE PkgConfig::DBUS)
 	install(FILES
 	  org.rpm.conf
-	  DESTINATION ${dbus-1_DATADIR}/dbus-1/system.d/
+	  DESTINATION ${DBUS_DATADIR}/dbus-1/system.d/
 	)
 endif()
 


### PR DESCRIPTION
CMake 3.31 normalizes DESTINATION paths (CMP0177) and gives a warning if a path differs from the original. This is the case with the dbus datadir path since it's defined as a relative path in dbus' pkgconfig file.

Normalizing is fine here so just do it ourselves, in order to silence the CMake warning.

Fixes: #3605