### PR TITLE
AIX: Fix compilation error due to __errno_location

### DIFF
--- a/misc/fts.c
+++ b/misc/fts.c
@@ -72,6 +72,9 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
 #		define stat64	stat
 #endif
 #endif
+#if defined(_AIX)
+#   define __errno_location()   (&errno)
+#endif
 
 #include "system.h"
 #include <fcntl.h>


### PR DESCRIPTION
This is an initial patch in a series of patches to fix errors on AIX.

In AIX we can see errors as below.

/home/sangam/rpm-ci/rpm/misc/fts.c:88:31: warning: implicit declaration of function '__errno_location' [-Wimplicit-function-declaration]
   88 | #   define __set_errno(val) (*__errno_location ()) = (val)
      |                               ^~~~~~~~~~~~~~~~
/home/sangam/rpm-ci/rpm/misc/fts.c:149:3: note: in expansion of macro '__set_errno'
  149 |   __set_errno (EINVAL);
      |   ^~~~~~~~~~~

The proposed patch fixes this issue.

Please review the patch and let me know your comments.