### PR TITLE
Fix regression when parsing macro define with an empty body

### DIFF
--- a/rpmio/macro.cc
+++ b/rpmio/macro.cc
@@ -695,7 +695,7 @@ doDefine(rpmMacroBuf mb, const std::string & str, int level, int expandbody, siz
 	}
 
 	/* Trim trailing blanks/newlines */
-	while (risblank(body.back()) || iseol(body.back()))
+	while (!body.empty() && (risblank(body.back()) || iseol(body.back())))
 	    body.pop_back();
     }
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -108,6 +108,22 @@ rpm --eval '%define _ that'
 [],
 [error: Macro %_ has illegal name (%define)
 ])
+
+RPMTEST_CHECK([
+rpm --eval '%define this'
+],
+[1],
+[],
+[error: Macro %this has empty body
+])
+
+RPMTEST_CHECK([
+rpm --eval '%define this {}'
+],
+[1],
+[],
+[error: Macro %this has empty body
+])
 RPMTEST_CLEANUP
 
 # ------------------------------


### PR DESCRIPTION
Commit ab1991084fc72d4036a8818e35c8966bcf7b7c86 introduced a regression where we can attempt to access an empty string. Add tests to cover the case.

Fixes: #4195