### PR TITLE
Implement a separate lock for the keystore

### DIFF
--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -363,30 +363,30 @@ rpmRC rpmtsImportPubkey(rpmts ts, const unsigned char * pkt, size_t pktlen);
 
 /** \ingroup rpmts
  * Import public key packet(s) to transaction keystore.
- * @param txn           transaction handle
+ * @param kxn           keystore handle
  * @param pkt           pgp pubkey packet(s)
  * @param pktlen        pgp pubkey length
  * @return              RPMRC_OK/RPMRC_FAIL
  */
-rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen);
+rpmRC rpmtxnImportPubkey(rpmtxn kxn, const unsigned char * pkt, size_t pktlen);
 
 /** \ingroup rpmts
  * Delete public key from transaction keystore.
- * @param txn           transaction handle
+ * @param kxn           keystore handle
  * @param key		public key
  * @return              RPMRC_OK on success
  * 			RPMRC_NOTFOUND if key not found
  * 			RPMRC_FAIL on other failure
  */
-rpmRC rpmtxnDeletePubkey(rpmtxn txn, rpmPubkey key);
+rpmRC rpmtxnDeletePubkey(rpmtxn kxn, rpmPubkey key);
 
 /** \ingroup rpmts
  * Rebuild key store using current settings and fill it with keys form keyring
- * @param txn		transaction handle
+ * @param kxn		keystore handle
  * @param from		backend to get the keys from
  * @return		RPMRC_OK on success
  */
-rpmRC rpmtxnRebuildKeystore(rpmtxn txn, const char * from);
+rpmRC rpmtxnRebuildKeystore(rpmtxn kxn, const char * from);
 
 /** \ingroup rpmts
  * Retrieve handle for keyring used for this transaction set
@@ -740,6 +740,14 @@ int rpmtsAddRestoreElement(rpmts ts, Header h);
  * @return		0 on success, 1 on error (not installed)
  */
 int rpmtsAddEraseElement(rpmts ts, Header h, int dboffset);
+
+/** \ingroup rpmts
+ * Create a keystore (lock) handle
+ * @param ts		transaction set
+ * @param flags		flags
+ * @return		transaction handle
+ */
+rpmtxn rpmkxnBegin(rpmts ts, rpmtxnFlags flags);
 
 /** \ingroup rpmts
  * Create a transaction (lock) handle

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -1069,55 +1069,57 @@ rpmte rpmtsiNext(rpmtsi tsi, rpmElementTypes types)
     return te;
 }
 
-#define RPMLOCK_PATH LOCALSTATEDIR "/rpm/.rpm.lock"
 static
-void rpmtsLockInit(rpmts ts)
+void rpmtxnLockInit(rpmts ts, const char *path, const char *fallback_path,
+		    const char *name, rpmlock *lockp)
 {
-    static const char * const rpmlock_path_default = "%{?_rpmlock_path}";
-    if (ts && ts->lockPath == NULL) {
-	const char *rootDir = rpmtsRootDir(ts);
-	char *t;
+    if (lockp && *lockp == NULL) {
+	char *t = rpmExpand(path, NULL);
 
+	if (t == NULL || *t == '\0' || *t == '%') {
+	    free(t);
+	    path = t = xstrdup(fallback_path);
+	}
+
+	const char *rootDir = rpmtsRootDir(ts);
 	if (!rootDir || rpmChrootDone())
 	    rootDir = "/";
 
-	t = rpmGenPath(rootDir, rpmlock_path_default, NULL);
-	if (t == NULL || *t == '\0' || *t == '%') {
-	    free(t);
-	    t = xstrdup(RPMLOCK_PATH);
-	}
-	ts->lockPath = xstrdup(t);
-	(void) rpmioMkpath(dirname(t), 0755, getuid(), getgid());
+	char *lockPath = rpmGenPath(rootDir, path, NULL);
+	char *dn = xstrdup(lockPath); /* dirname() modifies */
+	(void) rpmioMkpath(dirname(dn), 0755, getuid(), getgid());
+	free(dn);
+
+	*lockp = rpmlockNew(lockPath, name);
+	free(lockPath);
 	free(t);
     }
