### PR TITLE
Move rpm-setup-autosign to a standard path

### DIFF
--- a/docs/man/rpm-setup-autosign.1.scd
+++ b/docs/man/rpm-setup-autosign.1.scd
@@ -36,7 +36,7 @@ _~/.config/rpm/rpmbuild-\*.asc_++
 _~/.config/rpm/macros_
 
 # EXAMPLES
-*/usr/lib/rpm/rpm-setup-autosign -p sq*
+*rpm-setup-autosign -p sq*
 	Set up *rpmbuild*(1) autosigning using Sequoia-sq.
 
 # SEE ALSO

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-install(PROGRAMS gendiff TYPE BIN)
+install(PROGRAMS gendiff rpm-setup-autosign TYPE BIN)
 install(PROGRAMS
 	brp-compress brp-strip brp-strip-comment-note
 	brp-strip-static-archive brp-remove-la-files
@@ -11,7 +11,7 @@ install(PROGRAMS
 	rpm_macros_provides.sh
 	rpmdb_dump rpmdb_load
 	rpm2cpio.sh tgpg
-	sysusers.sh rpm-setup-autosign
+	sysusers.sh
 	DESTINATION ${RPM_CONFIGDIR}
 )
 install(FILES

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2814,7 +2814,7 @@ AT_KEYWORDS([autosign signature])
 rpmconf=$(rpm --eval "%{_rpmconfigdir}")
 
 RPMTEST_CHECK([
-runroot ${RPM_CONFIGDIR_PATH}/rpm-setup-autosign
+runroot rpm-setup-autosign
 ],
 [0],
 [],
@@ -2823,7 +2823,7 @@ runroot ${RPM_CONFIGDIR_PATH}/rpm-setup-autosign
 
 RPMTEST_CHECK([
 runroot rm -rf /root/.config/rpm
-runroot ${RPM_CONFIGDIR_PATH}/rpm-setup-autosign -p gpg
+runroot rpm-setup-autosign -p gpg
 ],
 [0],
 [],

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -28,5 +28,5 @@ chmod 700 /root/.gnupg
 
 # setup default signing id + key (USER is not set when this runs!)
 rpmconf=$(rpm --eval "%{_rpmconfigdir}")
-USER=root ${rpmconf}/rpm-setup-autosign -p sq
+USER=root rpm-setup-autosign -p sq
 rpmkeys --import /root/.config/rpm/*.asc


### PR DESCRIPTION
The initial idea was that this is a tool you only call once so it might as well be out of sight, but in retrospective that doesn't seem to make much sense. /usr/lib/rpm is supposed to be for rpm's internal needs, so we shouldn't point users there.