### PR TITLE
Fix installation of 7zip in Dockerfile

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -48,7 +48,7 @@ RUN dnf -y install \
   which \
   elfutils binutils \
   findutils sed grep gawk diffutils file patch \
-  tar unzip gzip bzip2 cpio xz p7zip \
+  tar unzip gzip bzip2 cpio xz 7zip 7zip-standalone \
   pkgconfig \
   /usr/bin/systemd-sysusers \
   gdb-headless \


### PR DESCRIPTION
The package providing /usr/bin/7za is now called 7zip-standalone (with a compat provide p7zip) so update the name accordingly.

While at it, also install the "full" 7zip package (3 MB) that provides the /usr/bin/7z binary, to make the image compatible with development hosts that use that package (as our CMake config will fall back to 7z if 7za is not found).