### PR TITLE
Only execute psm_pre and psm_post for the main package operation

### DIFF
--- a/docs/manual/plugins.md
+++ b/docs/manual/plugins.md
@@ -44,7 +44,7 @@ Post hook is guaranteed to execute whenever pre hook was executed.
 
 ## Per transaction element hooks
 
-Hooks `psm_pre` and `psm_post` occur before and after the processing of single transaction element within the transaction. Both hooks can get executed multiple times for a single element as these hooks get called separately for %pretrans and %posttrans scriptlets in addition to the main package install or erase action.
+Hooks `psm_pre` and `psm_post` occur before and after the processing of single transaction element within the transaction during install, erase and restore operations.
 
 Post hook is guaranteed to execute whenever pre hook was executed.
 

--- a/lib/psm.cc
+++ b/lib/psm.cc
@@ -1109,7 +1109,8 @@ static rpmRC runGoal(rpmpsm psm, pkgGoal goal)
 rpmRC rpmpsmRun(rpmts ts, rpmte te, pkgGoal goal)
 {
     rpmpsm psm = NULL;
-    rpmRC rc = RPMRC_FAIL;
+    rpmRC rc = RPMRC_OK;
+    int runplugins = (isScriptStage(goal) == 0);
 
     /* Psm can't fail in test mode, just return early */
     if (rpmtsFlags(ts) & RPMTRANS_FLAG_TEST)
@@ -1117,7 +1118,7 @@ rpmRC rpmpsmRun(rpmts ts, rpmte te, pkgGoal goal)
 
     psm = rpmpsmNew(ts, te, goal);
     /* Run pre transaction element hook for all plugins */
-    if (rpmChrootIn() == 0) {
+    if (runplugins && rpmChrootIn() == 0) {
 	rc = rpmpluginsCallPsmPre(rpmtsPlugins(ts), te);
 	rpmChrootOut();
     }
@@ -1126,7 +1127,7 @@ rpmRC rpmpsmRun(rpmts ts, rpmte te, pkgGoal goal)
 	rc = runGoal(psm, goal);
 
     /* Run post transaction element hook for all plugins (even on failure) */
-    if (rpmChrootIn() == 0) {
+    if (runplugins && rpmChrootIn() == 0) {
 	rpmpluginsCallPsmPost(rpmtsPlugins(ts), te, rc);
 	rpmChrootOut();
     }

--- a/lib/rpmte.cc
+++ b/lib/rpmte.cc
@@ -816,7 +816,7 @@ int rpmteAddOp(rpmte te)
 int rpmteProcess(rpmte te, pkgGoal goal, int num)
 {
     /* Only install/erase resets pkg file info */
-    int scriptstage = (goal != PKG_INSTALL && goal != PKG_ERASE && goal != PKG_RESTORE);
+    int scriptstage = isScriptStage(goal);
     int test = (rpmtsFlags(te->ts) & RPMTRANS_FLAG_TEST);
     int reset_fi = (scriptstage == 0 && test == 0);
     int failed = 1;

--- a/lib/rpmte_internal.hh
+++ b/lib/rpmte_internal.hh
@@ -22,6 +22,8 @@ typedef enum pkgGoal_e {
     PKG_TRANSFILETRIGGERUN	= RPMTAG_TRANSFILETRIGGERUN,
 } pkgGoal;
 
+#define isScriptStage(_g) ((_g) != PKG_INSTALL && (_g) != PKG_ERASE && (_g) != PKG_RESTORE)
+
 /** \ingroup rpmte
  * Transaction element ordering chain linkage.
  */

--- a/tests/rpmdevel.at
+++ b/tests/rpmdevel.at
@@ -67,8 +67,6 @@ debug_scriptlet_pre: %post(simple-1.0-1.noarch) 3
 debug_scriptlet_fork_post: /bin/sh 3
 debug_scriptlet_post: %post(simple-1.0-1.noarch) 3: 0
 debug_psm_post: simple-1.0-1.noarch:0
-debug_psm_pre: simple-1.0-1.noarch
-debug_psm_post: simple-1.0-1.noarch:0
 debug_tsm_post: 0
 debug_cleanup
 ])


### PR DESCRIPTION
Only execute psm_pre and psm_post for the main package operation

These hooks getting called multiple times with no means to identify why it's getting called makes them impossible to use meaningfully. Only run the psm hooks on non-script goals: install, erase and restore. 

It is of course a change to what is now a public API semantics, but the former behavior is really a bug that we're fixing here.
    
With this change, the syslog plugin no longer emits duplicates and in a strange order at that.

Fixes: #1254
