### PR TITLE
rpmio: fix macOS compile error by moving Apple environ include to file scope

### DIFF
--- a/rpmio/lposix.cc
+++ b/rpmio/lposix.cc
@@ -28,6 +28,13 @@
 #include <time.h>
 #include <unistd.h>
 #include <utime.h>
+
+#ifdef __APPLE__
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
+extern char **environ;
+#endif
 #include <rpm/rpmutil.h>
 #include "rpmio_internal.hh"
 #include "rpmlua.hh"
@@ -422,12 +429,6 @@ static int Pgetenv(lua_State *L)		/** getenv([name]) */
 {
 	if (lua_isnone(L, 1))
 	{
-	#ifdef __APPLE__
-		#include <crt_externs.h>
-		#define environ (*_NSGetEnviron())
-	#else
-		extern char **environ;
-	#endif /* __APPLE__ */
 		char **e;
 		if (*environ==NULL) lua_pushnil(L); else lua_newtable(L);
 		for (e=environ; *e!=NULL; e++)


### PR DESCRIPTION
On macOS, `rpmio/lposix.cc` fails to compile with Clang because
`#include <crt_externs.h>` is nested inside a function body. The
header contains declarations that must appear at file scope, triggering:

```
error: expected unqualified-id
```

**Fix:** Move the `#ifdef __APPLE__ ... #include <crt_externs.h> ...
#define environ ... #else ... extern char **environ ... #endif` block
from inside `Pgetenv()` to file scope, alongside the other system
includes. The function body now simply uses `environ` directly, which
is defined at file scope for both macOS and non-Apple platforms.

Fixes #4139