### PR TITLE
Ignore NOTTRUSTED results in verification

### DIFF
--- a/lib/rpmvs.cc
+++ b/lib/rpmvs.cc
@@ -619,10 +619,20 @@ int rpmvsVerify(struct rpmvs_s *sis, int type,
 	if (cb)
 	    cont = cb(sinfo, cbdata);
 
-	if (sinfo->rc == RPMRC_OK)
+	switch (sinfo->rc) {
+	case RPMRC_OK:
 	    success++;
-	else
+	    break;
+	case RPMRC_FAIL:
+	case RPMRC_NOKEY:
+	case RPMRC_NOTFOUND:
 	    failed++;
+	    break;
+	case RPMRC_NOTTRUSTED:
+	default:
+	    /* ignore */
+	    break;
+	};
     }
 
     return (success >= 1 && failed == 0) ? 0 : failed;

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -433,6 +433,7 @@ error: hello-2.0-1.x86_64: install failed
 
 RPMTEST_CHECK([
 runroot rpm -U --ignorearch --ignoreos --nodeps \
+	--define "_pkgverify_flags 0xfc000" \
 	--define "_pkgverify_level signature" \
 	/tmp/${pkg}
 ],
@@ -440,6 +441,20 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [],
 [warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 	package hello-2.0-1.x86_64 does not verify: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+])
+
+# This seems kinda wrong, but the initial package read can only look at
+# header signatures, so it only ever sees the bad signature during pre-install
+# verification.
+RPMTEST_CHECK([
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	--define "_pkgverify_level signature" \
+	/tmp/${pkg}
+],
+[1],
+[],
+[warning: /tmp/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
+	package hello-2.0-1.x86_64 does not verify: Legacy OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: BAD
 ])
 
 RPMTEST_CHECK([

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -1991,7 +1991,6 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP_RW([multisign with disabled algorithms])
 AT_KEYWORDS([rpmsign signature multisig v4])
 RPMTEST_SKIP_IF([test x$PGP = xdummy])
-AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 
 RPMTEST_CHECK([
 cat << EOF > ${HOME}/.config/rpm/macros


### PR DESCRIPTION
We have currently no way of differentiating between signatures whose algorithm is disabled in system policy and ones that are otherwise no longer trustworthy, eg due to expiration. The peculiar thing about these cases is that they are neither failures nor are they positive verifications. It seems they are best dealt with by simply ignoring, except for the verbose output where they need to be shown for diagnostic purposes.
    
This fixes the verification result wrt #3996 but the output is just wrong as these spew a bunch of noisy errors on stderr, which is good for troubleshooting but not something that you'd want to see in these situations. So this is not a full fix for that issue but posting as draft for comments/feedback/ideas.
