### PR TITLE
Use rpm's own allocator instead of malloc() almost everywhere

### DIFF
--- a/lib/tagexts.cc
+++ b/lib/tagexts.cc
@@ -903,7 +903,7 @@ static int epochnumTag(Header h, rpmtd td, headerGetFlags hgflags)
 {
     /* For consistency, always return malloced data */
     if (!headerGet(h, RPMTAG_EPOCH, td, HEADERGET_ALLOC)) {
-	uint32_t *e = (uint32_t *)malloc(sizeof(*e));
+	uint32_t *e = (uint32_t *)xmalloc(sizeof(*e));
 	*e = 0;
 	td->data = e;
 	td->type = RPM_INT32_TYPE;

--- a/rpmio/lposix.cc
+++ b/rpmio/lposix.cc
@@ -394,7 +394,7 @@ static int Pputenv(lua_State *L)		/** putenv(string) */
 #ifdef HAVE_PUTENV
 	size_t l;
 	const char *s=luaL_checklstring(L, 1, &l);
-	char *e=(char *)malloc(++l);
+	char *e=(char *)xmalloc(++l);
 	return pushresult(L, (e==NULL) ? -1 : putenv((char *)memcpy(e,s,l)), s);
 #else
 	return -1;

--- a/tools/rpmdump.cc
+++ b/tools/rpmdump.cc
@@ -1,3 +1,4 @@
+#include "system.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -8,6 +9,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include <rpm/rpmtag.h>
+#include "debug.h"
 
 struct entryInfo {
     uint32_t tag;
@@ -133,7 +135,7 @@ static int readhdr(int fd, int sighdr, const char *msg)
     indexLen = numEntries * sizeof(*entry);
     headerLen = indexLen + numBytes;
 
-    blob = (uint32_t *)malloc(sizeof(numEntries) + sizeof(numBytes) + headerLen);
+    blob = (uint32_t *)xmalloc(sizeof(numEntries) + sizeof(numBytes) + headerLen);
     blob[0] = htonl(numEntries);
     blob[1] = htonl(numBytes);
 


### PR DESCRIPTION
The rpm codebase relies on terminating allocation failure behavior practically everywhere. The epochnumTag() case is just a simple mistake, the others are in code that originated outside rpm and so were relying on C stdlib only. Fixes possible crashes in case of memory allocation failures in these spots.

misc/fts.c and rpmio/base64.cc still use plain malloc(), but they also check for the NULL returns so leaving them alone. In particular the base64 stuff is a documented public API with special code for malloc failure so seems safer to leave it alone.

Pointed out by Fedoras OpenScanHub static scanner.