### PR TITLE
elfdeps: fix incorrect string length in ld64 soname prefix check

### DIFF
--- a/tools/elfdeps.c
+++ b/tools/elfdeps.c
@@ -61,7 +61,7 @@ static int skipSoname(const char *soname)
 	    return 1;
 
 	if (rstreqn(soname, "ld.", 3) || rstreqn(soname, "ld-", 3) ||
-	    rstreqn(soname, "ld64.", 3) || rstreqn(soname, "ld64-", 3))
+	    rstreqn(soname, "ld64.", 5) || rstreqn(soname, "ld64-", 5))
 	    return 0;
 
 	if (rstreqn(soname, "lib", 3))


### PR DESCRIPTION
## Problem

In `tools/elfdeps.c`, the `skipSoname()` function checks soname prefixes to decide
whether a shared library should be skipped. The comparison for `ld64.` and `ld64-`
prefixes uses an incorrect length of 3 instead of 5:

```c
if (rstreqn(soname, "ld.", 3) || rstreqn(soname, "ld-", 3) ||
    rstreqn(soname, "ld64.", 3) || rstreqn(soname, "ld64-", 3))
```

The length `3` only covers the prefix `"ld6"`, not the intended `"ld64."` or `"ld64-"`.
This means:
- Sonames starting with `"ld6"` (e.g. `ld6something.so`) are incorrectly skipped
- Sonames like `ld640.so` or `ld641.so` would be accidentally filtered out

The adjacent checks for `"ld."` and `"ld-"` correctly pass length 3 because those
prefixes are exactly 3 characters long. The fix passes length 5 to match the full
`"ld64."` and `"ld64-"` prefixes.

## Fix

Pass the correct length `5` to `rstreqn()` for the `ld64.` and `ld64-` prefix checks.

Fixes: #3596