### PR TITLE
Report meaningful operation names in syslog output

### DIFF
--- a/docs/man/rpm-plugin-syslog.8.scd
+++ b/docs/man/rpm-plugin-syslog.8.scd
@@ -11,8 +11,14 @@ like transactions run and packages installed or removed.
 
 # CONFIGURATION
 
-There are currently no options for this plugin in particular. See
-*rpm-plugins*(8) on how to control plugins in general.
+*%\_\_transaction\_syslog\_target*
+	Specify target output for the plugin. Supported values are:
+	- *syslog*: system log (default)
+	- *stderr*: standard error
+
+See *rpm-plugins*(8) on how to control plugins in general.
+
+# OUTPUT
 
 # SEE ALSO
 

--- a/docs/man/rpm-plugin-syslog.8.scd
+++ b/docs/man/rpm-plugin-syslog.8.scd
@@ -20,6 +20,50 @@ See *rpm-plugins*(8) on how to control plugins in general.
 
 # OUTPUT
 
+The plugin uses *rpm* as its syslog identity.
+
+The package level output during transactions is as follows:
+
+_OPERATION_ _NEVRA_ [*(from:* _RELNEVRA_*)*]*:* _STATUS_
+
+_OPERATION_ is one of:
+- *cleanup*: cleanup of the previous version in *upgrade* or *downgrade*
+- *downgrade*: downgrade an installed package to an older version
+- *erase*: erase package from the system
+- *install*: install a new package on the system
+- *replace*: replace (obsolete) a previously installed package with another one
+- *restore*: restore permissions and similar on an installed package
+- *upgrade*: upgrade an installed package to a newer version
+
+_NEVRA_ identifies the transaction element being operated on.
+Note that operations *downgrade*, *replace* and *upgrade* consist of two
+elements: install of one package version and removal of another.
+In these cases, the related element identifier _RELNEVRA_ is indicated
+in parentheses after *from:*.  _STATUS_ is one of *success* or *failure*.
+
+# EXAMPLES
+
+*journalctl -t rpm*
+	Inspect RPM transaction history on a systemd-based OS.
+
+*Package aaa upgrade from 1.2-1 to 2.0-1*
+```
+upgrade: aaa-2.0-1.noarch (from: aaa-1.2-1.noarch): success
+cleanup: aaa-1.2-1.noarch (from: aaa-2.0-1.noarch): success
+```
+
+*Package bbb 1.3-5 obsoleting aaa 1.2-1*
+```
+replace: bbb-1.3-5.noarch (from: aaa-1.2-1.noarch): success
+erase: aaa-1.2-1.noarch (from: bbb-1.3-5.noarch): success
+```
+
+*Package aaa 1.2-1 install failure*
+```
+install: aaa-1.2-1.noarch: failure
+```
+
 # SEE ALSO
 
-*rpm*(8), *rpm-plugins*(8)
+*rpm*(8), *rpm-plugins*(8), *rpm-version*(7)
+*journalctl*(1) *syslog*(3)

--- a/plugins/syslog.c
+++ b/plugins/syslog.c
@@ -6,6 +6,7 @@
 
 #include <rpm/rpmlog.h>
 #include <rpm/rpmmacro.h>
+#include <rpm/rpmver.h>
 #include <rpm/rpmstring.h>
 #include <rpm/rpmts.h>
 #include <rpm/rpmplugin.h>
@@ -16,6 +17,7 @@ struct logstat {
     int logging;
     unsigned int scriptfail;
     unsigned int pkgfail;
+    rpmts ts;
     loggerfunc log;
 };
 
