### PR TITLE
Standardize on stdin/stdout/stderr use in manuals

### DIFF
--- a/docs/man/rpm-dependency-generators.7.scd
+++ b/docs/man/rpm-dependency-generators.7.scd
@@ -107,11 +107,11 @@ ignored and a warning is printed.
 
 # GENERATORS
 
-A generator is an executable that reads filenames from stdin and writes
-dependencies of a single _type_ to stdout, according to a _protocol_. It is
-written for a specific file attribute and defined as a macro in the respective
-_NAME.attr_ file. Zero or more generators, one for each supported type, can be
-defined for a single file attribute.
+A generator is an executable that reads filenames from standard input and writes
+dependencies of a single _type_ to standard output, according to a _protocol_.
+It is written for a specific file attribute and defined as a macro in the
+respective _NAME.attr_ file. Zero or more generators, one for each supported
+type, can be defined for a single file attribute.
 
 ## Generator macros
 *%\_\_*_NAME_*\_conflicts* _COMMAND_++
@@ -125,14 +125,15 @@ defined for a single file attribute.
 *%\_\_*_NAME_*\_supplements* _COMMAND_
 	Generate dependencies of the respective type. Executes _COMMAND_ (a
 	program name and any arguments), passing it one or more filenames that
-	have the file attribute _NAME_ on stdin, and reads dependency strings on
-	its stdout. See *Protocols* for details on the input and output format.
+	have the file attribute _NAME_ on standard input, and reads dependency
+	strings on its standard output. See *Protocols* for details on the input
+	and output format.
 
 ## Protocols
 *%\_\_*_NAME_*\_protocol* _PROTOCOL_
 	Use _PROTOCOL_ when running dependency generators for the file attribute
-	_NAME_. Determines the input and output format for the generators to
-	implement.
+	_NAME_. Determines the standard input and standard output format for the
+	generators to implement.
 
 	_PROTOCOL_ can be one of the following:
 
@@ -153,9 +154,9 @@ defined for a single file attribute.
 Unlike the _PATH_RE_ in file attributes, generators receive filenames with the
 *%{buildroot}* prefix so that they can access the actual file contents on disk.
 
-Generators must always consume all of stdin. For backwards compatibility,
-generators should not make any assumptions about the number of files passed,
-regardless of the protocol used.
+Generators must always consume all of standard input. For backwards
+compatibility, generators should not make any assumptions about the number of
+files passed, regardless of the protocol used.
 
 ## Exported macros
 
@@ -194,8 +195,8 @@ Added: 4.16.0
 *%\_\_find_*​_TYPE_ _COMMAND_
 	Generate dependencies of the respective _TYPE_. Executes _COMMAND_ (a
 	program name and any arguments), passing it the entire file list of the
-	package at once, and reads dependency strings on its stdout. See
-	*Generator macros* for the possible _TYPE_ values.
+	package at once, and reads dependency strings on its standard output.
+	See *Generator macros* for the possible _TYPE_ values.
 
 This is a legacy, deprecated interface that's only available for v4 packages for
 backwards compatibility, and should not be used. Packages built this way contain
@@ -309,7 +310,7 @@ The _%{\_rpmconfigdir}/frobnize_ script has the following contents:
 # Type of dependency strings to print
 mode=$1
 
-# Process every file on stdin
+# Process every file on standard input
 while read -r file; do
     # Print currently processed file as per multifile protocol
     echo ";$file"

--- a/docs/man/rpm-lua.7.scd
+++ b/docs/man/rpm-lua.7.scd
@@ -881,7 +881,7 @@ calls refer to the system manual, eg *access*(3) for *posix.access()*.
 
 *ttyname(*[_fd_]*)*
 	Get name of a terminal associated with file descriptor _fd_.
-	If _fd_ is omitted, *0* (aka stdin) is used. See *ttyname*(3).
+	If _fd_ is omitted, *0* (aka standard input) is used. See *ttyname*(3).
 
 	Example:
 	```

--- a/docs/man/rpm-macros.7.scd
+++ b/docs/man/rpm-macros.7.scd
@@ -555,7 +555,7 @@ the preceding *%*-character.
 	```
 
 *%{uncompress:*_PATH_*}*
-	Expand to a command for outputting argument _PATH_ to stdout,
+	Expand to a command for outputting argument _PATH_ to standard output,
 	uncompressing as needed.
 
 	Example:
@@ -613,7 +613,7 @@ the preceding *%*-character.
 
 ## Output
 *%{echo:*_STRING_*}*
-	Print _STRING_ to process stdout.
+	Print _STRING_ to process standard output.
 
 	Example:
 	```
@@ -621,7 +621,7 @@ the preceding *%*-character.
 	```
 
 *%{warn:*_STRING_*}*
-	Print _STRING_ prefixed with "warning: " to process stderr.
+	Print _STRING_ prefixed with "warning: " to process standard error.
 
 	Example:
 	```
@@ -629,7 +629,7 @@ the preceding *%*-character.
 	```
 
 *%{error:*_STRING_*}*
-	Print _STRING_ prefixed with "error: " to process stderr and
+	Print _STRING_ prefixed with "error: " to process standard error and
 	flag an error in the macro processor.
 
 	Example:

--- a/docs/man/rpm-man-template.scd
+++ b/docs/man/rpm-man-template.scd
@@ -23,7 +23,10 @@ Describe what *rpmcmd* command does in plain, understandable
 English. Command-line switches belong to *OPTIONS* and *OPERATIONS*
 as appropriate.
 
-Typographic conventions:
+Below are *rpm* specific conventions. When in doubt, consult *man-pages*(7).
+
+## Typographic conventions
+
 - Use imperative style when describing functionality
 - Use hard wrapping at 80 columns for all text
 - Use bold for literal values such as command name and options:
@@ -49,7 +52,16 @@ Typographic conventions:
   line of it's own, surrounded by empty lines (standalone variant).
   Only use this for versions 4.11.0 and newer.
 
-When in doubt, consult *man-pages*(7).
+## Preferred terms
+
+|[ *Term*
+:[ *Avoid using*
+|  standard input
+:  stdin
+|  standard output
+:  stdout
+|  standard error
+:  stderr
 
 # OPERATIONS
 For multi-operation commands, describe each operation invocation

--- a/docs/man/rpmspec.1.scd
+++ b/docs/man/rpmspec.1.scd
@@ -94,7 +94,7 @@ On success, 0 is returned, a nonzero failure code otherwise.
 	```
 
 *rpmspec -P rpm.spec*
-	Parse the rpm spec file to stdout, eg:
+	Parse the rpm spec file to standard output, eg:
 	```
 	Summary: The RPM package management system
 	Name: rpm


### PR DESCRIPTION
Use the spelled out form "standard input" and friends. Add a new table Preferred terms, modelled after the one in man-pages(7), to the manual template and document the new convention there.

Keep stdin/stdout in the generator protocol description, though, for brevity and clarity, as an exception to this new rule.

Fixes: #3966