### PR TITLE
Add support for database parking

### DIFF
--- a/docs/man/rpmdb.8.scd
+++ b/docs/man/rpmdb.8.scd
@@ -4,34 +4,38 @@ RPMDB(8)
 rpmdb - RPM Database Tool
 
 # SYNOPSIS
-*rpmdb* [options] {*--initdb*|*--rebuilddb*}
+## Maintenance
+*rpmdb* [options] {*--initdb*|*--rebuilddb*|*--parkdb*}
 
+## Diagnostics
 *rpmdb* [options] {*--verifydb*}
 
+## Migration
 *rpmdb* [options] {*--exportdb*|*--importdb*}
 
 # DESCRIPTION
-The *rpmdb* is used for *rpm* database maintenance operations.
+The *rpmdb* tool is used for low-level *rpm* database operations.
 
 # OPERATIONS
+## Maintenance
 *--initdb*
 	Create a new database if one doesn't already exist. An
 	existing database is not overwritten.
 
 *--rebuilddb*
-	Rebuild database from the installed package headers.
-	Rebuilding discards any unreadable (corrupt) headers
-	from the database, but also compacts the database in
-	case it has grown large over time.
+	Rebuild the database from the installed package headers. Discards any
+	unreadable (corrupt) headers and compacts the database in case it has
+	grown large over time.
 
-	Can also be used to convert between different *rpmdb*
-	formats.
+	Can also be used to convert between different *rpmdb* formats.
 
+## Diagnostics
 *--verifydb*
 	Perform a low-level integrity check on the database.
 	Rarely useful, for system health *rpm --verify -a* is a far more
 	meaningful operation.
 
+## Migration
 *--exportdb*
 	Export the database in header-list format, suitable
 	for transporting to another host or database type.
@@ -58,7 +62,7 @@ On success, 0 is returned, a nonzero failure code otherwise.
 	Initialize a new database in _/tmp/testdb_ directory.
 
 *rpmdb --rebuilddb*
-	Rebuild the system rpmdb.
+	Rebuild the system database.
 
 *rpmdb --verifydb --root /mnt*
 	Verify the system database of a system image mounted

--- a/docs/man/rpmdb.8.scd
+++ b/docs/man/rpmdb.8.scd
@@ -29,6 +29,19 @@ The *rpmdb* tool is used for low-level *rpm* database operations.
 
 	Can also be used to convert between different *rpmdb* formats.
 
+*--parkdb*
+	Park the database. Prepares and optimizes the database for inclusion on
+	read-only media, such as immutable OS images.
+
+	Write operations, such as RPM transactions, will unpark the database and
+	continue normally, leaving the database unparked when finished. Thus, to
+	unpark manually, use *--rebuilddb*.
+
+	Depending on the backend used, this operation may include the removal of
+	auxiliary, backend-specific files from disk, such as the write-ahead log
+	or shared memory index, and thus facilitate bit-for-bit reproducible OS
+	images.
+
 ## Diagnostics
 *--verifydb*
 	Perform a low-level integrity check on the database.
@@ -63,6 +76,9 @@ On success, 0 is returned, a nonzero failure code otherwise.
 
 *rpmdb --rebuilddb*
 	Rebuild the system database.
+
+*rpmdb --parkdb*
+	Park the system database prior to inclusion on read-only media.
 
 *rpmdb --verifydb --root /mnt*
 	Verify the system database of a system image mounted

