### PR TITLE
docs: fix SHA256 tag value from 272 to 273

### DIFF
--- a/docs/manual/format_v4.md
+++ b/docs/manual/format_v4.md
@@ -53,7 +53,7 @@ RSA                 |  268  | BIN
 SHA1                |  269  | STRING
 LONGSIZE            |  270  | INT_64
 LONGARCHIVESIZE     |  271  | INT_64
-SHA256              |  272  | STRING
+SHA256              |  273  | STRING
 FILESIGNATURES      |  274  | STRING_ARRAY
 FILESIGNATURELENGTH |  275  | INT_32
 VERITYSIGNATURES    |  276  | STRING_ARRAY

--- a/docs/manual/format_v6.md
+++ b/docs/manual/format_v6.md
@@ -52,7 +52,7 @@ Name        	    | Tag   | Header Type
 HEADERSIGNATURES    |   62  | BIN
 DSA (legacy)        |  267  | BIN
 RSA (legacy)        |  268  | BIN
-SHA256              |  272  | STRING
+SHA256              |  273  | STRING
 FILESIGNATURES      |  274  | STRING_ARRAY
 VERITYSIGNATURES    |  276  | STRING_ARRAY
 VERITYSIGNATUREALGO |  277  | INT_32


### PR DESCRIPTION
The SHA256 signature tag value was incorrectly listed as 272 in both `format_v4.md` and `format_v6.md`. The actual value is 273 (`RPMTAG_SIG_BASE + 17 = 256 + 17 = 273`), which is consistent with the source code and `tags.md`.

Fixes: #4136