### PR TITLE
Move rpmuncompress to the standard binary directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ function(makemacros)
 	set(infodir "\${prefix}/${CMAKE_INSTALL_INFODIR}")
 	set(mandir "\${prefix}/${CMAKE_INSTALL_MANDIR}")
 	set(rundir /run)
+	set(bindir_full ${CMAKE_INSTALL_FULL_BINDIR})
 
 	pkg_get_variable(sysusersdir systemd sysusersdir)
 	if (NOT sysusersdir)

--- a/docs/man/rpm-macros.7.scd
+++ b/docs/man/rpm-macros.7.scd
@@ -558,6 +558,9 @@ the preceding *%*-character.
 	Expand to a command for outputting argument _PATH_ to standard output,
 	uncompressing as needed.
 
+	Note: for unpackaging sources in *rpm-spec*(5) files, consider
+	calling *rpmuncompress*(1) directly instead.
+
 	Example:
 	```
 	%{uncompress /my/source.tar.gz}

--- a/docs/man/rpmuncompress.1.scd
+++ b/docs/man/rpmuncompress.1.scd
@@ -15,8 +15,6 @@ and uncompressed files, and extracting archives.
 It's normally invoked internally by *rpmbuild*(1) to handle *%setup*
 and *%patch* related tasks in spec files, but can be useful manually
 invoked as well.
-The installation directory of *rpmuncompress* can be determined with
-*rpm -E "%{\_rpmconfigdir}"*.
 
 # ARGUMENTS
 _FILE_

--- a/macros.in
+++ b/macros.in
@@ -65,7 +65,7 @@
 %__ld			@__LD@
 %__objdump		@__OBJDUMP@
 %__strip		@__STRIP@
-%__rpmuncompress	%{_rpmconfigdir}/rpmuncompress
+%__rpmuncompress	@bindir_full@/rpmuncompress
 
 %__find_debuginfo	@__FIND_DEBUGINFO@
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -4110,7 +4110,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([rpmuncompress external macros])
 AT_KEYWORDS([build tools])
 RPMTEST_CHECK([
-${RPM_CONFIGDIR_PATH}/rpmuncompress -n /data/SOURCES/hello-2.0.tar.gz
+rpmuncompress -n /data/SOURCES/hello-2.0.tar.gz
 ],
 [0],
 [],
@@ -4122,7 +4122,7 @@ cat << EOF > macros.aux
 %__gzip /an/alternative/gzip
 EOF
 
-${RPM_CONFIGDIR_PATH}/rpmuncompress --macros=macros.aux -n /data/SOURCES/hello-2.0.tar.gz
+rpmuncompress --macros=macros.aux -n /data/SOURCES/hello-2.0.tar.gz
 ],
 [0],
 [],

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -367,7 +367,7 @@ RPMTEST_CLEANUP
 RPMTEST_SETUP([uncompress 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
-${RPM_CONFIGDIR_PATH}/rpmuncompress /data/SOURCES/hello-2.0.tar.gz | tar t
+rpmuncompress /data/SOURCES/hello-2.0.tar.gz | tar t
 ],
 [0],
 [hello-2.0/
@@ -384,7 +384,7 @@ RPMTEST_SETUP([uncompress 2])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([
 echo xxxxxxxxxxxxxxxxxxxxxxxxx > "some%%ath"
-${RPM_CONFIGDIR_PATH}/rpmuncompress "some%%ath"
+rpmuncompress "some%%ath"
 ],
 [0],
 [xxxxxxxxxxxxxxxxxxxxxxxxx
@@ -395,13 +395,13 @@ RPMTEST_SETUP([uncompress 3])
 AT_KEYWORDS([macros rpmuncompress])
 
 RPMTEST_CHECK([
-${RPM_CONFIGDIR_PATH}/rpmuncompress -x -C test-1.2.3 /data/SOURCES/test-1.2.3.zip
+rpmuncompress -x -C test-1.2.3 /data/SOURCES/test-1.2.3.zip
 ],
 [0],
 [])
 
 RPMTEST_CHECK([
-${RPM_CONFIGDIR_PATH}/rpmuncompress -x -C test-1.2.3-7 /data/SOURCES/test-1.2.3.7z
+rpmuncompress -x -C test-1.2.3-7 /data/SOURCES/test-1.2.3.7z
 ],
 [0],
 [])
@@ -434,8 +434,8 @@ AT_KEYWORDS([macros rpmuncompress])
 
 RPMTEST_CHECK([
 runroot mkdir -p /tmp/1
-runroot --chdir /tmp/1 ${RPM_CONFIGDIR_PATH}/rpmuncompress -x /data/SOURCES/test-1.2.3.zip
-runroot --chdir /tmp/1 ${RPM_CONFIGDIR_PATH}/rpmuncompress -x /data/SOURCES/test-1.2.3.zip
+runroot --chdir /tmp/1 rpmuncompress -x /data/SOURCES/test-1.2.3.zip
+runroot --chdir /tmp/1 rpmuncompress -x /data/SOURCES/test-1.2.3.zip
 ],
 [0],
 [],
@@ -456,8 +456,8 @@ runroot --chdir /tmp/1 find . | sort
 
 RPMTEST_CHECK([
 runroot mkdir -p /tmp/2
-runroot --chdir /tmp/2 ${RPM_CONFIGDIR_PATH}/rpmuncompress -x /data/SOURCES/test-1.2.3.7z
-runroot --chdir /tmp/2 ${RPM_CONFIGDIR_PATH}/rpmuncompress -x /data/SOURCES/test-1.2.3.7z
+runroot --chdir /tmp/2 rpmuncompress -x /data/SOURCES/test-1.2.3.7z
+runroot --chdir /tmp/2 rpmuncompress -x /data/SOURCES/test-1.2.3.7z
 ],
 [0],
 [],
@@ -477,7 +477,7 @@ runroot --chdir /tmp/2 find . | sort
 [ignore])
 
 RPMTEST_CHECK([
-runroot ${RPM_CONFIGDIR_PATH}/rpmuncompress --dry-run /data/SOURCES/test-1.2.3.car
+runroot rpmuncompress --dry-run /data/SOURCES/test-1.2.3.car
 ],
 [0],
 [ignore],
@@ -485,7 +485,7 @@ runroot ${RPM_CONFIGDIR_PATH}/rpmuncompress --dry-run /data/SOURCES/test-1.2.3.c
 ])
 
 RPMTEST_CHECK([
-runroot ${RPM_CONFIGDIR_PATH}/rpmuncompress --dry-run /data/SOURCES/test-1.2.3.carv2
+runroot rpmuncompress --dry-run /data/SOURCES/test-1.2.3.carv2
 ],
 [0],
 [ignore],

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -290,10 +290,10 @@ RPMTEST_SETUP([rpmspec --parse])
 AT_KEYWORDS([rpmspec])
 RPMTEST_CHECK([
 
-# ensure the macros expand to expected values
+# ensure the macros expand to expected values, these depend on the prefix
 # debug packages disabled for simplicity, we're not testing for that here
 runroot rpmspec --parse \
-	--define "__rpmuncompress /usr/lib/rpm/rpmuncompress" \
+	--define "__rpmuncompress /usr/bin/rpmuncompress" \
 	--define "__make /usr/bin/make" \
 	--define "__patch /usr/bin/patch" \
 	--define "__chmod /usr/bin/chmod" \
@@ -335,7 +335,7 @@ Simple rpm demonstration.
 %prep
 cd '/build/BUILD/hello-1.0-build'
 rm -rf 'hello-1.0'
-/usr/lib/rpm/rpmuncompress -x '/build/SOURCES/hello-1.0.tar.gz'
+/usr/bin/rpmuncompress -x '/build/SOURCES/hello-1.0.tar.gz'
 STATUS=$?
 if [ $STATUS -ne 0 ]; then
   exit $STATUS

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -64,7 +64,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rpm2cpio TYPE BIN)
 
 install(TARGETS
 	rpm rpmdb rpmkeys rpmsign rpmbuild rpmspec
-	rpmlua rpmgraph
+	rpmlua rpmgraph rpmuncompress
 )
-install(TARGETS rpmdeps rpmdump rpmuncompress DESTINATION ${RPM_CONFIGDIR})
+install(TARGETS rpmdeps rpmdump DESTINATION ${RPM_CONFIGDIR})
 


### PR DESCRIPTION
Commit cd5d667e99f931504a512b591fcde7ed92cee344 split rpmuncompress out to a separate command with the implication it could be used as a standalone tool by packagers, but placed it into /usr/lib/rpm which makes it look like some special thing only to be called by rpm itself. Ditto with the double-underscore macro - it makes sense for rpm, but not packagers.

Let's just move it to the standard binary path so we can properly advertise it as a tool you can use. Just seeing how much crap it removes from our own test-suite suggests it's the sane thing to do. Add a note to the %{uncompress} macro pointing to this direction as well.

Note that we can't use %{_bindir}/rpmuncompress for the macro, because the command never moves but %_bindir can be overridden by a package, including indirectly just by using a different %_prefix. Curiously,
this is the first utility of it's kind where we need to point a macro to an executable in the path where rpm itself installs to, so we need to define a new cmake variable for this purpose.

Fixes: #4148