### PR TITLE
Fix delete_key_compat() friend definition

### DIFF
--- a/lib/keystore.cc
+++ b/lib/keystore.cc
@@ -126,7 +126,7 @@ static rpmRC delete_file_store(std::string path)
 }
 
 /* Wrapper for private delete_key() methods that falls back to short keyid */
-static rpmRC rpm::delete_key_compat(auto keystore, rpmtxn txn, rpmPubkey key, auto skip)
+rpmRC rpm::delete_key_compat(auto keystore, rpmtxn txn, rpmPubkey key, auto skip)
 {
     rpmRC rc = RPMRC_NOTFOUND;
     string fp = rpmPubkeyFingerprintAsHex(key);


### PR DESCRIPTION
Commit e360ca338e5215a2015fef6ed843cfefd8463f2e mistakenly defined the function as static while also declaring it as a friend function in the keystore header file. While GCC didn't seem to mind, Clang failed with:

    error: static declaration of 'delete_key_compat' follows non-static
    declaration

And rightfully so. We just didn't notice since most of us build with GCC (including the CI), oops.

Fix by dropping the static keyword. This is fine because access control and visibility is handled by C++ here (since it's a friend function, not a standalone one), and the keystore API isn't public anyway.

Fixes: #4070