### PR TITLE
Implement one-shot macro modifier <o>

### DIFF
--- a/docs/man/rpm-macros.7.scd
+++ b/docs/man/rpm-macros.7.scd
@@ -63,7 +63,17 @@ Macro behavior can be altered by supplying modifiers: (Added: 6.1.0)
 	_NAME_*<*_MODIFIERS_*>* _BODY_
 
 Supported modifiers are:
-- *l*iteral - macro body is literal, *%* is not processed when expanding
+- *l*: Literal expansion. *%* is not processed when expanding.
+- *o*: One-shot expansion. The macro is expanded on first use and the
+  literal result is pushed on top of the original macro.
+
+Literal macros can simplify dealing with content that may contain
+percent signs (*%*) which otherwise would need to be escaped.
+
+One-shot macros are useful for caching expansion results, for example to
+guard a result against underlying changes, or to perform an expensive
+shell invocation just once.
+The one-shot expansion can be re-armed by undefining the macro once.
 
 See *PARAMETRIC MACROS* for the more advanced macro variant with options
 and arguments processing.
@@ -292,8 +302,11 @@ callee(s).
 
 To define a global macro inside a parametric macro, you _must_ use *%global*
 instead of *%define*. Also note that because such a macro may be referring
-to other macros only visible in the current scope, *%global* _expands the
-macro body once at the time of definition_, unless it's a *l*iteral macro.
+to other macros only visible in the current scope, *%global* expands the
+macro body once at the time of definition, unless it's a *l*iteral macro.
+Note that the body of a *o*ne-shot macro defined via *%global* is actually
+expanded twice: once at the time of definition, and the result of that
+expansion is expanded again on first use.
 
 ## Calling convention
 When a parametric macro is expanded, the following calling convention is used:
