### PR TITLE
Fix wrong operation names used in the syslog plugin

### DIFF
--- a/plugins/syslog.c
+++ b/plugins/syslog.c
@@ -74,13 +74,24 @@ static rpmRC syslog_tsm_post(rpmPlugin plugin, rpmts ts, int res)
     return RPMRC_OK;
 }
 
+static const char *getOp(rpmte te)
+{
+    switch (rpmteType(te)) {
+    case TR_ADDED:	return "install";
+    case TR_REMOVED:	return "erase";
+    case TR_RPMDB:	return "rpmdb";
+    case TR_RESTORED:	return "restore";
+    }
+    return "<unknown>";
+}
+
 static rpmRC syslog_psm_post(rpmPlugin plugin, rpmte te, int res)
 {
     struct logstat * state = rpmPluginGetData(plugin);
 
     if (state->logging) {
 	int lvl = LOG_NOTICE;
-	const char *op = (rpmteType(te) == TR_ADDED) ? "install" : "erase";
+	const char *op = getOp(te);
 	const char *outcome = "success";
 	/* XXX: Permit configurable header queryformat? */
 	const char *pkg = rpmteNEVRA(te);

--- a/plugins/syslog.c
+++ b/plugins/syslog.c
@@ -16,7 +16,7 @@ struct logstat {
 static rpmRC syslog_init(rpmPlugin plugin, rpmts ts)
 {
     /* XXX make this configurable? */
-    const char * log_ident = "[RPM]";
+    const char * log_ident = "rpm";
     struct logstat * state = rcalloc(1, sizeof(*state));
 
     rpmPluginSetData(plugin, state);


### PR DESCRIPTION
There are more rpmte types than just TR_ADDED and TR_REMOVED these days, but this code was never updated to match. As a result, it'll log anything but installs (such as --restore) as erasure which can be a little hair-raising when looking at the log.

Fixes: #4172