### PR TITLE
Fix typo in add_sysuser ternary

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1385,7 +1385,7 @@ end
     if type == 'groupmember' then
         print(string.format('%s%s(%s/%s) = %s\\n', prefix, type, name, arg[3], enc))
 	if (prefix ~= '') then
-	   prefix2 = rpm.expand('%[%{?_use_weak_usergroup_deps} > 0 : "Recommends" : "Requires"]')
+	   prefix2 = rpm.expand('%[%{?_use_weak_usergroup_deps} > 0 ? "Recommends" : "Requires"]')
 	   print(string.format('%s: user(%s)\\n', prefix2, name))
 	   print(string.format('%s: group(%s)\\n', prefix2, arg[3]))
 	end

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1783,7 +1783,6 @@ RPMTEST_CLEANUP
 
 RPMTEST_SETUP_RW([rpm -i create group membership])
 AT_KEYWORDS([install sysusers])
-AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMTEST_CHECK([
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser m myuser mygroup}"\

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1781,6 +1781,29 @@ runroot rpm -V ${VERIFYOPTS} deptest-user
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([rpm -i create group membership])
+AT_KEYWORDS([install sysusers])
+AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
+RPMTEST_CHECK([
+
+runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser m myuser mygroup}"\
+  /data/SPECS/deptest.spec
+echo Requires
+runroot rpm -q --requires /build/RPMS/noarch/deptest-user-1.0-1.noarch.rpm | grep -E "user|group"
+echo Provides
+runroot rpm -q --provides /build/RPMS/noarch/deptest-user-1.0-1.noarch.rpm | grep -E "user|group"
+],
+[0],
+[Requires
+group(mygroup)
+user(myuser)
+Provides
+deptest-user = 1.0-1
+groupmember(myuser/mygroup) = bSBteXVzZXIgbXlncm91cAAA
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([rpm -i sysusers])
 AT_KEYWORDS([install build sysusers])
 


### PR DESCRIPTION
Was resulting in the following error when trying to add a user to a group

```
error: syntax error in expression: %{?_use_weak_usergroup_deps} > 0 : "Recommends" : "Requires"
error:                                                              ^
error: lua script failed: [string "add_sysuser"]:35: error expanding macro
```