### PR TITLE
Do not include legacy signatures in RPMTAG_OPENPGP "ext" handler

### DIFF
--- a/lib/tagexts.cc
+++ b/lib/tagexts.cc
@@ -1073,8 +1073,6 @@ static int openpgpTag(Header h, rpmtd td, headerGetFlags hgflags)
     ARGV_t sigs = NULL;
     trySigTag(h, RPMTAG_RSAHEADER, &sigs);
     trySigTag(h, RPMTAG_DSAHEADER, &sigs);
-    trySigTag(h, RPMTAG_SIGPGP, &sigs);
-    trySigTag(h, RPMTAG_SIGGPG, &sigs);
 
     if (sigs) {
 	td->data = sigs;

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -400,18 +400,6 @@ rpm \
 [RSA/SHA256, Thu Apr  6 13:02:33 2017, Key ID 4344591e1964c5fc],
 [warning: /data/RPMS/hello-2.0-1.x86_64-signed.rpm: Header OpenPGP V4 RSA/SHA256 signature, key ID 4344591e1964c5fc: NOKEY
 ])
-
-RPMTEST_CHECK([[
-runroot rpm \
-    --nosignature \
-    --qf "[%{openpgp:pgpsig}\n]" \
-    -qp /data/RPMS/hello-2.0-1.x86_64-signed.rpm
-]],
-[0],
-[RSA/SHA256, Thu Apr  6 13:02:33 2017, Key ID 4344591e1964c5fc
-RSA/SHA256, Thu Apr  6 13:02:32 2017, Key ID 4344591e1964c5fc
-],
-[])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP([hashalgo extension])
@@ -1399,32 +1387,3 @@ rpmlib(PayloadIsZstd) <= 5.4.18-1
 ],
 [])
 RPMTEST_CLEANUP
-
-RPMTEST_SETUP([info query output])
-AT_KEYWORDS([query signature])
-RPMTEST_CHECK([
-runroot rpm -qi --nosignature /data/RPMS/hello-2.0-1.x86_64-signed.rpm
-],
-[0],
-[[Name         : hello
-Version      : 2.0
-Release      : 1
-Architecture : x86_64
-Install Date : (not installed)
-Group        : Testing
-Size         : 7243
-License      : GPL
-Signature    :
-              RSA/SHA256, Thu Apr  6 13:02:33 2017, Key ID 4344591e1964c5fc
-              RSA/SHA256, Thu Apr  6 13:02:32 2017, Key ID 4344591e1964c5fc
-Source RPM   : hello-2.0-1.src.rpm
-Build Date   : Sat Nov 22 12:00:00 2008
-Build Host   : localhost
-Relocations  : /usr
-Summary      : hello -- hello, world rpm
-Description  :
-Simple rpm demonstration.
-]],
-[])
-RPMTEST_CLEANUP
-


### PR DESCRIPTION
closes #4137