### PR TITLE
Swap out rpmPopMacro with rpmUndefineMacro in public facing functions

### DIFF
--- a/python/rpmmacro-py.c
+++ b/python/rpmmacro-py.c
@@ -29,7 +29,7 @@ rpmmacro_DelMacro(PyObject * self, PyObject * args, PyObject * kwds)
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "s:DelMacro", kwlist, &name))
 	return NULL;
 
-    rpmPopMacro(NULL, name);
+    rpmUndefineMacro(NULL, name);
 
     Py_RETURN_NONE;
 }

--- a/rpmio/rpmlua.cc
+++ b/rpmio/rpmlua.cc
@@ -1323,7 +1323,7 @@ static int mc_newindex(lua_State *L)
     rpmMacroContext *mc = checkmc(L, 1);
     const char *name = luaL_checkstring(L, 2);
     if (lua_isnil(L, 3)) {
-	if (rpmPopMacro(*mc, name))
+	if (rpmUndefineMacro(*mc, name))
 	    luaL_error(L, "error undefining macro %s", name);
     } else {
 	const char *body = luaL_checkstring(L, 3);


### PR DESCRIPTION
Fixes #4203 

Two public facing functions had rpmPopMacro instead of rpmUndefineMacro.  Finishes the push by commit 47b005e67ab9e00539d03bf53de837f0613e7130 to update to function with error checking.