### PR TITLE
Change temp file suffix from ;tid to .tid~ for shell safety

### DIFF
--- a/lib/fsm.cc
+++ b/lib/fsm.cc
@@ -895,7 +895,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
     struct diriter_s di = { -1, -1 };
 
     /* transaction id used for temporary path suffix while installing */
-    rasprintf(&tid, ";%08x", (unsigned)rpmtsGetTid(ts));
+    rasprintf(&tid, ".%08x~", (unsigned)rpmtsGetTid(ts));
 
     /* Collect state data for the whole operation */
     fi = rpmfilesIter(files, RPMFI_ITER_FWD);

--- a/tests/data/debugplugin/debug.c
+++ b/tests/data/debugplugin/debug.c
@@ -64,9 +64,12 @@ static rpmRC debug_scriptlet_post(rpmPlugin plugin,
 static char *cleanpath(const char *path)
 {
     char *p = rstrdup(path);
-    char *t = strrchr(p, ';');
-    if (t)
-	*(t+1) = '\0';
+    size_t len = strlen(p);
+    /* strip .XXXXXXXX~ suffix */
+    if (len > 10 && p[len-1] == '~' && p[len-10] == '.') {
+	p[len-10] = '~';
+	p[len-9] = '\0';
+    }
     return p;
 }
 

--- a/tests/rpmdevel.at
+++ b/tests/rpmdevel.at
@@ -60,8 +60,8 @@ debug_psm_pre: simple-1.0-1.noarch
 debug_fsm_file_pre:  /opt/bin 40755 80000001
 debug_fsm_file_prepare:  1 /opt/bin /opt/bin 40755 80000001
 debug_fsm_file_post:  /opt/bin 40755 80000001: 0
-debug_fsm_file_pre: /opt/bin/simple /opt/bin/simple; 100755 1
-debug_fsm_file_prepare: /opt/bin/simple 1 /opt/bin/simple; /opt/bin/simple 100755 1
+debug_fsm_file_pre: /opt/bin/simple /opt/bin/simple~ 100755 1
+debug_fsm_file_prepare: /opt/bin/simple 1 /opt/bin/simple~ /opt/bin/simple 100755 1
 debug_fsm_file_post: /opt/bin/simple /opt/bin/simple 100755 1: 0
 debug_scriptlet_pre: %post(simple-1.0-1.noarch) 3
 debug_scriptlet_fork_post: /bin/sh 3

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -198,7 +198,7 @@ runroot --setenv SOURCE_DATE_EPOCH 1234 \
 ],
 [1],
 [],
-[error: unpacking of archive failed on file /usr/share/doc/hello-2.0/COPYING;000004d2: cpio: Digest mismatch
+[error: unpacking of archive failed on file /usr/share/doc/hello-2.0/COPYING.000004d2~: cpio: Digest mismatch
 error: hello-2.0-1.x86_64: install failed
 ])
 
@@ -246,7 +246,7 @@ runroot --setenv SOURCE_DATE_EPOCH 1234 \
 ],
 [1],
 [],
-[error: unpacking of archive failed on file /usr/share/doc/hello-2.0/COPYING;000004d2: cpio: Digest mismatch
+[error: unpacking of archive failed on file /usr/share/doc/hello-2.0/COPYING.000004d2~: cpio: Digest mismatch
 error: hello-2.0-1.x86_64: install failed
 ])
 RPMTEST_CLEANUP
@@ -1552,12 +1552,12 @@ error: hlinktest-1.0-1.noarch: install failed
 ])
 
 RPMTEST_CHECK([
-runroot rpm -i --noverify --nosignature /tmp/3.rpm 2>&1| sed 's/;.*:/:/g'
+runroot rpm -i --noverify --nosignature /tmp/3.rpm 2>&1| sed 's/\.[[0-9a-f]]*~:/:/g'
 # test that nothing of the contents remains after failure
 test -d "${RPMTEST}/foo"
 ],
 [1],
-[error: unpacking of archive failed on file /foo/hello-world: Digest mismatch
+[error: unpacking of archive failed on file /foo/hello-world: cpio: Digest mismatch
 error: hlinktest-1.0-1.noarch: install failed
 ],
 [])
@@ -2026,7 +2026,7 @@ runroot --setenv SOURCE_DATE_EPOCH 1699955855 rpm -U /build/RPMS/noarch/replacet
 [1],
 [],
 [error: failed to open dir opt of /opt/: cpio: Unsafe symlink
-error: unpacking of archive failed on file /opt/foo;6553448f: cpio: Unsafe symlink
+error: unpacking of archive failed on file /opt/foo.6553448f~: cpio: Unsafe symlink
 error: replacetest-1.0-1.noarch: install failed
 ])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Hi!

At Meta, I noticed we were seeing:
```
    zsh: command not found: 699f9aa7
```

After some debugging, it looks like RPM's file state machine uses a transaction ID as a temporary suffix when atomically installing files: write to file<tid>, then rename to file. The suffix format was ";%08x" (e.g., ";699f9aa7").

If an RPM install is interrupted (e.g., SIGKILL due to a timeout or OOM), these temp files are left behind. When they exist in shell completion directories like /usr/share/zsh/site-functions/, the semicolon in the filename is interpreted as a command separator by zsh, causing errors as mentioned above.

## Changes
* Change the suffix from ";%08x" to ".%08x~" (e.g., ".699f9aa7~"). 

## Reproducer

    # Build a package with many files
    cat > /tmp/manyfiles.spec << 'SPEC'
    Name:    manyfiles
    Version: 1.0
    Release: 1
    Summary: Test package
    License: MIT
    BuildArch: noarch
    %description
    Test
    %install
    mkdir -p %{buildroot}/usr/share/manyfiles
    for i in $(seq 1 10000); do
        dd if=/dev/urandom bs=1024 count=1 2>/dev/null | base64 > \
            %{buildroot}/usr/share/manyfiles/file_$(printf '%%05d' $i).txt
    done
    %files
    /usr/share/manyfiles/
    SPEC
    rpmbuild -bb /tmp/manyfiles.spec

    # Install into a test root and SIGKILL during install
    mkdir -p /tmp/rpmtest
    rpm --root /tmp/rpmtest --dbpath /tmp/rpmtest/var/lib/rpm --initdb
    rpm --root /tmp/rpmtest --dbpath /tmp/rpmtest/var/lib/rpm \
        -Uvh --noscripts --nodeps ~/rpmbuild/RPMS/noarch/manyfiles-1.0-1.noarch.rpm &
    PID=$!
    # Poll until files start appearing, then kill
    while [ "$(find /tmp/rpmtest/usr/share/manyfiles/ -type f 2>/dev/null | wc -l)" -lt 100 ]; do
        sleep 0.01
    done
    kill -9 $PID; wait $PID 2>/dev/null

    # Before this fix: leftover files like file_00001.txt;69bd8a7a
    # After this fix:  leftover files like file_00001.txt.69bd8a7a~
    find /tmp/rpmtest -name '*;*' | head
    
    
   CC @davide125 @teknoraver 