### PR TITLE
Add GitLeaks whitelist for our test-suite keys

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+  description = "global allowlist"
+  # Ignore our test keys
+  paths = [
+    '''tests/data/keys/''',
+  ]


### PR DESCRIPTION
Anything in /tests/data/keys/ is intentionally public.