-
-    if (ts->lock == NULL)
-	ts->lock = rpmlockNew(ts->lockPath, _("transaction"));
-
 }
 
 static
 void rpmtsLockFree(rpmts ts)
 {
     if (ts) {
-	ts->lockPath = _free(ts->lockPath);
 	ts->lock = rpmlockFree(ts->lock);
     }
 }
 
-rpmtxn rpmtxnBegin(rpmts ts, rpmtxnFlags flags)
+static
+rpmtxn rpmtxnCreate(rpmts ts, rpmtxnFlags flags,
+		    const char *path, const char *fallback_path,
+		    const char *name, rpmlock *lockp)
 {
     rpmtxn txn = NULL;
 
-    if (ts == NULL)
+    if (ts == NULL || lockp == NULL)
 	return NULL;
 
-    rpmtsLockInit(ts);
+    rpmtxnLockInit(ts, path, fallback_path, name, lockp);
 
     int lockmode = (flags & RPMTXN_WRITE) ? RPMLOCK_WRITE : RPMLOCK_READ;
-    if (rpmlockAcquire(ts->lock, lockmode)) {
+    if (rpmlockAcquire(*lockp, lockmode)) {
 	txn = new rpmtxn_s {};
-	txn->lock = ts->lock;
+	txn->lock = *lockp;
 	txn->flags = flags;
 	txn->ts = rpmtsLink(ts);
 	if (txn->flags & RPMTXN_WRITE)
@@ -1125,6 +1127,14 @@ rpmtxn rpmtxnBegin(rpmts ts, rpmtxnFlags flags)
     }
     
     return txn;
+}
+
+#define RPMLOCK_PATH LOCALSTATEDIR "/rpm/.rpm.lock"
+rpmtxn rpmtxnBegin(rpmts ts, rpmtxnFlags flags)
+{
+    static const char * const rpmlock_path_default = "%{?_rpmlock_path}";
+    return rpmtxnCreate(ts, flags, rpmlock_path_default, RPMLOCK_PATH,
+			_("transaction"), &(ts->lock));
 }
 
 rpmtxn rpmtxnEnd(rpmtxn txn)

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -102,13 +102,25 @@ int rpmtsOpenDB(rpmts ts, int dbmode)
     return rc;
 }
 
+/* Ensure keyring lock file exists so regular users can query */
+static void ensureKrlock(rpmts ts)
+{
+    ts->kslock = rpmlockFree(ts->kslock);
+    rpmtxn txn = rpmkxnBegin(ts, RPMTXN_WRITE);
+    if (txn)
+	rpmtxnEnd(txn);
+}
+
 int rpmtsInitDB(rpmts ts, int perms)
 {
     rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
     int rc = -1;
-    if (txn)
-	    rc = rpmdbInit(ts->rootDir, perms);
-    rpmtxnEnd(txn);
+    if (txn) {
+	rc = rpmdbInit(ts->rootDir, perms);
+	if (rc == 0)
+	    ensureKrlock(ts);
+	rpmtxnEnd(txn);
+    }
     return rc;
 }
 
@@ -129,9 +141,6 @@ int rpmtsSetDBMode(rpmts ts, int dbmode)
     return rc;
 }
 
-static
-void rpmtsLockFree(rpmts ts);
-
 int rpmtsRebuildDB(rpmts ts)
 {
     int rc = -1;
@@ -151,13 +160,10 @@ int rpmtsRebuildDB(rpmts ts)
 	    rc = rpmdbRebuild(ts->rootDir, ts, headerCheck, rebuildflags);
 	else
 	    rc = rpmdbRebuild(ts->rootDir, NULL, NULL, rebuildflags);
+	if (rc == 0)
+	    ensureKrlock(ts);
 	rpmtxnEnd(txn);
     }
