### PR TITLE
Implement immutable macro modifier

### DIFF
--- a/docs/man/rpm-macros.7.scd
+++ b/docs/man/rpm-macros.7.scd
@@ -63,6 +63,7 @@ Macro behavior can be altered by supplying modifiers: (Added: 6.1.0)
 	_NAME_*<*_MODIFIERS_*>* _BODY_
 
 Supported modifiers are:
+- *i*: Macro is immutable and cannot be redefined or undefined.
 - *l*: Literal expansion. *%* is not processed when expanding.
 - *o*: One-shot expansion. The macro is expanded on first use and the
   literal result is pushed on top of the original macro.
@@ -72,7 +73,8 @@ percent signs (*%*) which otherwise would need to be escaped.
 
 One-shot macros are useful for caching expansion results, for example to
 guard a result against underlying changes, or to perform an expensive
-shell invocation just once.
+shell invocation just once. The one-shot modifier is incompatible with
+immutable and literal modifiers.
 The one-shot expansion can be re-armed by undefining the macro once.
 
 See *PARAMETRIC MACROS* for the more advanced macro variant with options
@@ -237,8 +239,7 @@ This allows macros to fully decide how to handle their input, e.g.
 if the arguments of the macro only/mostly consist of items starting
 with *-*, the default processing only gets in the way.
 
-A modifier field may be present, but currently there are no modifiers
-compatible with parametric macros.
+The only modifier compatible with parametric macros is *i*mmutable.
 
 ## Automatic macros
 While a parameterized macro is being expanded, the following shell-like

--- a/include/rpm/rpmmacro.h
+++ b/include/rpm/rpmmacro.h
@@ -65,6 +65,7 @@ extern const char * macrofiles;
 enum rpmMacroFlags_e {
     RPMMACRO_DEFAULT	= 0,
     RPMMACRO_LITERAL	= (1 << 0),		/*!< do not expand body of macro */
+    RPMMACRO_IMMUTABLE	= (1 << 1),		/*!< immutable macro (for the user) */
 };
 typedef rpmFlags rpmMacroFlags;
 

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -51,10 +51,11 @@ enum macroFlags_e {
     ME_FUNC	= (1 << 4),
     ME_QUOTED	= (1 << 5),
     ME_ONESHOT	= (1 << 6),
+    ME_IMMUTABLE = (1 << 7),
 };
 
 /* bitmask of all modifiers */
-#define ME_MODIFIER (ME_LITERAL|ME_ONESHOT)
+#define ME_MODIFIER (ME_LITERAL|ME_ONESHOT|ME_IMMUTABLE)
 
 /*! The structure used to store a macro. */
 struct rpmMacroEntry_s {
@@ -137,8 +138,9 @@ static int pushMacro(rpmMacroContext mc,
 	int level, int flags);
 static int pushMacroAny(rpmMacroContext mc,
 	const string & n, const char * o, const string & b,
-	macroFunc f, void *priv, int nargs, int level, int flags);
-static int popMacro(rpmMacroContext mc, const std::string & n);
+	macroFunc f, void *priv, int nargs, int level, int flags,
+	bool force=true);
+static int popMacro(rpmMacroContext mc, const std::string & n, bool force=true);
 static int loadMacroFile(rpmMacroContext mc, const std::string fn);
 /* =============================================================== */
 
@@ -725,6 +727,9 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
 	case 'o':
 	    flags |= ME_ONESHOT;
 	    break;
+	case 'i':
+	    flags |= ME_IMMUTABLE;
+	    break;
 	default:
 	    rpmMacroBufErr(mb, 1,
 			    _("Macro %%%s has illegal modifier %c\n"), n, m);
@@ -740,7 +745,8 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
 	goto exit;
     }
 
-    if ((flags & ME_LITERAL) && (flags & ME_ONESHOT)) {
+    /* One-shot macros can't be literal or immutable */
+    if ((flags & ME_ONESHOT) && (flags & (ME_LITERAL | ME_IMMUTABLE))) {
 	rpmMacroBufErr(mb, 1, _("Macro %%%s has incompatible modifiers\n"), n);
 	goto exit;
     }
@@ -758,7 +764,7 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
 	_free(ebody);
     }
 
