### PR TITLE
Convert file triggers structures to STL set

### DIFF
--- a/lib/rpmtriggers.hh
+++ b/lib/rpmtriggers.hh
@@ -9,31 +9,23 @@
 
 #define RPMTRIGGER_DEFAULT_PRIORITY 1000000
 
-struct triggerInfo_s {
+struct triggerInfo {
     unsigned int hdrNum;
     unsigned int tix;
     unsigned int priority;
 
-    bool operator < (const triggerInfo_s & o) const
+    bool operator < (const triggerInfo & o) const
     {
 	return std::tie(priority, hdrNum, tix) <
 	       std::tie(o.priority, o.hdrNum, o.tix);
     }
-    triggerInfo_s(unsigned int _hnum, unsigned int _tix, unsigned int _prio) :
+    triggerInfo(unsigned int _hnum, unsigned int _tix, unsigned int _prio) :
 		hdrNum(_hnum), tix(_tix), priority(_prio)
     {
     }
 };
 
-typedef struct rpmtriggers_s {
-    std::set<triggerInfo_s> triggerInfo;
-} *rpmtriggers;
-
-RPM_GNUC_INTERNAL
-rpmtriggers rpmtriggersCreate(unsigned int hint);
-
-RPM_GNUC_INTERNAL
-rpmtriggers rpmtriggersFree(rpmtriggers triggers);
+using rpmtriggers = std::set<triggerInfo>;
 
 /*
  * Prepare post trans uninstall file triggers. After transcation uninstalled

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -524,6 +524,7 @@ void rpmtsEmpty(rpmts ts)
 	return;
 
     rpmtsClean(ts);
+    ts->trigs2run.clear();
 
     for (auto & te : tsmem->order) {
 	rpmtsNotifyChange(ts, RPMTS_EVENT_DEL, te, NULL);
@@ -600,7 +601,6 @@ rpmts rpmtsFree(rpmts ts)
 
     ts->plugins = rpmpluginsFree(ts->plugins);
 
-    rpmtriggersFree(ts->trigs2run);
     rpmlogReset((uint64_t) ts);
 
     if (_rpmts_stats)
@@ -999,9 +999,6 @@ rpmts rpmtsCreate(void)
     ts->nrefs = 0;
 
     ts->plugins = NULL;
-
-    ts->trigs2run = rpmtriggersCreate(10);
-
     ts->min_writes = (rpmExpandNumeric("%{?_minimize_writes}") > 0);
 
     return rpmtsLink(ts);


### PR DESCRIPTION
Details in the commits, but this is a surprisingly (for rpm code) straightforward conversion job, and nice LoC reduction.