### PR TITLE
rpmuncompress: handle top-level dir entries without trailing slash

### DIFF
--- a/tools/rpmuncompress.cc
+++ b/tools/rpmuncompress.cc
@@ -109,6 +109,7 @@ static char * singleRoot(const char *path)
 	struct archive *a;
 	struct archive_entry *entry;
 	int r, ret = -1, rootLen;
+	int rootNoSlash = 0;
 	char *rootName = NULL;
 	char *sep = NULL;
 
@@ -125,21 +126,32 @@ static char * singleRoot(const char *path)
 	rootName = xstrdup(archive_entry_pathname(entry));
 	sep = strchr(rootName, '/');
 	if (sep == NULL) {
-	    /* No directories in the pathname */
-	    ret = 0;
-	    goto afree;
+	    if (archive_entry_filetype(entry) != AE_IFDIR) {
+			/* No directories in the pathname */
+			ret = 0;
+			goto afree;
+	    }
+	    rootLen = strlen(rootName);
+	    rootNoSlash = 1;
+	} else {
+	    rootLen = sep - rootName + 1;
 	}
 
 	/* Do all entries in the archive start with the same lead directory? */
-	rootLen = sep - rootName + 1;
 	while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
 	    const char *p = archive_entry_pathname(entry);
-	    if (strncmp(rootName, p, rootLen)) {
-		ret = 0;
-		goto afree;
+	    if (rootNoSlash) {
+			if (strncmp(rootName, p, rootLen) || (p[rootLen] != '/' && p[rootLen] != '\0')) {
+				ret = 0;
+				goto afree;
+			}
+	    } else if (strncmp(rootName, p, rootLen)) {
+			ret = 0;
+			goto afree;
 	    }
 	}
-	*sep = '\0';
+	if (sep)
+	    *sep = '\0';
 	ret = 1;
 
 afree:


### PR DESCRIPTION
resolve #4182 
Use the fixed rpm.The build is successful.
```text
CallChecker' /home/abuild/rpmbuild/SOURCES/perl-Devel-CallChecker.spec
[   21s] Reading /var/tmp/rpm-tmp.KZprkt
[   21s] Executing(%mkbuilddir): /usr/bin/bash -e /var/tmp/rpm-tmp.XQ2G41
[   21s] Executing(%prep): /usr/bin/bash -e /var/tmp/rpm-tmp.BDxQEV
[   21s] + umask 022
[   21s] + cd /home/abuild/rpmbuild/BUILD/perl-Devel-CallChecker-0.009-build
[   21s] + cd /home/abuild/rpmbuild/BUILD/perl-Devel-CallChecker-0.009-build
[   21s] + rm -rf perl-Devel-CallChecker-0.009
[   21s] + /usr/lib/rpm/rpmuncompress -x -C perl-Devel-CallChecker-0.009 /home/abuild/rpmbuild/SOURCES/Devel-CallChecker-0.009.tar.gz
[   21s] + STATUS=0
[   21s] + '[' 0 -ne 0 ']'
[   21s] + cd perl-Devel-CallChecker-0.009
[   21s] + /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
[   21s] + RPM_EC=0
[   21s] ++ jobs -p
[   21s] + exit 0
[   21s] Executing(%conf): /usr/bin/bash -e /var/tmp/rpm-tmp.UunByy
[   21s] + umask 022
[   21s] + cd /home/abuild/rpmbuild/BUILD/perl-Devel-CallChecker-0.009-build
[   21s] + cd perl-Devel-CallChecker-0.009
[   21s] + RPM_EC=0
[   21s] ++ jobs -p
[   21s] + exit 0
[   21s] Executing(%build): /usr/bin/bash -e /var/tmp/rpm-tmp.7MIlMl
[   21s] + umask 022
[   21s] + cd /home/abuild/rpmbuild/BUILD/perl-Devel-CallChecker-0.009-build
[   21s] + cd perl-Devel-CallChecker-0.009
[   21s] + pwd
[   21s] /home/abuild/rpmbuild/BUILD/perl-Devel-CallChecker-0.009-build/perl-Devel-CallChecker-0.009
[   21s] + perl Build.PL --installdirs=vendor 'optimize=-O2 -g -fno-omit-frame-pointer -pipe -flto=auto -ffat-lto-objects -funwind-tables -fasynchronous-unwind-tables -fstack-protector-strong -D_FORTIFY_SOURCE=3 -fstack-clash-protection -Wformat -Werror=format-security'
[   21s] Created MYMETA.yml and MYMETA.json
[   21s] Creating new 'Build' script for 'Devel-CallChecker' version '0.009'
[   21s] + ./Build
```