-    rc = pushMacro(mb->mc, name, o, body, level, flags);
+    rc = pushMacroAny(mb->mc, name, o, body, NULL, NULL, 0, level, flags, false);
 
 exit:
     if (rc)
@@ -772,7 +778,7 @@ static int undefineMacro(rpmMacroBuf mb, const std::string & n)
     if (!validName(mb, n.c_str(), n.size(), "%undefine"))
 	return mb->error;
 
-    return popMacro(mb->mc, n);
+    return popMacro(mb->mc, n, false);
 }
 
 /**
@@ -1832,11 +1838,20 @@ static int doExpandMacros(rpmMacroContext mc, const string & src, int flags,
 
 static int pushMacroAny(rpmMacroContext mc,
 	const string & n, const char * o, const string & b,
-	macroFunc f, void *priv, int nargs, int level, int flags)
+	macroFunc f, void *priv, int nargs, int level, int flags, bool force)
 {
     auto res = mc->tab.insert({n, {}});
     auto & entry = res.first;
     auto & stack = entry->second;
+
+    if (stack.empty() == false && (stack.top().flags & ME_IMMUTABLE)) {
+	if (force == false) {
+	    rpmlog(RPMLOG_ERR,
+		    _("Macro %%%s is immutable and cannot be redefined\n"),
+		    n.c_str());
+	    return 1;
+	}
+    }
 
     /* push an empty entry to the stack and fillup */
     stack.push({});
@@ -1871,12 +1886,18 @@ static int pushMacro(rpmMacroContext mc,
 }
 
 /* Return pointer to the _previous_ macro definition (or NULL) */
