### PR TITLE
Bump rpm-sequoia requirement to >= 1.10.2

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -59,7 +59,7 @@ RUN dnf -y install \
   sequoia-sq \
   nss-altfiles
 # If updates to specific packages are needed, do it here
-RUN dnf -y --enablerepo=updates install rpm-sequoia-devel-1.10.1
+RUN dnf -y --enablerepo=updates install "rpm-sequoia-devel >= 1.10.2"
 
 # Install some development tools
 RUN dnf -y install \

--- a/tests/rpmapi.at
+++ b/tests/rpmapi.at
@@ -56,10 +56,9 @@ runroot sed -i '/^nist/s/always/never/g' /etc/crypto-policies/back-ends/rpm-sequ
 runroot importkey /data/keys/rpm.org-nistp256-test.pub
 ],
 [1],
-dnl XXX For desired behavior, rpm-sequoia should return 3 (NOTTRUSTED) here
-[/data/keys/rpm.org-nistp256-test.pub key 1: 2
+[/data/keys/rpm.org-nistp256-test.pub key 1: 3
 ],
 [error: Certificate 7F1C21F95F65BBE8:
-  Policy rejects 7F1C21F95F65BBE8: Policy rejected asymmetric algorithm
+  Policy rejects 7F1C21F95F65BBE8: Policy rejected asymmetric algorithm, because NistP256 is not considered secure
 ])
 RPMTEST_CLEANUP


### PR DESCRIPTION
Fedora doesn't preserve intermediate updates, and now with rpm-sequoia 1.10.2 in the updates, CI started failing.

rpm-sequoia 1.20.2 fixes a previous wrong return in the test-suite, adjust for that too. But then we also need to require that version. Use a >= range for the version to avoid failure just because there's a newer version in the repository. That wouldn't have helped in this case though because the test result changes.
