### PR TITLE
Tests for behavior of importing keys disabled in crypto policies

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -58,7 +58,7 @@ RUN dnf -y install \
   sequoia-sq \
   nss-altfiles
 # If updates to specific packages are needed, do it here
-RUN dnf -y --enablerepo=updates install "rpm-sequoia-devel >= 1.10.2"
+RUN dnf -y --enablerepo=updates,updates-testing install "rpm-sequoia-devel >= 1.10.2"
 
 # Install some development tools
 RUN dnf -y install \

--- a/tests/rpmapi.at
+++ b/tests/rpmapi.at
@@ -61,4 +61,14 @@ runroot importkey /data/keys/rpm.org-nistp256-test.pub
 [error: Certificate 7F1C21F95F65BBE8:
   Policy rejects 7F1C21F95F65BBE8: Policy rejected asymmetric algorithm, because NistP256 is not considered secure
 ])
+
+# ML-DSA keys are now known
+RPMTEST_CHECK([
+runroot importkey /data/keys/unknown/rpm.org-v6-mldsa87-test.asc
+],
+[0],
+[/data/keys/unknown/rpm.org-v6-mldsa87-test.asc key 1: 0
+],
+[])
+
 RPMTEST_CLEANUP

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2087,8 +2087,8 @@ Preparing packages...
 
 # RSA disabled
 RPMTEST_CHECK([
-runroot cp /etc/crypto-policies/back-ends/rpm-sequoia.config /tmp/
-runroot sed -i '/^rsa/s/always/never/g' /etc/crypto-policies/back-ends/rpm-sequoia.config
+runroot cp /etc/crypto-policies/back-ends/rpm-sequoia.config /tmp/ # backup
+runroot sed -i '/^rsa/s/always/never/g' /etc/crypto-policies/back-ends/rpm-sequoia.config # RSA disabled
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [0],
@@ -2118,9 +2118,40 @@ Preparing packages...
 ],
 [])
 