-static int popMacro(rpmMacroContext mc, const std::string & n)
+static int popMacro(rpmMacroContext mc, const std::string & n, bool force)
 {
     auto const & entry = mc->tab.find(n);
     if (entry == mc->tab.end())
 	return 0;
     auto & stack = entry->second;
+    if (force == false && stack.top().flags & ME_IMMUTABLE) {
+	rpmlog(RPMLOG_ERR,
+		_("Macro %%%s is immutable and cannot be undefined\n"),
+		n.c_str());
+	return 1;
+    }
     stack.pop();
     if (stack.empty())
 	mc->tab.erase(entry);
@@ -2152,6 +2173,8 @@ void macros::dump(FILE *fp)
 		    ((me.flags & ME_USED) ? '=' : ':'), me.name);
 	if (me.flags & ME_MODIFIER) {
 	    std::string mods;
+	    if (me.flags & ME_IMMUTABLE)
+		mods += "i";
 	    if (me.flags & ME_LITERAL)
 		mods += "l";
 	    if (me.flags & ME_ONESHOT)
@@ -2289,6 +2312,8 @@ int macros::push(const std::string & n, const char *o, const std::string & b,
     int iflags = ME_NONE;
     if (flags & RPMMACRO_LITERAL)
 	iflags |= ME_LITERAL;
+    if (flags & RPMMACRO_IMMUTABLE)
+	iflags |= ME_IMMUTABLE;
 
     return pushMacro(mc, n, o, b, level, iflags);
 }

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -132,13 +132,13 @@ static int print_expand_trace = _PRINT_EXPAND_TRACE;
 /* forward ref */
 static int expandMacro(rpmMacroBuf mb, const char *src, size_t slen);
 static int expandQuotedMacro(rpmMacroBuf mb, const char *src);
-static void pushMacro(rpmMacroContext mc,
+static int pushMacro(rpmMacroContext mc,
 	const std::string & n, const char * o, const std::string & b,
 	int level, int flags);
-static void pushMacroAny(rpmMacroContext mc,
+static int pushMacroAny(rpmMacroContext mc,
 	const string & n, const char * o, const string & b,
 	macroFunc f, void *priv, int nargs, int level, int flags);
-static void popMacro(rpmMacroContext mc, const std::string & n);
+static int popMacro(rpmMacroContext mc, const std::string & n);
 static int loadMacroFile(rpmMacroContext mc, const std::string fn);
 /* =============================================================== */
 
@@ -758,8 +758,7 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
 	_free(ebody);
     }
 
-    pushMacro(mb->mc, name, o, body, level, flags);
-    rc = 0;
+    rc = pushMacro(mb->mc, name, o, body, level, flags);
 
 exit:
     if (rc)
@@ -773,8 +772,7 @@ static int undefineMacro(rpmMacroBuf mb, const std::string & n)
     if (!validName(mb, n.c_str(), n.size(), "%undefine"))
 	return mb->error;
 
-    popMacro(mb->mc, n);
-    return 0;
+    return popMacro(mb->mc, n);
 }
 
 /**
@@ -1832,7 +1830,7 @@ static int doExpandMacros(rpmMacroContext mc, const string & src, int flags,
     return rc;
 }
 
-static void pushMacroAny(rpmMacroContext mc,
+static int pushMacroAny(rpmMacroContext mc,
 	const string & n, const char * o, const string & b,
 	macroFunc f, void *priv, int nargs, int level, int flags)
 {
@@ -1861,9 +1859,11 @@ static void pushMacroAny(rpmMacroContext mc,
     me.flags = flags;
     me.flags &= ~(ME_USED);
     me.level = level;
+
+    return 0;
 }
 
-static void pushMacro(rpmMacroContext mc,
+static int pushMacro(rpmMacroContext mc,
 		const string & n, const char * o, const string & b,
 		int level, int flags)
 {
@@ -1871,15 +1871,16 @@ static void pushMacro(rpmMacroContext mc,
 }
 
 /* Return pointer to the _previous_ macro definition (or NULL) */
-static void popMacro(rpmMacroContext mc, const std::string & n)
+static int popMacro(rpmMacroContext mc, const std::string & n)
 {
     auto const & entry = mc->tab.find(n);
     if (entry == mc->tab.end())
-	return;
+	return 0;
     auto & stack = entry->second;
     stack.pop();
     if (stack.empty())
 	mc->tab.erase(entry);
+    return 0;
 }
 
 static int defineMacro(rpmMacroContext mc, const std::string macro, int level)
@@ -2279,8 +2280,7 @@ int macros::load(const string & fn)
 
 int macros::pop(const std::string & n)
 {
-    popMacro(mc, n);
-    return 0;
+    return popMacro(mc, n);
 }
 
 int macros::push(const std::string & n, const char *o, const std::string & b,
@@ -2290,17 +2290,15 @@ int macros::push(const std::string & n, const char *o, const std::string & b,
     if (flags & RPMMACRO_LITERAL)
 	iflags |= ME_LITERAL;
 
-    pushMacro(mc, n, o, b, level, iflags);
-    return 0;
+    return pushMacro(mc, n, o, b, level, iflags);
 }
 
 int macros::push_aux(const std::string & n, const char *o,
 		    macroFunc f, void *priv, int nargs,
 		    int level, int flags)
 {
-    pushMacroAny(mc, n, nargs ? "" : NULL, "<aux>", f, priv, nargs,
-		level, flags|ME_FUNC);
-    return 0;
+    return pushMacroAny(mc, n, nargs ? "" : NULL, "<aux>", f, priv, nargs,
+			level, flags|ME_FUNC);
 }
 
 macros::macros(rpmMacroContext mctx) :

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -568,26 +568,15 @@ static unsigned int getncpus(void)
 static int
 validName(rpmMacroBuf mb, const char *name, size_t namelen, const char *action)
 {
-    rpmMacroEntry mep;
-    int rc = 0;
     int c;
 
     /* Names must start with alphabetic, or _ and be at least 2 chars */
     if (!((c = *name) && (risalpha(c) || (c == '_' && namelen > 1)))) {
 	rpmMacroBufErr(mb, 1, _("Macro %%%s has illegal name (%s)\n"), name, action);
-	goto exit;
+	return 0;
     }
 
-    mep = findEntry(mb->mc, name, namelen, NULL);
-    if (mep && mep->flags & (ME_FUNC|ME_AUTO)) {
-	rpmMacroBufErr(mb, 1, _("Macro %%%s is a built-in (%s)\n"), name, action);
-	goto exit;
-    }
-
-    rc = 1;
-
-exit:
-    return rc;
+    return 1;
 }
 
 /**
@@ -2129,7 +2118,8 @@ static void initBuiltins(rpmMacroContext_s *mc)
     /* Define built-in macros */
     for (const struct builtins_s *b = builtinmacros; b->name; b++) {
 	pushMacroAny(mc, b->name, b->nargs ? "" : NULL, "<builtin>",
-		    b->func, NULL, b->nargs, RMIL_BUILTIN, b->flags | ME_FUNC);
+		    b->func, NULL, b->nargs, RMIL_BUILTIN,
+		    b->flags | ME_FUNC | ME_IMMUTABLE);
     }
 }
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -120,7 +120,7 @@ rpm --define "undefine that"
 [1],
 [],
 [error: Macro %_ has illegal name (%define)
-error: Macro %undefine is a built-in (%define)
+error: Macro %undefine is immutable and cannot be redefined
 ])
 RPMTEST_CLEANUP
 
