### PR TITLE
Fix rpmkeys result wrapping around, potentially returning 0 on fail

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -45,6 +45,18 @@ hello-2.0-1.x86_64
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP([rpmkeys -K argument overflow])
+AT_KEYWORDS([rpmkeys digest])
+AT_SKIP_IF([test -z "${PYTHON}"])
+RPMTEST_CHECK([
+${PYTHON} -c "for i in range(1, 257): open('%s.notrpm' % i, 'w')"
+rpmkeys -K *.notrpm
+],
+[254],
+[ignore],
+[ignore])
+RPMTEST_CLEANUP
+
 # ------------------------------
 # Test pre-built package verification
 RPMTEST_SETUP([rpmkeys -Kv <unsigned> 1])

--- a/tools/rpmkeys.cc
+++ b/tools/rpmkeys.cc
@@ -204,5 +204,5 @@ exit:
     fflush(stdout);
     if (ferror(stdout) || ferror(stderr))
 	return 255; /* I/O error */
-    return ec;
+    return RETVAL(ec);
 }


### PR DESCRIPTION
If the number of failures is divisible by 256, the final exit code returned to the shell wraps around, returning zero despite failures. We already have a special purpose macro for this, just use it. Add a test while at it.

Fixes: #4176