--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -326,6 +326,13 @@ int rpmtsSetDBMode(rpmts ts, int dbmode);
 int rpmtsRebuildDB(rpmts ts);
 
 /** \ingroup rpmts
+ * Park the database used by the transaction.
+ * @param ts		transaction set
+ * @return		0 on success
+ */
+int rpmtsParkDB(rpmts ts);
+
+/** \ingroup rpmts
  * Verify the database used by the transaction.
  * @param ts		transaction set
  * @return		0 on success

--- a/lib/backend/dbi.hh
+++ b/lib/backend/dbi.hh
@@ -16,6 +16,7 @@ enum rpmdbFlags {
     RPMDB_FLAG_REBUILD		= (1 << 1),
     RPMDB_FLAG_VERIFYONLY	= (1 << 2),
     RPMDB_FLAG_SALVAGE		= (1 << 3),
+    RPMDB_FLAG_PARK		= (1 << 4),
 };
 
 typedef enum dbCtrlOp_e {

--- a/lib/backend/sqlite.cc
+++ b/lib/backend/sqlite.cc
@@ -214,6 +214,19 @@ static int sqlite_fini(rpmdb rdb)
 		sqlexec(sdb, "PRAGMA optimize");
 		sqlexec(sdb, "PRAGMA wal_checkpoint = TRUNCATE");
 
+		/* Park the database if requested */
+		if ((rdb->db_flags & RPMDB_FLAG_PARK) != 0) {
+		    int zero = 0;
+		    /* Make sure any WAL and SHM files are cleaned up */
+		    sqlite3_file_control(sdb, NULL, SQLITE_FCNTL_PERSIST_WAL,
+					 &zero);
+		    rc = sqlexec(sdb, "PRAGMA journal_mode = DELETE");
+		    if (rc == 0)
+			rpmlog(RPMLOG_DEBUG, _("rpmdb sqlite parking done\n"));
+		    else
+			rpmlog(RPMLOG_ERR, _("rpmdb sqlite parking failed\n"));
+		}
+
 		int max_size = rpmExpandNumeric("%{?_sqlite_vacuum_kb}");
 		if (max_size <= 0)
 		    max_size = 20*1024;
@@ -228,7 +241,7 @@ static int sqlite_fini(rpmdb rdb)
 	    }
 	    rdb->db_dbenv = NULL;
 	    int xx = sqlite3_close(sdb);
-	    rc = (xx != SQLITE_OK);
+	    rc += (xx != SQLITE_OK);
 	}
     }
 
@@ -357,7 +370,7 @@ static int sqlite_Close(dbiIndex dbi, unsigned int flags)
     int rc = 0;
     if (rdb->db_flags & RPMDB_FLAG_REBUILD)
 	rc = init_index(dbi, rpmTagGetValue(dbi->dbi_file));
-    sqlite_fini(dbi->dbi_rpmdb);
+    rc += sqlite_fini(dbi->dbi_rpmdb);
     dbiFree(dbi);
     return rc;
 }

--- a/lib/rpmdb.cc
+++ b/lib/rpmdb.cc
@@ -2407,7 +2407,9 @@ int rpmdbRebuild(const char * prefix, rpmts ts,
 	goto exit;
     }
     if (openDatabase(prefix, newdbpath, &newdb,
-		     (O_RDWR | O_CREAT), 0644, RPMDB_FLAG_REBUILD)) {
+		     (O_RDWR | O_CREAT), 0644, RPMDB_FLAG_REBUILD |
+		     (rebuildflags & RPMDB_REBUILD_FLAG_PARK ?
+		         RPMDB_FLAG_PARK : 0))) {
 	rc = 1;
 	goto exit;
     }
