### PR TITLE
Add compat links for rpmuncompress and rpm-setup-autosign

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,14 @@ install(DIRECTORY DESTINATION ${RPM_CONFIGDIR}/macros.d)
 install(DIRECTORY DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/rpm)
 install(FILES CONTRIBUTING.md COPYING CREDITS INSTALL README TYPE DOC)
 
+# Compat links for commands that moved from /usr/lib/rpm to bin
+foreach(cmd rpmuncompress rpm-setup-autosign)
+	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} \
+		-E create_symlink \
+			../../${CMAKE_INSTALL_BINDIR}/${cmd} \
+			\$ENV{DESTDIR}/${RPM_CONFIGDIR}/${cmd})")
+endforeach()
+
 add_custom_target(ChangeLog
 		   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		   COMMAND git log --no-merges --no-decorate


### PR DESCRIPTION
We moved rpmuncompress and rpm-setup-autosign from /usr/lib/rpm to the standard path in a698d1b6b18e430806c54755af56d47ac401e430 and 1f554d12f3b1dc6061c60fdda9f079e446925a79 which is a good thing but, if somebody is hardcoding those locations in their specs or scripts (and they would've had to, because they were outside the path), their stuff will break now. Which is a no-go now.

Cmake does its best to make a horror of this simple thing. We only want to do this at install-time to avoid confusing compat links pointing nowhere in the build directory. But to create links at install stage requires this bizarre execute_process() construct, with gotchas like `\$ENV{DESTDIR}` to go.

Related: #4148