+# Delete RSA and ECDSA from RPMDB
+# Importing bundle of nontrusted and trusted key should take just the trusted one (ECDSA)
+# FIXME should fail?
+RPMTEST_CHECK([
+runroot rpmkeys --delete 771b18d3d7baa28734333c424344591e1964c5fc # RSA
+runroot rpmkeys --delete e8a62c0512b06b5d2183ba207f1c21f95f65bbe8 # ECDSA
+runroot rpm -qa gpg-pubkey
+cat /data/keys/rpm.org-rsa-2048-test.pub /data/keys/rpm.org-nistp256-test.pub > "${RPMTEST}/tmp/bundle.pub"
+runroot rpmkeys --import /tmp/bundle.pub
+],
+[1],
+[],
+[error: Certificate 4344591E1964C5FC:
+  Policy rejects 4344591E1964C5FC: Policy rejected asymmetric algorithm, because RSA2048 is not considered secure
+error: /tmp/bundle.pub: key 1 import failed.
+])
+
+RPMTEST_CHECK([
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[0],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 152bb32fd9ca982797e835cfb0645aec757bf69e: OK
+    Header OpenPGP V4 ECDSA/SHA512 signature, key fingerprint: e8a62c0512b06b5d2183ba207f1c21f95f65bbe8: OK
+    Header OpenPGP V4 RSA/SHA512 signature, key ID 4344591e1964c5fc: NOTTRUSTED
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+],
+[stderr])
+
 # EDDSA disabled
 RPMTEST_CHECK([
-runroot cp -f /tmp/rpm-sequoia.config /etc/crypto-policies/back-ends/
+runroot cp -f /tmp/rpm-sequoia.config /etc/crypto-policies/back-ends/ # restore
+runroot rpmkeys --import /data/keys/*.pub # import back the missing keys
 # Work around https://gitlab.com/sequoia-pgp/sequoia/-/issues/1225
 # Disabling cv25519 disables ed25519, but disabling ed25519 does not:
 runroot sed -i '/^cv25519/s/always/never/g' /etc/crypto-policies/back-ends/rpm-sequoia.config
@@ -2155,9 +2186,32 @@ Preparing packages...
 ],
 [])
 
+# remove the EdDSA key from RPM DB -- should report UNTRUSTED instead of NOKEY
+RPMTEST_CHECK([
+runroot rpmkeys --delete 152bb32fd9ca982797e835cfb0645aec757bf69e
+runroot rpm -qa gpg-pubkey
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[0],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOTTRUSTED
+    Header OpenPGP V4 ECDSA/SHA512 signature, key fingerprint: e8a62c0512b06b5d2183ba207f1c21f95f65bbe8: OK
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+],
+[stderr])
+
 # ECDSA disabled
 RPMTEST_CHECK([
-runroot cp -f /tmp/rpm-sequoia.config /etc/crypto-policies/back-ends/
+runroot cp -f /tmp/rpm-sequoia.config /etc/crypto-policies/back-ends/ # restore
+runroot rpmkeys --import /data/keys/*.pub # import back the missing keys
 runroot sed -i '/^nist/s/always/never/g' /etc/crypto-policies/back-ends/rpm-sequoia.config
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
@@ -2188,9 +2242,32 @@ Preparing packages...
 ],
 [])
 
+# remove the ECDSA key from RPM DB -- should report UNTRUSTED instead of NOKEY
+RPMTEST_CHECK([
+runroot rpmkeys --delete e8a62c0512b06b5d2183ba207f1c21f95f65bbe8
+runroot rpm -qa gpg-pubkey
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[0],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 152bb32fd9ca982797e835cfb0645aec757bf69e: OK
+    Header OpenPGP V4 ECDSA/SHA512 signature, key ID 7f1c21f95f65bbe8: NOTTRUSTED
+    Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+],
+[stderr])
+
 # everything disabled
 RPMTEST_CHECK([
-runroot cp -f /tmp/rpm-sequoia.config /etc/crypto-policies/back-ends/
+runroot cp -f /tmp/rpm-sequoia.config /etc/crypto-policies/back-ends/ # restore
+runroot rpmkeys --import /data/keys/*.pub # import back the missing keys
 runroot sed -i 's/always/never/g' /etc/crypto-policies/back-ends/rpm-sequoia.config
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
@@ -2245,7 +2322,7 @@ Preparing packages...
 # remove the ECDSA key from RPM DB -- should report UNTRUSTED instead of NOKEY
 RPMTEST_CHECK([
 runroot rpmkeys --delete e8a62c0512b06b5d2183ba207f1c21f95f65bbe8
-runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+runroot --setenv RPM_TRACE 1 rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
 ],
 [1],
 [/tmp/hello-2.0-1.x86_64.rpm:
@@ -2311,6 +2388,31 @@ grep "^error:" stderr
 error: /data/keys/rpm.org-nistp256-test.pub: key 1 import failed.
 ],
 [])
+
+# remove all keys from RPM DB -- should report UNTRUSTED but fail
+RPMTEST_CHECK([
+runroot rpmkeys --delete 152bb32fd9ca982797e835cfb0645aec757bf69e
+runroot rpmkeys --delete 771b18d3d7baa28734333c424344591e1964c5fc
+runroot --setenv RPM_TRACE 1 rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+],
+[1],
+[/tmp/hello-2.0-1.x86_64.rpm:
+    Header OpenPGP V4 EdDSA/SHA512 signature, key ID b0645aec757bf69e: NOTTRUSTED
+    Header OpenPGP V4 ECDSA/SHA512 signature, key ID 7f1c21f95f65bbe8: NOTTRUSTED
+    Header OpenPGP V4 RSA/SHA512 signature, key ID 4344591e1964c5fc: NOTTRUSTED
+    Header SHA256 digest: OK
+    Payload SHA256 digest: OK
+],
+[stderr])
+
+RPMTEST_CHECK([
+runroot rpmkeys -K /tmp/hello-2.0-1.x86_64.rpm
+],
+[1],
+[/tmp/hello-2.0-1.x86_64.rpm: digests SIGNATURES NOT OK
+],
+[stderr])
+
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmsign --addsign legacy v6])

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -3163,17 +3163,8 @@ runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 RPMTEST_CHECK([[
 runroot rpmkeys --import /data/keys/unknown/rpm.org-v6-mldsa87-test.asc
 ]],
-[1],
-[],
-[stderr])
-
-RPMTEST_CHECK([
-grep "^error:" stderr
-],
 [0],
-[error: Certificate AED054589CBF8584:
-error: /data/keys/unknown/rpm.org-v6-mldsa87-test.asc: key 1 import failed.
-],
+[],
 [])
 
 RPMTEST_CHECK([
@@ -3181,7 +3172,7 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed-mldsa87.rpm
 ],
 [0],
 [/data/RPMS/hello-2.0-1.x86_64-signed-mldsa87.rpm:
-    Header OpenPGP V6 ML-DSA-87+Ed448/SHA512 signature, key ID db11ab41d7ae9cd3: NOTTRUSTED
+    Header OpenPGP V6 ML-DSA-87+Ed448/SHA512 signature, key fingerprint: aed054589cbf858445cfea63e827a16cc45ee27ff4b97d8eb8ec71d34684f4e6: OK
     Header OpenPGP V4 RSA/SHA512 signature, key fingerprint: 771b18d3d7baa28734333c424344591e1964c5fc: OK
     Header SHA256 digest: OK
     Payload SHA256 digest: OK

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2294,6 +2294,23 @@ Preparing packages...
 ],
 [	package hello-2.0-1.x86_64 does not verify: Header OpenPGP V4 EdDSA/SHA512 signature, key fingerprint: 152bb32fd9ca982797e835cfb0645aec757bf69e: NOTTRUSTED
 ])
+
+# importing key back should not work
+RPMTEST_CHECK([
+runroot rpmkeys --import /data/keys/rpm.org-nistp256-test.pub
+],
+[1],
+[],
+[stderr])
+
+RPMTEST_CHECK([
+grep "^error:" stderr
+],
+[0],
+[error: Certificate 7F1C21F95F65BBE8:
+error: /data/keys/rpm.org-nistp256-test.pub: key 1 import failed.
+],
+[])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpmsign --addsign legacy v6])


### PR DESCRIPTION
This is follow-up from #4116 where  we tested how untrusted signatures are handled (https://github.com/rpm-software-management/rpm-sequoia/pull/105). This is a respective test change related to rpm-software-management/rpm-sequoia/pull/109, which changed how `PubKeyLint` handles legacy algorithms.

Though, there are still some unanswered questions as it looks like the RPM behavior can be improved in some cases:
 * Importing certificate bundle with allowed and non-allowed key still exits with non-zero exit code. RHEL 10 has both classic and PQC keys in one file. This might be an issue for DNF.
 * Verifying RSA signatures that are disabled in crypto policies and where we miss the key from rpmdb still looks like returning NOKEY instead of NONTRUSTED error. This sounds like rpm-sequoia issue though. I will have to investigate this further.