### PR TITLE
Let the system runtime environment provide users and groups

### DIFF
--- a/tests/data/SPECS/klang.spec
+++ b/tests/data/SPECS/klang.spec
@@ -26,6 +26,12 @@ Summary: %{SUMMARY} server
 %description server
 %{summary}
 
+%package tools
+Summary: %{SUMMARY} tools
+
+%description tools
+%{summary}
+
 %install
 mkdir -p ${RPM_BUILD_ROOT}/var/lib/klangd
 mkdir -p ${RPM_BUILD_ROOT}/var/lib/plongd
@@ -35,6 +41,7 @@ mkdir -p ${RPM_BUILD_ROOT}/%{_sysusersdir}
 
 echo "aaaa" > ${RPM_BUILD_ROOT}/usr/bin/klang
 echo "bbbb" > ${RPM_BUILD_ROOT}/usr/bin/klangd
+echo "cccc" > ${RPM_BUILD_ROOT}/usr/bin/klangtool
 echo "xxxx" > ${RPM_BUILD_ROOT}/etc/klang.cfg
 
 cat << EOF > ${RPM_BUILD_ROOT}/%{_sysusersdir}/klang.conf
@@ -69,3 +76,6 @@ EOF
 %attr(-,klangd,klangd) /var/lib/klangd
 %attr(-,plong,klong) /var/lib/plongd
 /usr/bin/klangd
+
+%files tools
+%attr(-,plong,klang) /usr/bin/klangtool

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -812,3 +812,62 @@ runroot rpm -e deptest-four
 	(deptest-five unless deptest-four) conflicts with (installed) deptest-two-1.0-1.noarch
 ])
 RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([system provides])
+AT_KEYWORDS([install sysusers depends])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet /data/SPECS/klang.spec
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+runroot rpm -U --test /build/RPMS/noarch/klang-tools-1.0-1.noarch.rpm
+],
+[1],
+[],
+[error: Failed dependencies:
+	group(klang) is needed by klang-tools-1.0-1.noarch
+	user(plong) is needed by klang-tools-1.0-1.noarch
+])
+
+RPMTEST_CHECK([
+runroot useradd plong
+runroot rpm -U --test /build/RPMS/noarch/klang-tools-1.0-1.noarch.rpm
+],
+[1],
+[],
+[error: Failed dependencies:
+	group(klang) is needed by klang-tools-1.0-1.noarch
+])
+
+RPMTEST_CHECK([
+runroot groupadd klang
+runroot rpm -U /build/RPMS/noarch/klang-tools-1.0-1.noarch.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpm -V klang-tools
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot groupdel klang
+runroot userdel plong
+runroot rpm -V klang-tools
+],
+[1],
+[Unsatisfied dependencies for klang-tools-1.0-1.noarch:
+	group(klang) is needed by (installed) klang-tools-1.0-1.noarch
+	user(plong) is needed by (installed) klang-tools-1.0-1.noarch
+.....UG..    /usr/bin/klangtool
+],
+[])
+RPMTEST_CLEANUP

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1647,6 +1647,8 @@ group(klong)
 user(klangd)
 user(klangd)
 user(plong)
+group(klang)
+user(plong)
 Provides
 group(klang) = ZyBrbGFuZyAt
 group(klangd)
@@ -1675,6 +1677,8 @@ group(klong)
 group(klong)
 user(klangd)
 user(klangd)
+user(plong)
+group(klang)
 user(plong)
 Provides
 group(klang) = ZyBrbGFuZyAt


### PR DESCRIPTION
Rpm would prefer users and groups always provided by packages, but the real world is more complicated, and organizations may want to package software utilizing centrally managed groups for access control. To permit this, as the first step we need to let user() and group() dependencies to be provided by the system runtime environment.

Add a new system provides check to dependency resolution - we only add user and group provides here but there are many other potential areas in this direction.

Add a new sub-package to the klang family to have something with both a user and group dependency not provided by itself and adjust existing test for the extra output, add tests for various rpm -U and -V scenarios with system provided user/group.

This is all "good old" C to minimize backporting effort, we'll need to bring this to 4.x anyhow.

Related: #3994