@@ -31,7 +33,6 @@ static void errlog(int prio, const char *fmt, ...)
 
 static rpmRC syslog_init(rpmPlugin plugin, rpmts ts)
 {
-    /* XXX make this configurable? */
     const char * log_ident = "rpm";
     struct logstat * state = rcalloc(1, sizeof(*state));
     char *target = rpmExpand("%{?__transaction_syslog_target}", NULL);
@@ -65,6 +66,7 @@ static rpmRC syslog_tsm_pre(rpmPlugin plugin, rpmts ts)
     struct logstat * state = rpmPluginGetData(plugin);
     
     /* Reset counters */
+    state->ts = ts;
     state->scriptfail = 0;
     state->pkgfail = 0;
 
@@ -103,15 +105,89 @@ static rpmRC syslog_tsm_post(rpmPlugin plugin, rpmts ts, int res)
     return RPMRC_OK;
 }
 
-static const char *getOp(rpmte te)
+static rpmte findDependent(rpmts ts, rpmte te)
 {
-    switch (rpmteType(te)) {
-    case TR_ADDED:	return "install";
-    case TR_REMOVED:	return "erase";
-    case TR_RPMDB:	return "rpmdb";
-    case TR_RESTORED:	return "restore";
+    rpmte dep = NULL;
+    rpmte p = NULL;
+    rpmtsi pi = rpmtsiInit(ts);
+    while ((p = rpmtsiNext(pi, 0)) != NULL) {
+	if (rpmteDependsOn(p) == te) {
+	    dep = p;
+	    break;
+	}
     }
-    return "<unknown>";
+    rpmtsiFree(pi);
+
+    return dep;
+}
+
+static int isObsolete(rpmte a, rpmte b)
+{
+    return strcmp(rpmteN(a), rpmteN(b));
+}
+
+static int isDowngrade(rpmte a, rpmte b)
+{
+    int downgrade = 0;
+    rpmver av = rpmverParse(rpmteEVR(a));
+    rpmver bv = rpmverParse(rpmteEVR(b));
+
+    if (av && bv && rpmverCmp(av, bv) < 0)
+	downgrade = 1;
+
+    rpmverFree(av);
+    rpmverFree(bv);
+    return downgrade;
+}
+
+static char *getOp(rpmts ts, rpmte te)
+{
+    char *ret = NULL;
+    const char *op = NULL;
+    rpmte dep = NULL;
+
+    switch (rpmteType(te)) {
+    case TR_ADDED:
+	dep = findDependent(ts, te);
+	if (dep) {
+	    if (isObsolete(te, dep)) {
+		op = "replace";
+	    } else {
+		op = isDowngrade(te, dep) ? "downgrade" : "upgrade";
+	    }
+	} else {
+	    op = "install";
+	}
+	break;
+    case TR_REMOVED:
+	dep = rpmteDependsOn(te);
+	if (dep && !isObsolete(te, dep)) {
+	    op = "cleanup";
+	} else {
+	    op = "erase";
+	}
+	break;
+    case TR_RPMDB:
+	/* not an operation */
+	break;
+    case TR_RESTORED:
+	op = "restore";
+	break;
+    default:
+	op = "<unknown>";
+	break;
+    }
+
+    if (op) {
+	if (dep) {
+	    rasprintf(&ret, "%s: %s (from: %s)", op,
+			rpmteNEVRA(te), rpmteNEVRA(dep));
+	} else {
+	    rasprintf(&ret, "%s: %s", op, rpmteNEVRA(te));
+	}
+    }
+
+    return ret;
 }
 
 static rpmRC syslog_psm_post(rpmPlugin plugin, rpmte te, int res)
@@ -120,10 +196,8 @@ static rpmRC syslog_psm_post(rpmPlugin plugin, rpmte te, int res)
 
     if (state->logging) {
 	int lvl = LOG_NOTICE;
-	const char *op = getOp(te);
+	char *op = getOp(state->ts, te);
 	const char *outcome = "success";
-	/* XXX: Permit configurable header queryformat? */
-	const char *pkg = rpmteNEVRA(te);
 
 	if (res != RPMRC_OK) {
 	    lvl = LOG_WARNING;
@@ -131,7 +205,8 @@ static rpmRC syslog_psm_post(rpmPlugin plugin, rpmte te, int res)
 	    state->pkgfail++;
 	}
 
-	state->log(lvl, "%s %s: %s", op, pkg, outcome);
+	state->log(lvl, "%s: %s", op, outcome);
+	free(op);
     }
     return RPMRC_OK;
 }

