### PR TITLE
Disable automatic maintenance also when autopatching -S git

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1249,6 +1249,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %{__git} config user.name "%{__scm_username}"\
 %{__git} config user.email "%{__scm_usermail}"\
 %{__git} config gc.auto 0\
+%{__git} config maintenance.auto false\
 %{__git} add --force .\
 GIT_COMMITTER_DATE=%{__scm_source_timestamp} GIT_AUTHOR_DATE=%{__scm_source_timestamp}\\\
 	%{__git} commit %{-q} --no-gpg-sign --allow-empty -a\\\


### PR DESCRIPTION
since https://github.com/git/git/commit/1942d48380fec53f76361e9adebef15b5db9628a , `maintenance.auto` is used to control whether `git maintenance run --auto` is called automatically after some commands.

As `gc.auto` is ignored in some [rare cases](https://github.com/git/git/commit/29364f16242abd490160f66d2d239ac45e1d45fb), setting `maintenance.auto` is need.