### PR TITLE
Fix signature alignment in --info output

### DIFF
--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -96,7 +96,7 @@ Install Date : %|INSTALLTIME?{%{INSTALLTIME:date}}:{(not installed)}|\n\
 Group        : %{GROUP}\n\
 Size         : %{LONGSIZE}\n\
 %|LICENSE?{License      : %{LICENSE}}|\n\
-Signature    :%|OPENPGP?{[\n              %{OPENPGP:pgpsig}]}:{ (none)}|\n\
+Signature    :%|OPENPGP?{[\n               %{OPENPGP:pgpsig}]}:{ (none)}|\n\
 Source RPM   : %{SOURCERPM}\n\
 Build Date   : %{BUILDTIME:date}\n\
 Build Host   : %{BUILDHOST}\n\

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -1415,8 +1415,8 @@ Group        : Testing
 Size         : 7243
 License      : GPL
 Signature    :
-              RSA/SHA256, Thu Apr  6 13:02:33 2017, Key ID 4344591e1964c5fc
-              RSA/SHA256, Thu Apr  6 13:02:32 2017, Key ID 4344591e1964c5fc
+               RSA/SHA256, Thu Apr  6 13:02:33 2017, Key ID 4344591e1964c5fc
+               RSA/SHA256, Thu Apr  6 13:02:32 2017, Key ID 4344591e1964c5fc
 Source RPM   : hello-2.0-1.src.rpm
 Build Date   : Sat Nov 22 12:00:00 2008
 Build Host   : localhost


### PR DESCRIPTION
The alignment looks fine in commit bea8f4557819449e6aec948dae192d71fe49d526 diff, but in reality it's missing one space worth of indentation and looks ugly. Amusingly, in this diff the wrong does look wrong.