### PR TITLE
Add tests for user/group lookup via NSS

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -56,7 +56,8 @@ RUN dnf -y install \
   scd2html \
   sequoia-sq \
   libasan \
-  libubsan
+  libubsan \
+  nss-altfiles
 # If updates to specific packages are needed, do it here
 # RUN dnf -y --enablerepo=updates install ...
 

--- a/tests/data/SPECS/hello.spec
+++ b/tests/data/SPECS/hello.spec
@@ -5,6 +5,7 @@
 # package which can be built under runroot in the test-suite.
 
 %bcond hello32 0
+%bcond fileown 0
 
 Summary: hello -- hello, world rpm
  Name: hello
@@ -46,7 +47,11 @@ cp %{SOURCE1} $RPM_BUILD_ROOT/usr/local/bin/hello
 %doc	FAQ
 #%readme README
 #%license COPYING
+%if %{with fileown}
+%attr(0751,foobar,foobar)	/usr/local/bin/hello
+%else
 %attr(0751,root,root)	/usr/local/bin/hello
+%endif
 
 %changelog
 * Tue Oct 20 1998 Jeff Johnson <jbj@redhat.com>

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -4003,7 +4003,7 @@ runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.s
 [0],
 [bd70bbf9335f28297008dafdc7679583e3b63469c435aee7c3ba1c86890fb91e hello-1.0-modernize.patch
 7da10c0f91e120beff34b1d1077f1a77b2422dab7cb158379d44de4e83f90f30 hello-1.0.tar.gz
-93d8095d3fa73c1f9d49468fe34c8ab30d044277ae2d6d5f8d446bb4842bb05d hello.spec
+9b4f23793911a48ba75eba3eabe24c2051227f4596acf28c9ec214fd76d71c73 hello.spec
 ],
 [])
 
@@ -4016,7 +4016,7 @@ runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.s
 [0],
 [bd70bbf9335f28297008dafdc7679583e3b63469c435aee7c3ba1c86890fb91e hello-1.0-modernize.patch
 7da10c0f91e120beff34b1d1077f1a77b2422dab7cb158379d44de4e83f90f30 hello-1.0.tar.gz
-93d8095d3fa73c1f9d49468fe34c8ab30d044277ae2d6d5f8d446bb4842bb05d hello.spec
+9b4f23793911a48ba75eba3eabe24c2051227f4596acf28c9ec214fd76d71c73 hello.spec
 ],
 [])
 
@@ -4029,7 +4029,7 @@ runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.s
 [0],
 [bd70bbf9335f28297008dafdc7679583e3b63469c435aee7c3ba1c86890fb91e hello-1.0-modernize.patch
 7da10c0f91e120beff34b1d1077f1a77b2422dab7cb158379d44de4e83f90f30 hello-1.0.tar.gz
-93d8095d3fa73c1f9d49468fe34c8ab30d044277ae2d6d5f8d446bb4842bb05d hello.spec
+9b4f23793911a48ba75eba3eabe24c2051227f4596acf28c9ec214fd76d71c73 hello.spec
 ],
 [warning: Unknown file digest algorithm 12345, falling back to 8
 ])
@@ -4044,7 +4044,7 @@ runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.s
 [0],
 [79678ec5e51e7565b4703286f26ac6a6 hello-1.0-modernize.patch
 b718a835936fd2f6c8855f210c4789a1 hello-1.0.tar.gz
-4b84966fc3486237ea5861c6ab645f35 hello.spec
+e7c181d30fb60e70ffe8fb24bb7152b5 hello.spec
 ],
 [])
 RPMTEST_CLEANUP
@@ -4060,7 +4060,7 @@ runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.s
 [0],
 [f1a0a1e0e413d66a4bd948cb16bdd03600c7aea6dcd04522bcbc3041a29ee651 hello-1.0-modernize.patch
 a0da711d71069ab2735448140c5e0b51b4aeb3150a72877df54f372350e68644 hello-1.0.tar.gz
-aaf17b3d5277fb7d985461f6b682f24eaf33d352715f2957888434bd55628d25 hello.spec
+6b606602c56431fe768f8490a68c34211644b47a73882395f60a9a4195a5b980 hello.spec
 ],
 [])
 
