### PR TITLE
Implement -e(xpand) and -g(lobal) options to %define

### DIFF
--- a/docs/man/rpm-macros.7.scd
+++ b/docs/man/rpm-macros.7.scd
@@ -330,11 +330,22 @@ The macro primitives are used for macro manipulation in spec files
 and other macros. Note that all these operate on the macro name _without_
 the preceding *%*-character. 
 
-*%define* _NAME_[([_OPTIONS_])] _BODY_
+*%define* [_DEFOPTS_] _NAME_[([_OPTIONS_])] _BODY_
 	This is the primary way to define macros.
-	A *%define* is always fully declarative: no macro expansion takes place,
-	and it has no side-effects. Macros defined with it are in global scope,
-	unless the definition occurs inside a parametric macro.
+	By default, a *%define* is declarative: no macro expansion takes place
+	and it has no side-effects. Macros are placed in the current scope by
+	default: local inside parametric macros, otherwise global.
+
+	The *%define* macro accepts the following options (_DEFOPTS_):
+
+	*-e*
+		Expand body at the time of definition, making the result
+		the actual macro body.
+	*-g*
+		Place macro in the global context.
+		Has no effect outside parametric macros.
+
+	*%define -eg* is identical to using *%global*.
 
 	Example:
 	```

--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -597,7 +597,8 @@ exit:
  * @return		number of consumed characters
  */
 static void
-doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, size_t *parsed)
+doDefine(rpmMacroBuf mb, const std::string & str, int level,
+	int expandbody, int handleopts, size_t *parsed)
 {
     const char *se = str.c_str();
     const char *s = se;
@@ -607,6 +608,37 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
     int rc = 1; /* assume failure */
     int flags = ME_NONE;
     std::string name, opts, mods, body;
+
+    /* Parse options if enabled */
+    while (handleopts) {
+	SKIPBLANK(s, c);
+	if (*s == '-') {
+	    const char *o = s + 1;
+	    while (*o && !risblank(*o)) {
+		switch (*o) {
+		case 'e':
+		    expandbody = 1;
+		    break;
+		case 'g':
+		    level = RMIL_GLOBAL;
+		    break;
+		default:
+		    rpmMacroBufErr(mb, 1,
+				_("%%define: invalid option -- '%c'\n"), *o);
+		    return;
+		}
+		++o;
+	    }
+	    if (o == s + 1) {
+		rpmMacroBufErr(mb, 1, _("%%define: no option after -\n"));
+		return;
+	    }
+	    s = o;
+	} else {
+	    handleopts = 0;
+	}
+	se = s;
+    }
 
     /* Copy name */
     COPYNAME(name, s, c);
@@ -645,9 +677,10 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
 	}
     }
 
-    /* Copy body, skipping over escaped newlines */
     sbody = s;
     SKIPBLANK(s, c);
+
+    /* Copy body, skipping over escaped newlines */
     if (!parsed) {
 	body = s;
 	s += body.size();
@@ -790,7 +823,8 @@ doUndefine(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 	mb->error = 1;
 }
 
-static void doArgvDefine(rpmMacroBuf mb, ARGV_t argv, int level, int expand, size_t *parsed)
+static void doArgvDefine(rpmMacroBuf mb, ARGV_t argv, int level,
+			int expand, int handleopts, size_t *parsed)
 {
     std::string args = argv[1];
 
@@ -800,17 +834,17 @@ static void doArgvDefine(rpmMacroBuf mb, ARGV_t argv, int level, int expand, siz
 	args += argv[2];
     }
 
-    doDefine(mb, args, level, expand, parsed);
+    doDefine(mb, args, level, expand, handleopts, parsed);
 }
 
 static void doDef(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 {
-    doArgvDefine(mb, argv, mb->level, 0, parsed);
+    doArgvDefine(mb, argv, mb->level, 0, 1, parsed);
 }
 
 static void doGlobal(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 {
-    doArgvDefine(mb, argv, RMIL_GLOBAL, 1, parsed);
+    doArgvDefine(mb, argv, RMIL_GLOBAL, 1, 0, parsed);
 }
 
 static void doDump(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
@@ -1890,7 +1924,7 @@ static int defineMacro(rpmMacroContext mc, const std::string macro, int level)
 
     /* XXX just enough to get by */
     mb->mc = mc;
-    doDefine(mb, macro, level, 0, &parsed);
+    doDefine(mb, macro, level, 0, 0, &parsed);
     rc = mb->error;
     delete mb;
     return rc;

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1725,6 +1725,97 @@ rpm --define "myonce<o> %(date)" --eval "%myonce" --showrc | grep ' myonce' | aw
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP([%define options])
+AT_KEYWORDS([macros])
+
+RPMTEST_CHECK([
+rpm \
+	--eval "%define aa 123" \
+	--eval "%define mm %aa %bb" \
+	--eval "%define -e nn %aa %bb" \
+	--eval "%define bb 321" \
+	--eval "%define aa 555" \
+	--eval "%mm" \
+	--eval "%nn"
+],
+[0],
+[555 321
+123 321
+],
+[])
+
+RPMTEST_CHECK([
+cat << EOF > mymacro
+%myparm() %{span:
+%define aa 123
+%define -g bb 321
+%define -eg cc %aa%bb
+%define -eg dd %aa%yy
+%aa
+%bb
+%cc
+%dd
+}
+EOF
+
+rpm \
+	--macros mymacro \
+	--eval "%myparm" \
+	--eval "%aa" \
+	--eval "%bb" \
+	--eval "%cc" \
+	--eval "%dd" \
+	--define "yy 555" \
+	--eval "%dd"
+],
+[0],
+[
+123
+321
+123321
+123%yy
+
+%aa
+321
+123321
+123%yy
+123555
+],
+[])
+
+RPMTEST_CHECK([
+rpm --eval "%define -x aa bb"
+],
+[1],
+[],
+[error: %define: invalid option -- 'x'
+])
+
+RPMTEST_CHECK([
+rpm --eval "%define -g -y aa bb"
+],
+[1],
+[],
+[error: %define: invalid option -- 'y'
+])
+
+RPMTEST_CHECK([
+rpm --eval "%define -"
+],
+[1],
+[],
+[error: %define: no option after -
+])
+
+RPMTEST_CHECK([
+rpm --eval "%define - xx yy"
+],
+[1],
+[],
+[error: %define: no option after -
+])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP([error macro return])
 AT_KEYWORDS([macros lua])
 


### PR DESCRIPTION
%define -eg is identical to %global, but separate options allows for finer control.

Annoyingly we need to parse the options manually because we get this as a free-form string instead of argv array, and we can't parse it into an argv array with eg poptParseArgvString() because we the body must not be split on whitespace. We could get just the options that way, but then we'd need to parse through the options to locate name start anyhow. This also doesn't help implement options for other ME_PARSE macros, but that can always be refactored later.

It'd be trivial to support modifiers as %define options as well, but as the reverse is not true (in particular, body expansion must not be available for macro files), perhaps it's best to not overlap at all.

Fixes: #4163