@@ -770,6 +783,19 @@ overlapping with other macros:
 ```
 
 *%cc* expands to *some%thing*, whereas *%dd* expands to *some%%thing*.
+
+## Example 8. One-shot macros
+
+Define a one-shot *\_python_platlib* macro to output Python platform
+library path:
+
+```
+%_python_platlib<o> %(python -c "import sysconfig; print(sysconfig.get_path('platlib'))")
+```
+
+The Python interpreter will only be invoked on the first use of this macro,
+the result of that expansion is pushed as a literal macro on top of the
+original.
 
 # DEBUGGING
 Some useful tools for working with and troubleshooting macros:

--- a/docs/man/rpm-macros.7.scd
+++ b/docs/man/rpm-macros.7.scd
@@ -75,10 +75,10 @@ described in *rpm-common*(8) and the API (C, Python, Lua).
 Except for those defined inside parametric macros, macros are always global
 in scope.
 
-RPM macros are stacked, ie. when redefining an already existing
-macro, it shadows the previous definition instead of replacing it, and
-undefining a macro only pops the topmost definition, thus activating
-the previous macro definition.
+RPM macros are stacked, ie. when redefining an already existing macro,
+the new definition is pushed on top of the previous one, shadowing it.
+Conversely, undefining a macro only pops the topmost definition,
+reactivating the previous macro definition if there is one.
 
 Note that this manual only describes the macro processor engine itself.
 On a normal RPM based system, there are a vast number of other macros

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -50,10 +50,11 @@ enum macroFlags_e {
     ME_PARSE	= (1 << 3),
     ME_FUNC	= (1 << 4),
     ME_QUOTED	= (1 << 5),
+    ME_ONESHOT	= (1 << 6),
 };
 
 /* bitmask of all modifiers */
-#define ME_MODIFIER (ME_LITERAL)
+#define ME_MODIFIER (ME_LITERAL|ME_ONESHOT)
 
 /*! The structure used to store a macro. */
 struct rpmMacroEntry_s {
@@ -134,6 +135,9 @@ static int expandQuotedMacro(rpmMacroBuf mb, const char *src);
 static void pushMacro(rpmMacroContext mc,
 	const std::string & n, const char * o, const std::string & b,
 	int level, int flags);
+static void pushMacroAny(rpmMacroContext mc,
+	const string & n, const char * o, const string & b,
+	macroFunc f, void *priv, int nargs, int level, int flags);
 static void popMacro(rpmMacroContext mc, const std::string & n);
 static int loadMacroFile(rpmMacroContext mc, const std::string fn);
 /* =============================================================== */
@@ -718,6 +722,9 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
 	    /* A %global literal must not expand */
 	    expandbody = 0;
 	    break;
+	case 'o':
+	    flags |= ME_ONESHOT;
+	    break;
 	default:
 	    rpmMacroBufErr(mb, 1,
 			    _("Macro %%%s has illegal modifier %c\n"), n, m);
@@ -727,7 +734,12 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
     }
 
     /* Check for modifier compatibility */
-    if (o && (flags & ME_LITERAL)) {
+    if (o && (flags & (ME_LITERAL|ME_ONESHOT))) {
+	rpmMacroBufErr(mb, 1, _("Macro %%%s has incompatible modifiers\n"), n);
+	goto exit;
+    }
+
+    if ((flags & ME_LITERAL) && (flags & ME_ONESHOT)) {
 	rpmMacroBufErr(mb, 1, _("Macro %%%s has incompatible modifiers\n"), n);
 	goto exit;
     }
@@ -1492,6 +1504,7 @@ doMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t args, size_t *parsed)
 	if (me->body && *me->body)
 	    rpmMacroBufAppendStr(mb, me->body);
     } else if (me->body && *me->body) {
+	size_t mblen = mb->buf.size();
 	/* Setup args for "%name " macros with opts */
 	if (args != NULL)
 	    setupArgs(mb, me, args);
@@ -1502,6 +1515,13 @@ doMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t args, size_t *parsed)
 	/* Free args for "%name " macros with opts */
 	if (args != NULL)
 	    freeArgs(mb);
+	/* Push the literal expansion on top of one-shot macro on first use */
+	if (me->flags & ME_ONESHOT) {
+	    int flags = me->flags | ME_LITERAL;
+	    flags &= ~ME_ONESHOT;
+	    pushMacroAny(mb->mc, me->name, me->opts, mb->buf.substr(mblen),
+			 me->func, me->priv, me->nargs, me->level, flags);
+	}
     }
 
     /* postprocess macros that contain quotes */
@@ -2132,6 +2152,8 @@ void macros::dump(FILE *fp)
 	    std::string mods;
 	    if (me.flags & ME_LITERAL)
 		mods += "l";
+	    if (me.flags & ME_ONESHOT)
+		mods += "o";
 	    fprintf(fp, "<%s>", mods.c_str());
 	}
 	if (me.opts && *me.opts)

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -735,7 +735,8 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
 
     /* Check for modifier compatibility */
     if (o && (flags & (ME_LITERAL|ME_ONESHOT))) {
-	rpmMacroBufErr(mb, 1, _("Macro %%%s has incompatible modifiers\n"), n);
+	rpmMacroBufErr(mb, 1, _("Macro %%%s has modifiers incompatible "
+				"with parametric macros\n"), n);
 	goto exit;
     }
 

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -52,6 +52,9 @@ enum macroFlags_e {
     ME_QUOTED	= (1 << 5),
 };
 
+/* bitmask of all modifiers */
+#define ME_MODIFIER (ME_LITERAL)
+
 /*! The structure used to store a macro. */
 struct rpmMacroEntry_s {
     const char *name;  	/*!< Macro name. */
@@ -2125,6 +2128,12 @@ void macros::dump(FILE *fp)
 	auto const & me = entry.second.top();
 	fprintf(fp, "%3d%c %s", me.level,
 		    ((me.flags & ME_USED) ? '=' : ':'), me.name);
+	if (me.flags & ME_MODIFIER) {
+	    std::string mods;
+	    if (me.flags & ME_LITERAL)
+		mods += "l";
+	    fprintf(fp, "<%s>", mods.c_str());
+	}
 	if (me.opts && *me.opts)
 		fprintf(fp, "(%s)", me.opts);
 	if (me.body && *me.body)

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1618,6 +1618,28 @@ rpm --define "aa 123" --define "mymod<l> %aa" --eval "%mymod"
 [])
 
 RPMTEST_CHECK([
+rpm --define "aa 123" --define "mymod<> %aa" --eval "%mymod" \
+    --define "aa 321" --eval "%mymod"
+],
+[0],
+[123
+321
+],
+[])
+
+RPMTEST_CHECK([
+rpm --define "aa 123" --define "mymod<o> %aa" --eval "%mymod" \
+    --define "aa 321" --eval "%mymod" \
+    --undefine "mymod" --define "aa 987" --eval "%mymod"
+],
+[0],
+[123
+123
+987
+],
+[])
+
+RPMTEST_CHECK([
 rpm --define "aa 123" --eval "%global mymod %aa" --eval "%mymod"
 ],
 [0],
@@ -1630,6 +1652,19 @@ rpm --define "aa 123" --eval "%global mymod<l> %aa" --eval "%mymod"
 ],
 [0],
 [%aa
+],
+[])
+
+RPMTEST_CHECK([
+rpm --define "aa 123" --eval "%global mymod<o> %aa%bb" \
+    --define "aa 321" --define "bb 987" \
+    --eval "%mymod" \
+    --undefine "aa" --undefine "bb" \
+    --eval "%mymod"
+],
+[0],
+[123987
+123987
 ],
 [])
 
@@ -1658,10 +1693,34 @@ rpm --define "aa 123" --define "mymod()<l> %aa" --eval "%mymod"
 ])
 
 RPMTEST_CHECK([
+rpm --define "aa 123" --define "mymod<lo> %aa" --eval "%mymod"
+],
+[1],
+[],
+[error: Macro %mymod has incompatible modifiers
+])
+
+RPMTEST_CHECK([
 rpm --define "mylit<l> %%%%" --showrc | grep ' mylit' | awk '{print $2}'
 ],
 [0],
 [mylit<l>
+],
+[])
+
+RPMTEST_CHECK([
+rpm --define "myonce<o> %(date)" --showrc | grep ' myonce' | awk '{print $2}'
+],
+[0],
+[myonce<o>
+],
+[])
+
+RPMTEST_CHECK([
+rpm --define "myonce<o> %(date)" --eval "%myonce" --showrc | grep ' myonce' | awk '{print $2}'
+],
+[0],
+[myonce<l>
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1656,6 +1656,14 @@ rpm --define "aa 123" --define "mymod()<l> %aa" --eval "%mymod"
 [],
 [error: Macro %mymod has incompatible modifiers
 ])
+
+RPMTEST_CHECK([
+rpm --define "mylit<l> %%%%" --showrc | grep ' mylit' | awk '{print $2}'
+],
+[0],
+[mylit<l>
+],
+[])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP([error macro return])

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1689,7 +1689,7 @@ rpm --define "aa 123" --define "mymod()<l> %aa" --eval "%mymod"
 ],
 [1],
 [],
-[error: Macro %mymod has incompatible modifiers
+[error: Macro %mymod has modifiers incompatible with parametric macros
 ])
 
 RPMTEST_CHECK([


### PR DESCRIPTION
A one-shot macro is expanded once on the first use, and the result of that expansion is pushed on the stack as a literal macro so it wont be expanded again. Using the stack this way allows one-shot macros to be re-armed by just undefining it once.

Things get a bit stranger with %global which expands the body once at the time of definition, and then once at the first use.

The first commit is basically just something forgotten from #4129.

Fixes: #1155