@@ -4073,7 +4073,7 @@ runroot rpm -q --qf "[%{filedigests} %{filenames}\n]" /build/SRPMS/hello-1.0-1.s
 [0],
 [11ddad2c1e5ef58d94d008634d9ad3a95cb7b5fab51652e73bb999c8d12110c4cdf6c572187c1a880a3c171a1af739fb48f77e98f5e30cc3bc1ec91a16182915 hello-1.0-modernize.patch
 154b8717381c284af9b939cc28199347edc5cbcc3228bf0983d52323ca19ec73ad85a834ee9851d746561a0bdfc2dfa7278846b3b7b492d66451658275e0f1d5 hello-1.0.tar.gz
-e744c7bd0cb3a535cc3bf78d4a4725b23a3fc2c72e12fe32e11d8db41eb9b7d5122144e9a31ce46024b1745b4cc31d9ae4505a4749882c3d556633829ee129cc hello.spec
+ddef8d0a7d769ef678fd852219647e2e2f8c4bd56ea7d7e2326ada4f20640a7ab3a5cddddf60553cc6c7cb115b79ab435ea3e6687fecaec9b92350b1f5089cb5 hello.spec
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1756,6 +1756,70 @@ klangd
 
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([rpm -i user/group lookup])
+AT_KEYWORDS([])
+AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
+
+# Symlink to read-only file /etc/authselect/nsswitch.conf
+rm $RPMTEST/etc/nsswitch.conf
+
+# Set up nss-altfiles
+echo "passwd: files altfiles" > $RPMTEST/etc/nsswitch.conf
+echo "group: files altfiles" >> $RPMTEST/etc/nsswitch.conf
+
+# Add new user and group for lookup via nss-altfiles
+echo "foobar:x:12345:12345:foobar:/:/usr/sbin/nologin" \
+    > $RPMTEST/usr/lib/passwd
+echo "foobar:x:12345:foobar" \
+    > $RPMTEST/usr/lib/group
+
+runroot rpmbuild --quiet -bb --with fileown /data/SPECS/hello.spec
+
+# Verify if new user/group is resolvable from NSS
+RPMTEST_CHECK([
+runroot rpm --eval "%_passwd_path"
+runroot rpm --eval "%_group_path"
+runroot getent passwd foobar
+runroot getent group foobar
+],
+[0],
+[/etc/passwd
+/etc/group
+foobar:x:12345:12345:foobar:/:/usr/sbin/nologin
+foobar:x:12345:foobar
+],
+[])
+
+# Install to system root, should resolve from NSS
+RPMTEST_CHECK([
+runroot rpm -i --nodeps /build/RPMS/x86_64/hello-1.0-1.x86_64.rpm
+runroot stat -c '%u %g' /usr/local/bin/hello
+],
+[0],
+[12345 12345
+],
+[])
+
+# Install to custom root, should resolve from standard paths there
+RPMTEST_CHECK([
+
+# Add new user/group to custom root
+mkdir -p $RPMTEST/alt/etc
+echo "foobar:x:54321:54321:foobar:/:/usr/sbin/nologin" \
+    > $RPMTEST/alt/etc/passwd
+echo "foobar:x:54321:foobar" \
+    > $RPMTEST/alt/etc/group
+
+runroot rpm -i --noplugins --nodeps --nosignature \
+	    --root /alt /build/RPMS/x86_64/hello-1.0-1.x86_64.rpm
+runroot stat -c '%u %g' /alt/usr/local/bin/hello
+],
+[0],
+[54321 54321
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([install on invalid symlinked directory])
 AT_KEYWORDS([install])
 

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -310,6 +310,7 @@ runroot rpmspec --parse \
 
 
 
+
 Summary: hello -- hello, world rpm
  Name: hello
 Version: 1.0


### PR DESCRIPTION
This should cover the gist of #3994. We should still add a test for the override option (e.g. --use-host-nss) but that can be done later, when the details are fleshed out.

Use the NSS altfiles module as a simple way to test whether we are using NSS or not.