@@ -2444,7 +2446,8 @@ int rpmdbRebuild(const char * prefix, rpmts ts,
 
     rpmdbClose(olddb);
     dbCtrl(newdb, DB_CTRL_INDEXSYNC);
-    rpmdbClose(newdb);
+    if (rpmdbClose(newdb))
+	failed = 1;
 
     if (failed) {
 	rpmlog(RPMLOG_WARNING, 

--- a/lib/rpmdb_internal.hh
+++ b/lib/rpmdb_internal.hh
@@ -13,6 +13,7 @@ using packageHash = std::unordered_map<unsigned int,rpmte>;
 
 enum rpmdbRebuildFlags_e {
     RPMDB_REBUILD_FLAG_SALVAGE	= (1 << 0),
+    RPMDB_REBUILD_FLAG_PARK	= (1 << 1),
 };
 
 /** \ingroup rpmdb

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -141,11 +141,10 @@ int rpmtsSetDBMode(rpmts ts, int dbmode)
     return rc;
 }
 
-int rpmtsRebuildDB(rpmts ts)
+static int rebuildDB(rpmts ts, int rebuildflags)
 {
     int rc = -1;
     rpmtxn txn = NULL;
-    int rebuildflags = 0;
 
     /* Cannot do this on a populated transaction set */
     if (rpmtsNElements(ts) > 0)
@@ -166,6 +165,11 @@ int rpmtsRebuildDB(rpmts ts)
     }
 
     return rc;
+}
+
+int rpmtsRebuildDB(rpmts ts)
+{
+    return rebuildDB(ts, 0);
 }
 
 int rpmtsVerifyDB(rpmts ts)

--- a/lib/rpmts.cc
+++ b/lib/rpmts.cc
@@ -172,6 +172,11 @@ int rpmtsRebuildDB(rpmts ts)
     return rebuildDB(ts, 0);
 }
 
+int rpmtsParkDB(rpmts ts)
+{
+    return rebuildDB(ts, RPMDB_REBUILD_FLAG_PARK);
+}
+
 int rpmtsVerifyDB(rpmts ts)
 {
     int rc = -1;

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -375,6 +375,18 @@ rpmts_RebuildDB(rpmtsObject * s)
 }
 
 static PyObject *
+rpmts_ParkDB(rpmtsObject * s)
+{
+    int rc;
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = rpmtsParkDB(s->ts);
+    Py_END_ALLOW_THREADS
+
+    return Py_BuildValue("i", rc);
+}
+
+static PyObject *
 rpmts_VerifyDB(rpmtsObject * s)
 {
     int rc;
@@ -839,6 +851,9 @@ Remove all elements from the transaction set\n" },
  {"rebuildDB",	(PyCFunction) rpmts_RebuildDB,	METH_NOARGS,
 "ts.rebuildDB() -> None\n\
 - Rebuild the default transaction rpmdb.\n" },
+ {"parkDB",	(PyCFunction) rpmts_ParkDB,	METH_NOARGS,
+"ts.parkDB() -> None\n\
+- Park the default transaction rpmdb.\n" },
  {"verifyDB",	(PyCFunction) rpmts_VerifyDB,	METH_NOARGS,
 "ts.verifyDB() -> None\n\
 - Verify the default transaction rpmdb.\n" },

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -780,3 +780,90 @@ D: rpmdb sqlite backend VACUUM maxfree: 1kB, free: 8kB -> 0kB
 ],
 [])
 RPMTEST_CLEANUP
