### PR TITLE
[WIP] Document format of `elfdeps` output

### DIFF
--- a/docs/man/elfdeps.1.scd
+++ b/docs/man/elfdeps.1.scd
@@ -19,6 +19,9 @@ for use in RPM dependencies. The main interest areas are *DT_SONAME*,
 *DT_NEEDED* fields of the *SHT_DYNAMIC* section, and symbol versioning
 information in the *SHT_GNU_verdef* and *SHT_GNU_verneed* sections.
 
+The generated dendency string is in a form of _soname(version)(elf class
+marker)_.
+
 *elfdeps* is not normally invoked directly, but doing so can be useful for
 troubleshooting dependency generation and developing new dependency
 generators. The installation directory of *elfdeps* can be determined with


### PR DESCRIPTION
This is naive attempt to document the `elfdeps` dependencies, because I don't think the format is documented anywhere. Marking this as a WIP, because I am noob in this area and I don't really know if the terminology used is anything useful. I am also not sure about the formatting 🤷

And just FTR, this PR was triggered by [this](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/37JJ2HCTGF3E5WQUHZ55LK3VZUJ3YPBN/#ZNMHZV3NCN6ODFCB65FT6HQPJXXCSJE5) discussion, where @fweimer suggested provides such as `libc.so.6(_dl_find_object@GLIBC_2.35)(64-bit)` (there were actually additional pair of parenthesis, which was likely mistake). The question is if this could be used as extension. But we can discuss this separately.