### PR TITLE
Add entry about %caps to spec manual

### DIFF
--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -858,6 +858,23 @@ Supported modifiers are:
 * rdev
 * caps
 
+#### %caps
+
+`%caps(<text>)` sets the given POSIX.1e draft 15 `capabilities(7)` on the file.
+`<text>` is the textual representation of capability sets as described in
+`cap_text_formats(7)`.
+
+This feature is only available if RPM was built with libcap support. On Linux,
+file capabilities are only available since the kernel version 2.6.24. Many
+filesystems (such as NFS) do not support capabilities at all, which can cause
+install-time failures and/or incorrectly functioning packages when such
+filesystems are in use.
+
+Example:
+```
+    %caps(cap_net_raw=p) %{_bindir}/foo
+```
+
 ### Shell Globbing
 
 The usual rules for shell globbing apply (see `glob(7)`), including brace


### PR DESCRIPTION
There's no rpm-spec(5) yet so add it to the existing spec manual for now. The compatibility note is based on the RPM 4.7.0 release notes [1] and the INSTALL file. Once migrated to rpm-spec(5), the example should probably be moved to EXAMPLES there.

This feature was added in RPM 4.7.0 and came with the rpmlib(FileCaps) dependency but that's older than our threshold for annotating features with RPM versions in the man pages, which is 4.11.0 as per the man page template, so no such note is added here.

[1] https://rpm.org/wiki/Releases/4.7.0#POSIX.1edraft15filecapabilities

Fixes: #2832