### PR TITLE
rpmsign: handle _file_sign_key_id values greater than i32::MAX

### DIFF
--- a/sign/rpmgensig.cc
+++ b/sign/rpmgensig.cc
@@ -5,6 +5,7 @@
 
 #include "system.h"
 
+#include <algorithm>
 #include <errno.h>
 #include <sys/wait.h>
 #include <popt.h>
@@ -549,7 +550,13 @@ static rpmRC includeFileSignatures(Header *sigp, Header *hdrp)
     rpmRC rc;
     char *key = rpmExpand("%{?_file_signing_key}", NULL);
     char *keypass = rpmExpand("%{?_file_signing_key_password}", NULL);
-    uint32_t keyid = rpmExpandNumeric("%{?_file_signing_key_id}");
+    auto [ ign, keyid ] = rpm::macros().expand_numeric("%{?_file_signing_key_id}");
+    if (keyid < 0 || keyid > std::numeric_limits<uint32_t>::max()) {
+	rpmlog(RPMLOG_ERR, _("invalid %%_file_signing_key_id value; must fit into an unsigned 32 bit integer\n"));
+	free(keypass);
+	free(key);
+	return RPMRC_FAIL;
+    }
 
     if (rstreq(keypass, "")) {
 	free(keypass);

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2513,6 +2513,14 @@ gpg2 --import /data/keys/rpm.org-rsa-2048-test.secret
 rpmsign --key-id 4344591E1964C5FC --addsign --signfiles --fskpath=/data/keys/privkey.pem /tmp/hello-2.0-1.x86_64.rpm
 
 RPMTEST_CHECK([[
+rpmsign --key-id 4344591E1964C5FC --addsign --signfiles --fskpath=/data/keys/privkey.pem --define "_file_signing_key_id 9000000000" /tmp/hello-2.0-1.x86_64.rpm
+]],
+[1],
+[],
+[error: invalid %_file_signing_key_id value; must fit into an unsigned 32 bit integer
+])
+
+RPMTEST_CHECK([[
 rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" /tmp/hello-2.0-1.x86_64.rpm | sed 's/:[^(none)].\+$/:(...)/'
 rpm -qp --qf "[%{filenames}:%{filesignatures}\n]" /data/RPMS/imatest-1.0-1.fc34.noarch.rpm
 ]],
@@ -2615,7 +2623,7 @@ OSSL_EOF
 
 cp /data/RPMS/hello-2.0-1.x86_64.rpm /tmp/
 rpmsign --addsign --key-id 4344591E1964C5FC --signfiles \
-  --define='_file_signing_key_id 42' \
+  --define='_file_signing_key_id 3846977987' \
   --fskpath="pkcs11:token=${token_label};id=%01;type=private?pin-value=${token_pin}" \
   /tmp/hello-2.0-1.x86_64.rpm
 ]],


### PR DESCRIPTION
The file signing key ID is an unsigned 32 bit value derived (typically) from the last 4 bytes of the certificate's Subject Key ID field. If this happens to be larger than a signed int's max value, rpmExpandNumeric clamps it to be i32::MAX. This will result in the wrong value being embedded in the IMA signature.

Use the C++ expand_numeric which returns an int64_t, which is enough to parse any valid keyid.

Fixes: commit b186b739bb6d ("rpmsign: enable signing files with PKCS11 tokens")

Note: I hit this while testing the 6.1.0 RC, so ideally it gets included in the 6.1.0 final release.