### PR TITLE
find-lang.sh: Put one lang variants altogether when --generate-subpackage

### DIFF
--- a/scripts/find-lang.sh
+++ b/scripts/find-lang.sh
@@ -301,7 +301,7 @@ echo "" > $MO_NAME
 while IFS= read -r line
 do
     LOCALE=`echo $line|sed 's/%lang(//'|sed 's/).*//'`
-    LANG=`echo $LOCALE|sed 's/_.*//'`
+    LANG=`echo $LOCALE|sed 's/[_.@].*//'`
     LANGNAME=$LANG
     #LANGNAME=`locale -av | grep -m 1 -A 12 "locale: $LOCALE" | grep " language |" | cut "-d|" -f2`
     if [ -z "$LANGNAME" ]; then

--- a/tests/data/SPECS/find-lang-test.spec
+++ b/tests/data/SPECS/find-lang-test.spec
@@ -16,7 +16,7 @@ BuildArch:	noarch
 %setup -c -T
 
 %install
-for f in fi de_DE pl ""; do
+for f in fi de_DE pl be be@latin ""; do
     mkdir -p $RPM_BUILD_ROOT/%{_datadir}/man/$f/man1
     echo "This is $f language" | gzip > $RPM_BUILD_ROOT/%{_datadir}/man/$f/man1/%{name}.1.gz
 done

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -748,6 +748,8 @@ runroot rpm -qp --qf '[%{FILELANGS} %{FILENAMES}\n]' /build/RPMS/noarch/find-lan
 ]],
 [0],
 [ /usr/share/find-lang-test/empty.txt
+be /usr/share/man/be/man1/find-lang-test.1.gz
+be@latin /usr/share/man/be@latin/man1/find-lang-test.1.gz
 de /usr/share/man/de_DE/man1/find-lang-test.1.gz
 fi /usr/share/man/fi/man1/find-lang-test.1.gz
  /usr/share/man/man1/find-lang-test.1.gz
@@ -773,6 +775,9 @@ runroot rpm -qp --qf '%{NVRA}\n[%{FILELANGS} %{FILENAMES}\n]' /build/RPMS/noarch
 [find-lang-test-1.0-1.noarch
  /usr/share/find-lang-test/empty.txt
  /usr/share/man/man1/find-lang-test.1.gz
+find-lang-test-langpack-be-1.0-1.noarch
+be /usr/share/man/be/man1/find-lang-test.1.gz
+be@latin /usr/share/man/be@latin/man1/find-lang-test.1.gz
 find-lang-test-langpack-de-1.0-1.noarch
 de /usr/share/man/de_DE/man1/find-lang-test.1.gz
 find-lang-test-langpack-fi-1.0-1.noarch


### PR DESCRIPTION
Locale name is typically of the form:
  language[_territory][.codeset][@modifier]

All three variants are optional. `find-lang.sh --generate-subpackages` only dealed with _territory variant but not others. When the name had language@modifier format, find-lang.sh would error out due to "Illegal char '@'" in the package name.

Now, put all variants of one language in the same lang package.

Fixes: #4180