### PR TITLE
rpmsign: enable signing files with PKCS11 tokens

### DIFF
--- a/docs/man/rpmsign.1.scd
+++ b/docs/man/rpmsign.1.scd
@@ -47,7 +47,12 @@ See *rpm-common*(8) for the options common to all *rpm* executables.
 	Used with *--signverity*, use file signing certificate _CERT_.
 
 *--fskpath* _KEY_
-	Used with *--signfiles*, use file signing key _KEY_.
+	Used with *--signfiles*, use file signing key _KEY_. This can be
+	used with a PKCS #11 URI as long as OpenSSL has been configured to
+	load the pkcs11 provider. For PKCS #11 keys, the IMA library cannot
+	calculate the IMA key ID so you must provide it; this is done via the
+	*%\_file_signing_key_id* macro. Typically, the key ID is set to the
+	Subject Key Identifier (SKID) of the associated X509 certificate.
 
 *--key-id* _KEYID_
 	Use key _KEYID_ for signing. Overrides *%\_openpgp_sign_id*

--- a/sign/rpmgensig.cc
+++ b/sign/rpmgensig.cc
@@ -549,13 +549,14 @@ static rpmRC includeFileSignatures(Header *sigp, Header *hdrp)
     rpmRC rc;
     char *key = rpmExpand("%{?_file_signing_key}", NULL);
     char *keypass = rpmExpand("%{?_file_signing_key_password}", NULL);
+    uint32_t keyid = rpmExpandNumeric("%{?_file_signing_key_id}");
 
     if (rstreq(keypass, "")) {
 	free(keypass);
 	keypass = NULL;
     }
 
-    rc = rpmSignFiles(*sigp, *hdrp, key, keypass);
+    rc = rpmSignFiles(*sigp, *hdrp, key, keypass, keyid);
 
     free(keypass);
     free(key);

--- a/sign/rpmsignfiles.cc
+++ b/sign/rpmsignfiles.cc
@@ -38,7 +38,7 @@ static const char *hash_algo_name[] = {
 #define ARRAY_SIZE(a)  (sizeof(a) / sizeof(a[0]))
 
 static char *signFile(const char *algo, const uint8_t *fdigest, int diglen,
-const char *key, char *keypass, uint32_t *siglenp)
+const char *key, char *keypass, uint32_t keyid, uint32_t *siglenp)
 {
     char *fsignature;
     std::vector<unsigned char> zeros(diglen, 0);
@@ -55,10 +55,24 @@ const char *key, char *keypass, uint32_t *siglenp)
 
     /* calculate file signature */
 #if HAVE_IMAEVM_SIGNHASH
+    /* imaevm_signhash doesn't document its API, so this relies on knowledge of the internal
+     * implementation.
+     *
+     * The library only uses the type field if the key starts with pkcs11, so passing the provider
+     * type is identical to passing the none type unless the key is accessible via the
+     * pkcs11-provider.
+     *
+     * What's more, the library does not ever use the provider passed in via the access_info
+     * structure. Instead, it uses OSSL_STORE_open_ex() with the global context with the
+     * "provider=pkcs11" propery query. As a result, there's no reason to explicitly load the
+     * provider here; users must configure openssl to load the provider.
+     */
     imaevm_ossl_access access_info = {
-	.type = IMAEVM_OSSL_ACCESS_TYPE_NONE,
+	.type = IMAEVM_OSSL_ACCESS_TYPE_PROVIDER,
     };
-    siglen = imaevm_signhash(algo, fdigest, diglen, key, keypass, signature+1, 0, &access_info, 0);
+    access_info.u.provider = NULL;
+
+    siglen = imaevm_signhash(algo, fdigest, diglen, key, keypass, signature+1, 0, &access_info, keyid);
 
 #else
     siglen = sign_hash(algo, fdigest, diglen, key, keypass, signature+1);
@@ -75,7 +89,7 @@ const char *key, char *keypass, uint32_t *siglenp)
     return fsignature;
 }
 