-    /* Re-create lock file */
-    rpmtsLockFree(ts);
-    txn = rpmtxnBegin(ts, RPMTXN_WRITE);
-    if (txn)
-	rpmtxnEnd(txn);
 
     return rc;
 }
@@ -298,7 +304,7 @@ static void loadKeyring(rpmts ts)
 	RPMVSF_MASK_NOSIGNATURES) {
 	ts->keystore = rpmtsGetKeystore(ts);
 	ts->keyring = rpmKeyringNew();
-	rpmtxn txn = rpmtxnBegin(ts, RPMTXN_READ);
+	rpmtxn txn = rpmkxnBegin(ts, RPMTXN_READ);
 	if (txn) {
 	    ts->keystore->load_keys(txn, ts->keyring);
 	    rpmtxnEnd(txn);
@@ -318,13 +324,26 @@ rpmRC rpmtsImportHeader(rpmtxn txn, Header h, rpmFlags flags)
     return rc;
 }
 
-rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
+static rpmtxn ensureKxn(rpmtxn txn, const char *fname)
+{
+    if (txn && txn->lock == rpmtxnTs(txn)->lock) {
+	/* XXX Make this a warning in 6.1 */
+	rpmlog(RPMLOG_DEBUG,
+	    _("%s: expected a keystore handle, got a transaction handle\n"),
+	    fname);
+	txn = rpmkxnBegin(txn->ts, txn->flags);
+    }
+    return txn;
+}
+
+rpmRC rpmtxnImportPubkey(rpmtxn kxn, const unsigned char * pkt, size_t pktlen)
 {
     rpmRC rc = RPMRC_FAIL;		/* assume failure */
     char *lints = NULL;
     rpmPubkey pubkey = NULL;
     rpmKeyring keyring = NULL;
     int krc;
+    rpmtxn txn = ensureKxn(kxn, __func__);
 
     if (txn == NULL)
 	return rc;
@@ -370,15 +389,18 @@ rpmRC rpmtxnImportPubkey(rpmtxn txn, const unsigned char * pkt, size_t pktlen)
 
 exit:
     /* Clean up. */
+    if (txn != kxn)
+	rpmtxnEnd(txn);
     rpmPubkeyFree(pubkey);
 
     rpmKeyringFree(keyring);
     return rc;
 }
 
-rpmRC rpmtxnDeletePubkey(rpmtxn txn, rpmPubkey key)
+rpmRC rpmtxnDeletePubkey(rpmtxn kxn, rpmPubkey key)
 {
     rpmRC rc = RPMRC_FAIL;
+    rpmtxn txn = ensureKxn(kxn, __func__);
 
     if (txn) {
 	/* force keyring load */
@@ -396,6 +418,8 @@ rpmRC rpmtxnDeletePubkey(rpmtxn txn, rpmPubkey key)
 	}
 	rc = RPMRC_OK;
 	rpmKeyringFree(keyring);
+	if (kxn != txn)
+	    rpmtxnEnd(txn);
     }
     return rc;
 }
