### PR TITLE
Document that rpmtsOrder() output depends on package addition order

### DIFF
--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -245,6 +245,9 @@ int rpmtsCheck(rpmts ts);
  * with packages removed for upgrades immediately following the new package
  * to be installed.
  *
+ * The algorithm is deterministic, but the final order depends on the order in
+ * which packages were added to the transaction set.
+ *
  * @param ts		transaction set
  * @return		no. of (added) packages that could not be ordered
  */


### PR DESCRIPTION
This gives a hint useful for anyone interested in reproducible builds.

See also https://github.com/rpm-software-management/rpm/issues/2219#issuecomment-3220423612