### PR TITLE
Fix "package X does not verify: (null)" output in some configurations

### DIFF
--- a/lib/transaction.cc
+++ b/lib/transaction.cc
@@ -1296,8 +1296,11 @@ static int verifyPackage(rpmts ts, rpmte p, struct rpmvs_s *vs, int vfylevel)
 	verified |= RPMSIG_DIGEST_TYPE;
     rpmteSetVerified(p, verified);
 
-    if (prc)
+    if (prc) {
+	if (vd.msg == NULL)
+	    vd.msg = xstrdup(_("no verifiable digest or signature available"));
 	rpmteAddProblem(p, RPMPROB_VERIFY, NULL, vd.msg, 0);
+    }
 
     vd.msg = _free(vd.msg);
     headerFree(auxh);

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -227,6 +227,18 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 
 RPMTEST_CHECK([
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	--define "_pkgverify_flags 0xfffff" \
+	--define "__vsflags 0x30300" \
+	--define "_pkgverify_level digest" \
+	/tmp/${pkg}
+],
+[1],
+[],
+[	package hello-2.0-1.x86_64 does not verify: no verifiable digest or signature available
+])
+
+RPMTEST_CHECK([
 runroot --setenv SOURCE_DATE_EPOCH 1234 \
 	rpm -U --ignorearch --ignoreos --nodeps --nodigest --noverify \
 	--define "_pkgverify_level digest" \


### PR DESCRIPTION
Commit 11dc680bdc43f65fedbfb71edb2315b86075a1d4 means that there are configurations where the verify callback never encounters NOTFOUND items so we can't rely on that to generate a message for the user. Add an explicit check and a generic error message for this situation, and a test that triggers the situation.

Related: #3303