@@ -403,7 +427,7 @@ rpmRC rpmtxnDeletePubkey(rpmtxn txn, rpmPubkey key)
 rpmRC rpmtsImportPubkey(const rpmts ts, const unsigned char * pkt, size_t pktlen)
 {
     rpmRC rc = RPMRC_FAIL;
-    rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
+    rpmtxn txn = rpmkxnBegin(ts, RPMTXN_WRITE);
     if (txn) {
 	rc = rpmtxnImportPubkey(txn, pkt, pktlen);
 	rpmtxnEnd(txn);
@@ -411,9 +435,13 @@ rpmRC rpmtsImportPubkey(const rpmts ts, const unsigned char * pkt, size_t pktlen
     return rc;
 }
 
-rpmRC rpmtxnRebuildKeystore(rpmtxn txn, const char * from)
+rpmRC rpmtxnRebuildKeystore(rpmtxn kxn, const char * from)
 {
-    rpmts ts = rpmtxnTs(txn);
+    rpmtxn txn = ensureKxn(kxn, __func__);
+    if (txn == NULL)
+	return RPMRC_FAIL;
+
+    rpmts ts = rpmtxnTs(kxn);
     rpmRC rc = RPMRC_OK;
     rpmKeyring keyring = rpmtsGetKeyring(ts, 1);
     rpmKeyringIterator iter = NULL;
@@ -443,6 +471,8 @@ rpmRC rpmtxnRebuildKeystore(rpmtxn txn, const char * from)
     rpmKeyringIteratorFree(iter);
 
  exit:
+    if (kxn != txn)
+	rpmtxnEnd(txn);
 
     rpmKeyringFree(keyring);
     return rc;
@@ -596,7 +626,8 @@ rpmts rpmtsFree(rpmts ts)
 	ts->scriptFd = NULL;
     }
     ts->rootDir = _free(ts->rootDir);
-    rpmtsLockFree(ts);
+    ts->lock = rpmlockFree(ts->lock);
+    ts->kslock = rpmlockFree(ts->kslock);
 
     ts->keyring = rpmKeyringFree(ts->keyring);
     ts->netsharedPaths = argvFree(ts->netsharedPaths);
@@ -1097,14 +1128,6 @@ void rpmtxnLockInit(rpmts ts, const char *path, const char *fallback_path,
 }
 
 static
-void rpmtsLockFree(rpmts ts)
-{
-    if (ts) {
-	ts->lock = rpmlockFree(ts->lock);
-    }
-}
-
-static
 rpmtxn rpmtxnCreate(rpmts ts, rpmtxnFlags flags,
 		    const char *path, const char *fallback_path,
 		    const char *name, rpmlock *lockp)
@@ -1135,6 +1158,14 @@ rpmtxn rpmtxnBegin(rpmts ts, rpmtxnFlags flags)
     static const char * const rpmlock_path_default = "%{?_rpmlock_path}";
     return rpmtxnCreate(ts, flags, rpmlock_path_default, RPMLOCK_PATH,
 			_("transaction"), &(ts->lock));
+}
+
+#define KSLOCK_PATH LOCALSTATEDIR "/rpm/.keyring.lock"
+rpmtxn rpmkxnBegin(rpmts ts, rpmtxnFlags flags)
+{
+    static const char * const kslock_path_default = "%{?_keyring_lockpath}";
+    return rpmtxnCreate(ts, flags, kslock_path_default, KSLOCK_PATH,
+			_("keyring"), &(ts->kslock));
 }
 
 rpmtxn rpmtxnEnd(rpmtxn txn)

--- a/lib/rpmts_internal.hh
+++ b/lib/rpmts_internal.hh
@@ -73,7 +73,6 @@ struct rpmts_s {
     tsMembers members;		/*!< Transaction set member info (order etc) */
 
     char * rootDir;		/*!< Path to top of install tree. */
-    char * lockPath;		/*!< Transaction lock path */
     rpmlock lock;		/*!< Transaction lock file */
     FD_t scriptFd;		/*!< Scriptlet stdout/stderr. */
     rpm_tid_t tid;		/*!< Transaction id. */

--- a/lib/rpmts_internal.hh
+++ b/lib/rpmts_internal.hh
@@ -85,6 +85,7 @@ struct rpmts_s {
     int vfylevel;		/*!< Package verification level */
     rpmKeyring keyring;		/*!< Keyring in use. */
     rpm::keystore *keystore;	/*! <Keystore in use. */
+    rpmlock kslock;		/*! <Keystore lock. */
 
     ARGV_t netsharedPaths;	/*!< From %{_netsharedpath} */
     ARGV_t installLangs;	/*!< From %{_install_langs} */

--- a/lib/transaction.cc
+++ b/lib/transaction.cc
@@ -1785,6 +1785,7 @@ int rpmtsRun(rpmts ts, rpmps okProbs, rpmprobFilterFlags ignoreSet)
     int nfailed = -1;
     tsMembers tsmem = rpmtsMembers(ts);
     rpmtxn txn = NULL;
+    rpmtxn kxn = NULL;
     rpmps tsprobs = NULL;
     int TsmPreDone = 0; /* TsmPre hook hasn't been called */
     int nelem = rpmtsNElements(ts);
@@ -1803,9 +1804,13 @@ int rpmtsRun(rpmts ts, rpmps okProbs, rpmprobFilterFlags ignoreSet)
 	goto exit;
     }
 
-    /* If we are in test mode, then there's no need for transaction lock. */
+    /* If we are in test mode, then there's no need for locks. */
     if (!(rpmtsFlags(ts) & RPMTRANS_FLAG_TEST)) {
 	if (!(txn = rpmtxnBegin(ts, RPMTXN_WRITE))) {
+	    goto exit;
+	}
+	/* Take a read-lock on the keyring to prevent imports from scripts */
+	if (!(kxn = rpmkxnBegin(ts, RPMTXN_READ))) {
 	    goto exit;
 	}
     }
@@ -1913,6 +1918,7 @@ exit:
     (void) umask(oldmask);
     (void) rpmtsFinish(ts);
     rpmpsFree(tsprobs);
+    rpmtxnEnd(kxn);
     rpmtxnEnd(txn);
     /* Restore SIGPIPE *after* unblocking signals in rpmtxnEnd() */
     sigaction(SIGPIPE, &oact, NULL);

--- a/macros.in
+++ b/macros.in
@@ -131,6 +131,8 @@
 
 %_keyringpath		%{_dbpath}/pubkeys/
 
+%_keyring_lockpath	%{_dbpath}/.keyring.lock
+
 # Location of passwd(5) and group(5), as : separated list
 # Uncomment to disable NSS lookups
 #%_passwd_path		/etc/passwd

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,8 @@ foreach(at ${TESTSUITE_AT})
 	FILE(APPEND ${CMAKE_CURRENT_BINARY_DIR}/rpmtests.at "m4_include([${at}])\n")
 endforeach()
 
-set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint readpkgnullts rpmdig importkey)
+set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint readpkgnullts rpmdig
+	      importkey oldtxn)
 foreach(prg ${TESTPROGS})
 	add_executable(${prg} EXCLUDE_FROM_ALL ${prg}.c)
 	target_link_libraries(${prg} PRIVATE librpm)