--- a/plugins/syslog.c
+++ b/plugins/syslog.c
@@ -1,34 +1,63 @@
 #include "system.h"
 
+#include <stdarg.h>
 #include <stdlib.h>
 #include <syslog.h>
 
+#include <rpm/rpmlog.h>
+#include <rpm/rpmmacro.h>
 #include <rpm/rpmstring.h>
 #include <rpm/rpmts.h>
 #include <rpm/rpmplugin.h>
+
+typedef void (*loggerfunc)(int prio, const char *fmt, ...);
 
 struct logstat {
     int logging;
     unsigned int scriptfail;
     unsigned int pkgfail;
+    loggerfunc log;
 };
+
+static void errlog(int prio, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
+}
 
 static rpmRC syslog_init(rpmPlugin plugin, rpmts ts)
 {
     /* XXX make this configurable? */
     const char * log_ident = "rpm";
     struct logstat * state = rcalloc(1, sizeof(*state));
+    char *target = rpmExpand("%{?__transaction_syslog_target}", NULL);
+
+    if (rstreq(target, "stderr")) {
+	state->log = errlog;
+    } else {
+	if (*target && !rstreq(target, "syslog")) {
+	    rpmlog(RPMLOG_WARNING,
+		_("unknown syslog target %s, using 'syslog'\n"), target);
+	}
+	state->log = syslog;
+	openlog(log_ident, (LOG_PID), LOG_USER);
+    }
 
     rpmPluginSetData(plugin, state);
-    openlog(log_ident, (LOG_PID), LOG_USER);
+    free(target);
     return RPMRC_OK;
 }
 
 static void syslog_cleanup(rpmPlugin plugin)
 {
     struct logstat * state = rpmPluginGetData(plugin);
+    if (state->log == syslog)
+	closelog();
     free(state);
-    closelog();
 }
 
 static rpmRC syslog_tsm_pre(rpmPlugin plugin, rpmts ts)
@@ -51,7 +80,7 @@ static rpmRC syslog_tsm_pre(rpmPlugin plugin, rpmts ts)
 	state->logging = 0;
 
     if (state->logging) {
-	syslog(LOG_NOTICE, "Transaction ID %x started", rpmtsGetTid(ts));
+	state->log(LOG_NOTICE, "Transaction ID %x started", rpmtsGetTid(ts));
     }
 
     return RPMRC_OK;
@@ -63,10 +92,10 @@ static rpmRC syslog_tsm_post(rpmPlugin plugin, rpmts ts, int res)
 
     if (state->logging) {
 	if (state->pkgfail || state->scriptfail) {
-	    syslog(LOG_WARNING, "%u elements failed, %u scripts failed",
+	    state->log(LOG_WARNING, "%u elements failed, %u scripts failed",
 		   state->pkgfail, state->scriptfail);
 	}
-	syslog(LOG_NOTICE, "Transaction ID %x finished: %d",
+	state->log(LOG_NOTICE, "Transaction ID %x finished: %d",
 		rpmtsGetTid(ts), res);
     }
 
@@ -102,7 +131,7 @@ static rpmRC syslog_psm_post(rpmPlugin plugin, rpmte te, int res)
 	    state->pkgfail++;
 	}
 
-	syslog(lvl, "%s %s: %s", op, pkg, outcome);
+	state->log(lvl, "%s %s: %s", op, pkg, outcome);
     }
     return RPMRC_OK;
 }
@@ -113,7 +142,7 @@ static rpmRC syslog_scriptlet_post(rpmPlugin plugin,
     struct logstat * state = rpmPluginGetData(plugin);
 
     if (state->logging && res) {
-	syslog(LOG_WARNING, "scriptlet %s failure: %d\n", s_name, res);
+	state->log(LOG_WARNING, "scriptlet %s failure: %d\n", s_name, res);
 	state->scriptfail++;
     }
     return RPMRC_OK;

--- a/tests/data/SPECS/logtest.spec
+++ b/tests/data/SPECS/logtest.spec
@@ -1,0 +1,11 @@
+Name: %{myname}
+Version: %{myver}
+Release: %{myrel}
+License: Public domain
+Summary: Minimal test spec
+BuildArch: noarch
+%{?mydep}
+
+%description
+
+%files

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -2158,3 +2158,80 @@ runroot rpm -U --nosignature /data/RPMS/mwe-rpm-lua-problem-1.0.0-1.noarch.rpm
 ],
 [])
 RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([syslog plugin])
