### PR TITLE
Honor alternate root in system user/group provides

### DIFF
--- a/lib/depends.cc
+++ b/lib/depends.cc
@@ -21,6 +21,7 @@
 #include "rpmds_internal.hh"
 #include "rpmfi_internal.hh" /* rpmfiles stuff for now */
 #include "misc.hh"
+#include "rpmchroot.hh"
 #include "rpmug.hh"
 
 #include "backend/dbiset.hh"
@@ -1053,6 +1054,9 @@ int rpmtsCheck(rpmts ts)
     if (reqnotfilehash->empty())
 	reqnotfilehash = filedepHashFree(reqnotfilehash);
 
+    /* Enable system provides lookup from the target root */
+    rpmChrootSet(rpmtsRootDir(ts));
+
     /*
      * Look at all of the added packages and make sure their dependencies
      * are satisfied.
@@ -1135,6 +1139,7 @@ int rpmtsCheck(rpmts ts)
     }
     rpmtsiFree(pi);
 
+    rpmChrootSet(NULL);
     if (rdb)
 	rpmdbCtrl(rdb, RPMDB_CTRL_UNLOCK_RO);
 

--- a/lib/rpmchroot.cc
+++ b/lib/rpmchroot.cc
@@ -107,6 +107,12 @@ int rpmChrootOut(void)
     return rc;
 }
 
+const char *rpmChrootPath(void)
+{
+    const char *path = rootState.rootDir;
+    return (path && rstreq(path, "/")) ? NULL : path;
+}
+
 int rpmChrootDone(void)
 {
     return (rootState.chrootDone > 0);

--- a/lib/rpmchroot.hh
+++ b/lib/rpmchroot.hh
@@ -13,6 +13,13 @@ RPM_GNUC_INTERNAL
 int rpmChrootSet(const char *rootDir);
 
 /** \ingroup rpmchroot
+ * Return absolute path to current chroot directory.
+ * return		chroot directory (or NULL if "/" or unset)
+ */
+RPM_GNUC_INTERNAL
+const char *rpmChrootPath(void);
+
+/** \ingroup rpmchroot
  * Enter chroot if necessary.
  * return		-1 on error, 0 on success.
  */

--- a/lib/rpmug.cc
+++ b/lib/rpmug.cc
@@ -10,6 +10,7 @@
 #include <rpm/rpmmacro.h>
 
 #include "misc.hh"
+#include "rpmchroot.hh"
 #include "rpmug.hh"
 #include "debug.h"
 
@@ -30,12 +31,18 @@ static __thread struct rpmug_s *rpmug = NULL;
 static const char *getpath(const char *bn, const char *dfl, char **dest)
 {
     if (*dest == NULL) {
+	const char *root = rpmChrootPath();
 	char *s = rpmExpand("%{_", bn, "_path}", NULL);
 	if (*s == '%' || *s == '\0') {
 	    free(s);
 	    s = xstrdup(dfl);
 	}
-	*dest = s;
+	if (root && !rpmChrootDone()) {
+	    *dest = rpmGetPath(root, s, NULL);
+	    free(s);
+	} else {
+	    *dest = s;
+	}
     }
     return *dest;
 }

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -870,4 +870,17 @@ runroot rpm -V klang-tools
 .....UG..    /usr/bin/klangtool
 ],
 [])
+
+RPMTEST_CHECK([
+mkdir -p $RPMTEST/alt/etc/default
+# Avoid spurious warning about failed mailbox creation
+echo CREATE_MAIL_SPOOL=no > $RPMTEST/alt/etc/default/useradd
+runroot useradd --root /alt plong
+runroot groupadd --root /alt klang
+runroot rpm -U --test --root /alt --noplugins --nosignature \
+	    /build/RPMS/noarch/klang-tools-1.0-1.noarch.rpm
+],
+[0],
+[],
+[])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Commit 3617d160eb6a1a8a95689db5eb5648355ea60c2a missed the --root use case, causing it to only ever look up users and groups on the host, which is of course wrong. This is because rpmtsCheck() (where this dependency check is done) happens well before we enter the target chroot.

Fix that by setting the chroot just before the rpmug calls and adapting those functions to take the chroot path into account when constructing the final passwd/group file paths.

Ideally, we would enter the chroot already in rpmtsCheck() but that would cause --test transactions to require root privileges, which might (and likely would) break some existing use cases out there, so let's leave that consideration for the future (if at all) and just go with the "manual" string concatenation here.

Note that this new logic, much like the existing one, is based on the assumption that the rpmug cache is flushed across chroots. However, this is currently the case only when setting a new chroot, not when entering or leaving one, which will be fixed separately via #4093.

Add a test to cover the --root use case with system provides, too.

Fixes: #4094