--- a/tests/data/SPECS/selfimport.spec
+++ b/tests/data/SPECS/selfimport.spec
@@ -1,0 +1,20 @@
+Name: selfimport
+Version: 1
+Release: 1
+License: Public domain
+Summary: Testing keyring import from transaction
+BuildArch: noarch
+
+%description
+
+%pretrans
+echo PRETRANS
+rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub; echo $?
+exit 0
+
+%posttrans
+echo POSTTRANS
+rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub; echo $?
+exit 0
+
+%files

--- a/tests/data/SPECS/selfinst.spec
+++ b/tests/data/SPECS/selfinst.spec
@@ -1,0 +1,20 @@
+Name: selfinst
+Version: 1
+Release: 1
+License: Public domain
+Summary: Testing install from transaction
+BuildArch: noarch
+
+%description
+
+%pretrans
+echo PRETRANS
+rpm -Uv /build/RPMS/noarch/selfinst-1-1.noarch.rpm
+echo $?
+
+%posttrans
+echo POSTTRANS
+rpm -Uv /build/RPMS/noarch/selfinst-1-1.noarch.rpm
+echo $?
+
+%files

--- a/tests/data/SPECS/selfkeys.spec
+++ b/tests/data/SPECS/selfkeys.spec
@@ -1,0 +1,20 @@
+Name: selfkeys
+Version: 1
+Release: 1
+License: Public domain
+Summary: Testing keyring listing from transaction
+BuildArch: noarch
+
+%description
+
+%pretrans
+echo PRETRANS
+rpmkeys -l | wc -l
+exit 0
+
+%posttrans
+echo POSTTRANS
+rpmkeys -l | wc -l
+exit 0
+
+%files