+AT_KEYWORDS([install plugin])
+runroot rpmbuild -bb \
+	--define "myname aaa" --define "myver 1.2" --define "myrel 1" \
+	/data/SPECS/logtest.spec
+runroot rpmbuild -bb \
+	--define "myname aaa" --define "myver 2.0" --define "myrel 1" \
+	/data/SPECS/logtest.spec
+runroot rpmbuild -bb \
+	--define "myname bbb" --define "myver 1.3" --define "myrel 5" \
+	--define "mydep Obsoletes: aaa <= 2.0" \
+	/data/SPECS/logtest.spec
+
+RPMTEST_CHECK([
+runroot --setenv SOURCE_DATE_EPOCH 1 \
+	rpm -U --define "%__transaction_syslog_target stderr" \
+		/build/RPMS/noarch/aaa-1.2-1.noarch.rpm
+],
+[0],
+[],
+[Transaction ID 1 started
+install: aaa-1.2-1.noarch: success
+Transaction ID 1 finished: 0
+])
+
+RPMTEST_CHECK([
+runroot --setenv SOURCE_DATE_EPOCH 2 \
+	rpm -U --define "%__transaction_syslog_target stderr" \
+		/build/RPMS/noarch/aaa-2.0-1.noarch.rpm
+],
+[0],
+[],
+[Transaction ID 2 started
+upgrade: aaa-2.0-1.noarch (from: aaa-1.2-1.noarch): success
+cleanup: aaa-1.2-1.noarch (from: aaa-2.0-1.noarch): success
+Transaction ID 2 finished: 0
+])
+
+RPMTEST_CHECK([
+runroot --setenv SOURCE_DATE_EPOCH 2 \
+	rpm -U --oldpackage --define "%__transaction_syslog_target stderr" \
+		/build/RPMS/noarch/aaa-1.2-1.noarch.rpm
+],
+[0],
+[],
+[Transaction ID 2 started
+downgrade: aaa-1.2-1.noarch (from: aaa-2.0-1.noarch): success
+cleanup: aaa-2.0-1.noarch (from: aaa-1.2-1.noarch): success
+Transaction ID 2 finished: 0
+])
+
+RPMTEST_CHECK([
+runroot --setenv SOURCE_DATE_EPOCH 3 \
+	rpm -U --define "%__transaction_syslog_target stderr" \
+		/build/RPMS/noarch/bbb-1.3-5.noarch.rpm
+],
+[0],
+[],
+[Transaction ID 3 started
+replace: bbb-1.3-5.noarch (from: aaa-1.2-1.noarch): success
+erase: aaa-1.2-1.noarch (from: bbb-1.3-5.noarch): success
+Transaction ID 3 finished: 0
+])
+
+RPMTEST_CHECK([
+runroot --setenv SOURCE_DATE_EPOCH 4 \
+	rpm -e --define "%__transaction_syslog_target stderr" \
+		bbb
+],
+[0],
+[],
+[Transaction ID 4 started
+erase: bbb-1.3-5.noarch: success
+Transaction ID 4 finished: 0
+])
+RPMTEST_CLEANUP


### PR DESCRIPTION
Determine and output human understandable operations, including the related transaction elements where relevant and explain it in the manual. Drop the comment about making things more configurable, that's not helpful to the community (except perhaps if the default is bad, as it originally was).

Add tests now that we can actually test it.

The first commit is just a means to make the output reasonably testable without having to hook up a syslogger into the container and then filter all the datestamps and all out of it etc.

Related: RHEL-155272