### PR TITLE
Document that --verify with --verbose can be used to show unchanged files.

### DIFF
--- a/docs/man/rpm.8.scd
+++ b/docs/man/rpm.8.scd
@@ -45,7 +45,9 @@ code and recipe necessary to produce binary packages.
 	the package with information about the files taken from the package
 	metadata stored in the *rpm* database. Among other things, verifying
 	compares the size, digest, permissions, type, owner and group of each
-	file. Any discrepancies are displayed.
+	file. By default, only files with discrepancies are displayed. Use
+	*--verbose* to display all verified files.
+
 *-q*,
 *--query*
 	Query package files or installed package(s).
@@ -602,6 +604,10 @@ On success, 0 is returned, a nonzero failure code otherwise.
 *rpm --verify --noconfig openssh-server*
 	Verify the integrity of the installed *openssh-server* package,
 	ignoring changes in configuration.
+
+*rpm --verify --configfiles --verbose logrotate*
+	List all config files of the installed *logrotate* package,
+	showing both changed and unchanged files.
 
 *rpm -qa*
 	List all installed packages, using the default formatting.


### PR DESCRIPTION
Useful when wondering if rpm actually verified files the user wanted verified.

Discovered by browsing the source files and finding `|| rpmIsVerbose()` at https://github.com/rpm-software-management/rpm/blob/98bcdb37397c23c6689ab64824875f4021a986ed/lib/verify.cc#L385, this documentation change makes this use case available to people who would not browse the sources.