--- a/tests/data/SPECS/selfquery.spec
+++ b/tests/data/SPECS/selfquery.spec
@@ -1,0 +1,20 @@
+Name: selfquery
+Version: 1
+Release: 1
+License: Public domain
+Summary: Testing query from transaction
+BuildArch: noarch
+
+%description
+
+%pretrans
+echo PRETRANS
+rpm -q %{name}
+exit 0
+
+%posttrans
+echo POSTTRANS
+rpm -q %{name}
+exit 0
+
+%files

--- a/tests/data/macros.testenv
+++ b/tests/data/macros.testenv
@@ -5,3 +5,4 @@
 %_dbpath /var/lib/rpm-testsuite
 %_keyring openpgp
 %_keyringpath /var/lib/rpm-keyring
+%_install_script_path /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin

--- a/tests/oldtxn.c
+++ b/tests/oldtxn.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <rpm/rpmlib.h>
+#include <rpm/rpmlog.h>
+#include <rpm/rpmts.h>
+
+int main(int argc, char *argv[])
+{
+    int rc = EXIT_FAILURE;
+    if (rpmReadConfigFiles(NULL, NULL) == 0) {
+	rpmts ts = rpmtsCreate();
+	/* XXX it's 2026 and this is still needed :facepalm: */
+	rpmtsSetRootDir(ts, NULL);
+	rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
+
+	if (txn) {
+	    rpmSetVerbosity(RPMLOG_DEBUG);
+	    rc = rpmtxnRebuildKeystore(txn, NULL);
+	    rpmSetVerbosity(RPMLOG_NOTICE);
+	    rpmtxnEnd(txn);
+	}
+	rpmtsFree(ts);
+    }
+
+    return rc;
+}

--- a/tests/rpmapi.at
+++ b/tests/rpmapi.at
@@ -12,6 +12,24 @@ readpkgnullts /data/RPMS/hello-2.0-1.x86_64-signed.rpm
 ])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([keystore API with wrong lock])