@@ -143,7 +143,7 @@ rpm --undefine getenv
 ],
 [1],
 [],
-[error: Macro %getenv is a built-in (%undefine)
+[error: Macro %getenv is immutable and cannot be undefined
 ])
 RPMTEST_CLEANUP
 
@@ -354,8 +354,8 @@ rpm --eval "%dump" 2>&1 | head -3
 ],
 [0],
 [[========================
--20: P	<builtin>
--20: S	<builtin>
+-20: P<i>	<builtin>
+-20: S<i>	<builtin>
 ]],
 [])
 RPMTEST_CLEANUP
@@ -1132,7 +1132,7 @@ rpm --eval '%{lua: rpm.undefine("define")}'
 ],
 [1],
 [],
-[[error: Macro %define is a built-in (%undefine)
+[[error: Macro %define is immutable and cannot be undefined
 error: lua script failed: [string "<lua>"]:1: error undefining macro
 ]])
 RPMTEST_CLEANUP

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1701,6 +1701,14 @@ rpm --define "aa 123" --define "mymod<lo> %aa" --eval "%mymod"
 ])
 
 RPMTEST_CHECK([
+rpm --define "aa 123" --define "mymod<io> %aa" --eval "%mymod"
+],
+[1],
+[],
+[error: Macro %mymod has incompatible modifiers
+])
+
+RPMTEST_CHECK([
 rpm --define "mylit<l> %%%%" --showrc | grep ' mylit' | awk '{print $2}'
 ],
 [0],
@@ -1723,6 +1731,61 @@ rpm --define "myonce<o> %(date)" --eval "%myonce" --showrc | grep ' myonce' | aw
 [myonce<l>
 ],
 [])
+
+RPMTEST_CHECK([
+rpm --define "myonce<o> %(date)" --showrc | grep ' myonce' | awk '{print $2}'
+],
+[0],
+[myonce<o>
+],
+[])
+
+RPMTEST_CHECK([
+rpm --define "myimm<i> someval" --showrc | grep ' myimm' | awk '{print $2}'
+],
+[0],
+[myimm<i>
+],
+[])
+
+RPMTEST_CHECK([
+rpm --define "aa<i> 123" --define "aa 321"
+],
+[1],
+[],
+[error: Macro %aa is immutable and cannot be redefined
+])
+
+RPMTEST_CHECK([
+rpm --define "aa<i> 123" --undefine "aa"
+],
+[1],
+[],
+[error: Macro %aa is immutable and cannot be undefined
+])
+
+RPMTEST_CHECK([
+rpm --define "myimm()<i> 123%{1}321"  --eval "%{myimm xxx}"
+],
+[0],
+[123xxx321
+],
+[])
+
+RPMTEST_CHECK([
+cat << EOF > mymacros
+%aa aa
+%aa<i> bb
+%aa cc
+EOF
+
+rpm --macros mymacros --eval "%aa"
+],
+[0],
+[bb
+],
+[error: Macro %aa is immutable and cannot be redefined
+])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP([error macro return])


### PR DESCRIPTION
Immutable macros cannot be redefined or undefined, so they make it possible to lock macro values in place. They are compatible with regular, parametric and literal macros, but not one-shot macros because they use stacking.

RPM itself needs to be redefine and undefine anything at all to guarantee operation, so this is enforced at "user" level macro defines and undefines only.  It might seem more reasonable to have the "force" flag for overriding immutable checks default to false, but it would require updating way more callers throughout the codebase, so this looks like the better option, at least for now.

Take advantage of the immutable flag to remove other special casing for built-in macros.

Fixes: #2314