+
+# ------------------------------
+RPMTEST_SETUP_RW([rpmdb --parkdb])
+RPMTEST_USER
+AT_KEYWORDS([install rpmdb sqlite])
+# this is only relevant with sqlite db, make sure we get one
+echo "%_db_backend sqlite" >> $RPMTEST/root/.config/rpm/macros
+RPMDB_RESET
+
+runroot rpm -U --nodeps --ignorearch --ignoreos --nosignature \
+	/data/RPMS/capstest-1.0-1.noarch.rpm
+DBPATH=$RPMTEST/$(rpm --eval '%_dbpath')
+
+# Assert unparked state
+RPMTEST_CHECK([
+cd $DBPATH; ls
+],
+[0],
+[rpmdb.sqlite
+rpmdb.sqlite-shm
+rpmdb.sqlite-wal
+],
+[])
+
+# Park
+RPMTEST_CHECK([
+runroot rpmdb --parkdb || exit $?
+cd $DBPATH; ls
+],
+[0],
+[rpmdb.sqlite
+],
+[])
+
+# Query with read-only database should not fail
+RPMTEST_CHECK([
+mkdir $PWD/rpmdb
+mount -o bind,ro $DBPATH $PWD/rpmdb
+rpm --dbpath $PWD/rpmdb -qa || exit $?
+umount -ql $PWD/rpmdb
+],
+[0],
+[capstest-1.0-1.noarch
+],
+[])
+
+# Query with writable database should not unpark
+RPMTEST_CHECK([
+runroot rpm -qa || exit $?
+cd $DBPATH; ls
+],
+[0],
+[capstest-1.0-1.noarch
+rpmdb.sqlite
+],
+[])
+
+# Implicit unpark
+RPMTEST_CHECK([
+runroot rpm -e capstest || exit $?
+cd $DBPATH; ls
+],
+[0],
+[rpmdb.sqlite
+rpmdb.sqlite-shm
+rpmdb.sqlite-wal
+],
+[])
+
+# Explicit unpark
+RPMTEST_CHECK([
+runroot rpmdb --parkdb || exit $?
+cd $DBPATH; ls
+echo ---
+runroot rpmdb --rebuilddb || exit $?
+cd $DBPATH; ls
+],
+[0],
+[rpmdb.sqlite
+---
+rpmdb.sqlite
+rpmdb.sqlite-shm
+rpmdb.sqlite-wal
+],
+[])
+
+RPMTEST_CLEANUP

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -695,6 +695,44 @@ print(c1 != c2)
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([database parking])
+AT_KEYWORDS([python rpmdb])
+# this is only relevant with sqlite db, make sure we get one
+echo "%_db_backend sqlite" >> $RPMTEST/root/.config/rpm/macros
+RPMDB_RESET
+
+DBPATH=$RPMTEST/$(rpm --eval '%_dbpath')
+
+# Assert unparked state
+RPMTEST_CHECK([
+cd $DBPATH; ls
+],
+[0],
+[rpmdb.sqlite
+rpmdb.sqlite-shm
+rpmdb.sqlite-wal
+],
+[])
+
+# Park
+RPMPY_CHECK([
+rc = ts.parkDB()
+print(rc)
+],
+[0
+],
+[])
+
+# Verify parked
+RPMTEST_CHECK([
+cd $DBPATH; ls
+],
+[0],
+[rpmdb.sqlite
+],
+[])
+RPMTEST_CLEANUP
+
 RPMPY_TEST([dependency sets 1],[
 h = ts.hdrFromFdno('${RPMDATA}/RPMS/hello-1.0-1.ppc64.rpm')
 for dep in rpm.ds(h, 'requires'):

--- a/tools/rpmdb.cc
+++ b/tools/rpmdb.cc
@@ -13,6 +13,7 @@ enum modes {
     MODE_EXPORTDB	= (1 << 3),
     MODE_IMPORTDB	= (1 << 4),
     MODE_SALVAGEDB	= (1 << 5),
+    MODE_PARKDB		= (1 << 6),
 };
 
 static int mode = 0;
@@ -23,6 +24,8 @@ static struct poptOption dbOptsTable[] = {
     { "rebuilddb", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR), &mode, MODE_REBUILDDB,
 	N_("rebuild database inverted lists from installed package headers"),
 	NULL},
+    { "parkdb", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR),
+	&mode, MODE_PARKDB, N_("park database"), NULL},
     { "verifydb", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR),
 	&mode, MODE_VERIFYDB, N_("verify database"), NULL},
     { "salvagedb", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR|POPT_ARGFLAG_DOC_HIDDEN),
@@ -118,6 +121,9 @@ int main(int argc, char *argv[])
 	ec = rpmtsRebuildDB(ts);
 	rpmtsSetVSFlags(ts, ovsflags);
     }	break;
+    case MODE_PARKDB:
+	ec = rpmtsParkDB(ts);
+	break;
     case MODE_VERIFYDB:
 	ec = rpmtsVerifyDB(ts);
 	break;


### PR DESCRIPTION
This adds `--parkdb` to `rpmdb(8)`, as per #2219 and RHEL-126405. Details in the commits.

Fixes: #2219