+AT_KEYWORDS([api])
+RPMTEST_CHECK([
+runroot oldtxn
+],
+[0],
+[],
+[stderr])
+
+RPMTEST_CHECK([
+grep rpmtxnRebuildKeystore stderr
+],
+[0],
+[D: rpmtxnRebuildKeystore: expected a keystore handle, got a transaction handle
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([rpmtsImportPubkey()])
 AT_KEYWORDS([api signature import])
 RPMTEST_CHECK([
@@ -44,5 +62,4 @@ dnl XXX For desired behavior, rpm-sequoia should return 3 (NOTTRUSTED) here
 [error: Certificate 7F1C21F95F65BBE8:
   Policy rejects 7F1C21F95F65BBE8: Policy rejected asymmetric algorithm
 ])
-
 RPMTEST_CLEANUP

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -604,6 +604,7 @@ runroot rpm -ql hello.i386 hello.ppc64
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmdb --rebuilddb])
+RPMTEST_USER
 AT_KEYWORDS([rpmdb])
 RPMDB_RESET
 
@@ -616,7 +617,7 @@ runroot rpm -U --noscripts --nodeps --ignorearch --noverify --nosignature \
 [])
 
 RPMTEST_CHECK([
-runroot rpm -qa --qf "%{nevra} %{dbinstance}\n"
+runroot_user rpm -qa --qf "%{nevra} %{dbinstance}\n"
 ],
 [0],
 [hello-1.0-1.i386 1
@@ -632,7 +633,7 @@ runroot rpm -U --noscripts --nodeps --ignorearch --nosignature \
 [])
 
 RPMTEST_CHECK([
-runroot rpm -qa --qf "%{nevra} %{dbinstance}\n"
+runroot_user rpm -qa --qf "%{nevra} %{dbinstance}\n"
 ],
 [0],
 [hello-2.0-1.i686 2
@@ -647,14 +648,10 @@ runroot rpmdb --rebuilddb
 [])
 
 RPMTEST_CHECK([
-runroot ls `rpm -E "%{_dbpath}/.rpm.lock"`
-runroot rpm -qa --qf "%{nevra} %{dbinstance}\n"
-runroot ls `rpm -E "%{_dbpath}/.rpm.lock"`
+runroot_user rpm -qa --qf "%{nevra} %{dbinstance}\n"
 ],
 [],
-[/var/lib/rpm-testsuite/.rpm.lock
-hello-2.0-1.i686 1
-/var/lib/rpm-testsuite/.rpm.lock
+[hello-2.0-1.i686 1
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -662,14 +662,16 @@ RPMTEST_SETUP_RW([rpmdb --rebuilddb and verify empty database])
 AT_KEYWORDS([rpmdb])
 RPMTEST_CHECK([
 RPMDB_RESET
+runroot rpm -E "%{exists:%{_rpmlock_path}} %{exists:%{_keyring_lockpath}}"
 runroot rpmdb --rebuilddb
-runroot ls `rpm -E "%{_dbpath}/.rpm.lock"`
+runroot rpm -E "%{exists:%{_rpmlock_path}} %{exists:%{_keyring_lockpath}}"
 runroot rpmdb --verifydb
-runroot ls `rpm -E "%{_dbpath}/.rpm.lock"`
+runroot rpm -E "%{exists:%{_rpmlock_path}} %{exists:%{_keyring_lockpath}}"
 ],
 [0],
-[/var/lib/rpm-testsuite/.rpm.lock
-/var/lib/rpm-testsuite/.rpm.lock
+[1 1
+0 1
+1 1
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -605,24 +605,54 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmdb --rebuilddb])
 AT_KEYWORDS([rpmdb])
-RPMTEST_CHECK([
 RPMDB_RESET
 
+RPMTEST_CHECK([
 runroot rpm -U --noscripts --nodeps --ignorearch --noverify --nosignature \
   /data/RPMS/hello-1.0-1.i386.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
 runroot rpm -qa --qf "%{nevra} %{dbinstance}\n"
+],
+[0],
+[hello-1.0-1.i386 1
+],
+[])
+
+RPMTEST_CHECK([
 runroot rpm -U --noscripts --nodeps --ignorearch --nosignature \
   /data/RPMS/hello-2.0-1.i686.rpm
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
 runroot rpm -qa --qf "%{nevra} %{dbinstance}\n"
+],
+[0],
+[hello-2.0-1.i686 2
+],
+[])
+
+RPMTEST_CHECK([
 runroot rpmdb --rebuilddb
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
 runroot ls `rpm -E "%{_dbpath}/.rpm.lock"`
 runroot rpm -qa --qf "%{nevra} %{dbinstance}\n"
 runroot ls `rpm -E "%{_dbpath}/.rpm.lock"`
 ],
 [],
-[hello-1.0-1.i386 1
-hello-2.0-1.i686 2
-/var/lib/rpm-testsuite/.rpm.lock
+[/var/lib/rpm-testsuite/.rpm.lock
 hello-2.0-1.i686 1
 /var/lib/rpm-testsuite/.rpm.lock
 ],

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -2104,13 +2104,11 @@ runroot rpm -U /build/RPMS/noarch/selfkeys-1-1.noarch.rpm
 ],
 [0],
 [PRETRANS
-0
+1
 POSTTRANS
-0
+1
 ],
-[error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
-error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
-])
+[])
 
 RPMTEST_CHECK([
 runroot rpm -U /build/RPMS/noarch/selfimport-1-1.noarch.rpm
@@ -2121,9 +2119,9 @@ runroot rpm -U /build/RPMS/noarch/selfimport-1-1.noarch.rpm
 POSTTRANS
 1
 ],
-[error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
+[error: can't create keyring lock on /var/lib/rpm-testsuite/.keyring.lock (Resource temporarily unavailable)
 error: /data/keys/rpm.org-rsa-2048-test.pub: key 1 import failed.
-error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
+error: can't create keyring lock on /var/lib/rpm-testsuite/.keyring.lock (Resource temporarily unavailable)
 error: /data/keys/rpm.org-rsa-2048-test.pub: key 1 import failed.
 ])
 
@@ -2136,9 +2134,7 @@ package selfquery is not installed
 POSTTRANS
 selfquery-1-1.noarch
 ],
-[error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
-error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
-])
+[])
 
 RPMTEST_CHECK([
 runroot rpm -U /build/RPMS/noarch/selfinst-1-1.noarch.rpm

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -2083,3 +2083,71 @@ runroot rpm -U --nodb --test --ignorearch --ignoreos --nodeps --nosignature \
 [	installing package hello-2.0-1.x86_64 needs 36KB more space on the / filesystem
 ])
 RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([run rpm from scriptlet])
+AT_KEYWORDS([install query script])
+RPMTEST_CHECK([
+runroot rpmbuild -bb \
+	/data/SPECS/fakeshell.spec \
+	/data/SPECS/selfquery.spec \
+	/data/SPECS/selfinst.spec \
+	/data/SPECS/selfkeys.spec \
+	/data/SPECS/selfimport.spec
+runroot rpm -U /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/selfkeys-1-1.noarch.rpm
+],
+[0],
+[PRETRANS
+0
+POSTTRANS
+0
+],
+[error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
+error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
+])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/selfimport-1-1.noarch.rpm
+],
+[0],
+[PRETRANS
+1
+POSTTRANS
+1
+],
+[error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
+error: /data/keys/rpm.org-rsa-2048-test.pub: key 1 import failed.
+error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
+error: /data/keys/rpm.org-rsa-2048-test.pub: key 1 import failed.
+])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/selfquery-1-1.noarch.rpm
+],
+[0],
+[PRETRANS
+package selfquery is not installed
+POSTTRANS
+selfquery-1-1.noarch
+],
+[error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
+error: can't create transaction lock on /var/lib/rpm-testsuite/.rpm.lock (Resource temporarily unavailable)
+])
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/selfinst-1-1.noarch.rpm
+],
+[0],
+[PRETRANS
+1
+POSTTRANS
+1
+],
+[ignore])
+RPMTEST_CLEANUP

