### PR TITLE
Fix RPM self-destruction in Dockerfile

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -83,7 +83,9 @@ RUN ln -sf $(rpm --eval '%{_target_platform}%{?_gnu}')-pkg-config \
 RUN rpm -e --nodeps --nodb \
 	rpm \
 	rpm-libs \
-	rpm-build-libs
+	rpm-sign-libs \
+	rpm-build-libs \
+	rpm-plugin-ima
 
 WORKDIR /
 CMD /bin/bash


### PR DESCRIPTION
Commit 08e30d8abbe447d8987010d0b5951b1b22c5b247 dropped the removal of rpm-plugin-ima since it no longer was pulled in by default, however that (no longer?) is the case, due to ima-evm-utils-devel that requires it.

The plugin also pulled in rpm-sign-libs, which could then cause a false positive in the "rpm library version" test in "make check" if the local build was configured with the /usr prefix.