### PR TITLE
Switch elfdeps to use fmt for formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ set(REQFUNCS
 find_package(PkgConfig REQUIRED)
 find_package(Lua 5.2 REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package(fmt REQUIRED)
 if (WITH_BZIP2)
     find_package(BZip2 REQUIRED)
 endif()

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -17,6 +17,7 @@ RUN dnf -y install \
   gettext-devel \
   debugedit \
   doxygen \
+  fmt-devel \
   make \
   gcc \
   gcc-c++ \

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 if (LIBELF_FOUND)
 	add_executable(elfdeps elfdeps.cc)
 	target_link_libraries(elfdeps PRIVATE PkgConfig::LIBELF)
+	target_link_libraries(elfdeps PRIVATE fmt)
 	install(TARGETS elfdeps DESTINATION ${RPM_CONFIGDIR})
 endif()
 

--- a/tools/elfdeps.cc
+++ b/tools/elfdeps.cc
@@ -1,6 +1,6 @@
 #include "system.h"
 
-#include <format>
+#include <fmt/core.h>
 #include <string>
 #include <vector>
 
@@ -105,7 +105,7 @@ static void addSoDep(std::vector<std::string> & deps,
     if (ver.empty() && marker.empty()) {
 	addDep(deps, soname);
     } else {
-	auto dep = std::format("{}({}){}", soname, ver, marker);
+	auto dep = fmt::format("{}({}){}", soname, ver, marker);
 	addDep(deps, dep);
     }
 }


### PR DESCRIPTION
- Replaced std::format with fmt::format due to std::format requiring GCC 13