### PR TITLE
Unconditionally print lints.

### DIFF
--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -333,11 +333,11 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
     rpmVSFlags oflags = rpmtsVSFlags(ts);
 
     rc = pgpPubKeyLint(pkt, pktlen, &lints);
+    if (lints) {
+      rpmlog(RPMLOG_ERR, "%s\n", lints);
+      free(lints);
+    }
     if (rc != RPMRC_OK) {
-	if (lints) {
-            rpmlog(RPMLOG_ERR, "%s\n", lints);
-	    free(lints);
-	}
 	goto exit;
     }
     if (lints) {


### PR DESCRIPTION
While reviewing https://github.com/rpm-software-management/rpm-sequoia/pull/105 , I called into question a commit that changed `pgpPubKeyLint` to fail more often.  After doing some digging, I discovered that this was probably motivated by an [inadvertent change](00a3170dada2b7053088512c1d18c29801020460) to how rpm uses `pgpPubKeyLint`: instead of always printing the lints, it only prints lints if `pgpPubKeyLint` fails.  This MR reverts that change and I believe makes @Jakuje's proposed change to rpm-sequoia unnecessary.
