### PR TITLE
AIX: implement xsetprogname and xgetprogname

### DIFF
--- a/misc/system.h
+++ b/misc/system.h
@@ -85,6 +85,15 @@ extern int fdatasync(int fildes);
 # define xsetprogname(pn)
   extern const char *__progname;
 # define xgetprogname(pn) __progname
+#elif defined(_AIX)
+char *aix_progname = NULL;
+#define xsetprogname(pn) \
+  {  if (aix_progname == NULL) { \
+        if ((aix_progname = strrchr(pn, '/')) != NULL)  aix_progname++; \
+        else  aix_progname = pn; \
+     } \
+  }
+#define xgetprogname() aix_progname
 #else
 # error "Did not find any sutable implementation of xsetprogname/xgetprogname"
 #endif


### PR DESCRIPTION
AIX don't have xgetprogname & xsetprogname.

Hence, we see an compilation error due to missing xgetprogname & xsetprogname. 
The proposed patch fixes the compilation error by implementing these missing function. 

We can launch rpm program without any issue, and also run some query commands (With some local changes which we would be contributing). 

$ LIBPATH=/opt/freeware/lib/gcc/powerpc-ibm-aix7.3.0.0/10/pthread/ppc64 ./tools/rpm RPM version 6.0.90
Copyright (C) 1998-2002 - Red Hat, Inc.
This program may be freely redistributed under the terms of the GNU GPL

Usage: rpm [-afgpqlsiv?] [-a|--all] [-f|--file] [--path] [-g|--group] [-p|--package] [-q|--query] [--triggeredby]
.......

Please review the changes and let us know if any comments.