--- a/tools/rpmkeys.cc
+++ b/tools/rpmkeys.cc
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
     }
     case MODE_DELKEY:
     {
-	rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
+	rpmtxn txn = rpmkxnBegin(ts, RPMTXN_WRITE);
 	if (txn) {
 	    ec = matchingKeys(ts, args, deleteKey, txn);
 	    rpmtxnEnd(txn);
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
     case MODE_REBUILD:
     {
 
-	rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
+	rpmtxn txn = rpmkxnBegin(ts, RPMTXN_WRITE);
 	if (txn) {
 	    ec = rpmtxnRebuildKeystore(txn, from);
 	    rpmtxnEnd(txn);


### PR DESCRIPTION
https://github.com/rpm-software-management/rpm/commit/79b26f1ac5c4abe3a2ebbb8679f023cf3a2dd412 introduced transaction locking on the keyring, mostly considered a "for now" solution, but the fact it blocks rpm queries while a transaction is in progress is too jarring a change.

More details in the commit notes but in short, this introduces another lock for the keystore, using the same machinery as the transaction lock. This much locking is more or less necessary to ensure keyring coherence, but these can proceed independently and keyring writes don't take minutes like package transactions can.

What bothers me about this solution is that it's kind of an API/ABI break in a place where we don't want one, but then I fail to see a way to address this without that breakage. In this form, it's also silent breakage. It should probably error out, or at least warn if the wrong kind of txn handle is handed to a function.  So this seems incomplete in this form, but then I seem to be kinda stuck on this, so hoping some external feedback on it.

Fixes: #4110