### PR TITLE
Fix missing TOOLCHAIN ARG in second image stage

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -107,6 +107,7 @@ WORKDIR /
 CMD /bin/bash
 
 FROM base AS full
+ARG TOOLCHAIN=gcc
 
 WORKDIR /srv/rpm
 COPY . .


### PR DESCRIPTION
Commit 7369ea4de99e01d9bd64c17a3bd4ac40254e3811 forgot to declare the TOOLCHAIN argument for the second stage, which is mandated, see the following excerpt from Containerfile(5):

    Note that a second FROM in a Containerfile sets the values
    associated with an Arg variable to nil and they must be reset if
    they are to be used later in the Containerfile

Curiously enough, this has worked just fine with the latest Podman versions (5.8.1) as well as with Docker, the former of which is what we normally run on our Fedora workstations and the latter of which we still use in the CI.

However, rpm-sequoia uses Podman 4.9.3 in its CI (shipped with Ubuntu 24.04.3 LTS) where it has started failing because the TOOLCHAIN value is unset in the second stage. It's unclear to me why this isn't an issue with the newer Podman versions, however it could have been a deliberate change that just wasn't reflected in the Containerfile(5) man page.

Either way, kudos to our friends over at rpm-sequoia for noticing!