-rpmRC rpmSignFiles(Header sigh, Header h, const char *key, char *keypass)
+rpmRC rpmSignFiles(Header sigh, Header h, const char *key, char *keypass, uint32_t keyid)
 {
     struct rpmtd_s td;
     unsigned algo;
@@ -113,7 +127,7 @@ rpmRC rpmSignFiles(Header sigh, Header h, const char *key, char *keypass)
     while (rpmfiNext(fi) >= 0) {
 	uint32_t slen = 0;
 	digest = rpmfiFDigest(fi, NULL, NULL);
-	signature = signFile(algoname, digest, diglen, key, keypass, &slen);
+	signature = signFile(algoname, digest, diglen, key, keypass, keyid, &slen);
 	if (!signature) {
 	    rpmlog(RPMLOG_ERR, _("signFile failed\n"));
 	    goto exit;

--- a/sign/rpmsignfiles.hh
+++ b/sign/rpmsignfiles.hh
@@ -21,9 +21,11 @@ extern "C" {
  * @param h		package header
  * @param key		signing key
  * @param keypass	signing key password
+ * @param keyid 	the key ID IMA embeds in the signature; typically the
+ *                      Subject Key ID from an x509 certificate.
  * @return		RPMRC_OK on success
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmSignFiles(Header sigh, Header h, const char *key, char *keypass);
+rpmRC rpmSignFiles(Header sigh, Header h, const char *key, char *keypass, uint32_t keyid);
 
 #endif /* H_RPMSIGNFILES */

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -32,6 +32,9 @@ RUN dnf -y install \
   rpm-sequoia-devel \
   file-devel \
   popt-devel \
+  kryoptic \
+  pkcs11-provider \
+  opensc \
   libarchive-devel \
   sqlite-devel \
   libselinux-devel \

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -50,6 +50,11 @@ if [ "@WITH_IMAEVM@" == "ON" ]; then
 else
     IMA_DISABLED=true;
 fi
+if [ "@ENABLE_ASAN@" == "ON" ]; then
+    ASAN_ENABLED=true;
+else
+    ASAN_ENABLED=false;
+fi
 if mknod foodev c 123 123 2>/dev/null; then
    MKNOD_DISABLED=false
    rm -f foodev

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2565,6 +2565,65 @@ hello-1.0.tar.gz:(none)
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([ima file signatures with pkcs11 token])
+AT_KEYWORDS([rpmsign ima signature pkcs11])
+RPMTEST_SKIP_IF([$IMA_DISABLED])
+RPMTEST_SKIP_IF([$ASAN_ENABLED])
+echo "%_openpgp_sign gpg" >> $RPMTEST/root/.config/rpm/macros
+gpg2 --import /data/keys/rpm.org-rsa-2048-test.secret
+
+RPMTEST_CHECK([[
+# Set up a NIST P-256 key in a soft token for signing
+pkcs11_mod=/usr/lib64/pkcs11/libkryoptic_pkcs11.so
+token_label="kryoptic"
+token_pin="12345678"
+token_dir=$(mktemp -d)
+export KRYOPTIC_CONF="${token_dir}/token.conf"
+cat > ${KRYOPTIC_CONF} << KRYOPTIC_EOF
+[[slots]]
+slot = 1
+dbtype = "sqlite"
+dbargs = "${token_dir}/token.sql"
+KRYOPTIC_EOF
+pkcs11-tool --module "${pkcs11_mod}" --init-token \
+  --label "${token_label}" --so-pin "${token_pin}"
+pkcs11-tool --module "${pkcs11_mod}" --init-pin \
+  --login --so-pin "${token_pin}" --pin "${token_pin}"
+pkcs11-tool --module "${pkcs11_mod}" --login \
+  --pin "${token_pin}" --keypairgen --key-type EC:prime256v1 \
+  --id 01 --label "ima-signing"
+
+# Configure OpenSSL to load the pkcs11-provider
+export OPENSSL_CONF=/tmp/ossl_config
+cat > ${OPENSSL_CONF} << OSSL_EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = providers
+
+[providers]
+default = default_provider
+pkcs11 = pkcs11_provider
+
+[default_provider]
+activate = 1
+
+[pkcs11_provider]
+module = /usr/lib64/ossl-modules/pkcs11.so
+activate = 1
+OSSL_EOF
+
+cp /data/RPMS/hello-2.0-1.x86_64.rpm /tmp/
+rpmsign --addsign --key-id 4344591E1964C5FC --signfiles \
+  --define='_file_signing_key_id 42' \
+  --fskpath="pkcs11:token=${token_label};id=%01;type=private?pin-value=${token_pin}" \
+  /tmp/hello-2.0-1.x86_64.rpm
+]],
+[0],
+[ignore],
+[ignore])
+RPMTEST_CLEANUP
+
 # Test that installing an ima signed package works.
 # The installation should succeed in all cases, but whether setting the
 # IMA signature succeeds depends on container privileges - in rootless


### PR DESCRIPTION
Attempt to load the PKCS11 provider for OpenSSL and use it if it is available. This allows users of rpmsign to pass in a pkcs11 URI as the file signing key. For example:

rpmsign --addsign --rpmv6 --signfiles \
  --fskpath "pkcs11:token=test-codesigning-key;id=%01;type=private" \
  cloud-init-25.2-10.fc43.noarch.rpm

When this is provided, a non-zero keyid is required, so there's also a _file_signing_key_id macro to provide that. ima-evm-utils has a flag to extract the Subject Key ID from an x509 certificate to use as the keyid so that's a direction we could go as well, or we can leave that as an exercise to the reader.

Fixes: #4124

I've marked this as a draft because I'd like some early feedback before I go write tests to setup a software pkcs11 token and all that. Should there be a CLI argument for the keyid? Does this need to support OpenSSL 1? The INSTALL file indicates openssl-1.0.2+ is supported, but it feels a bit weird to add support for that since engines aren't even available in many current RPM-based distributions.