### PR TITLE
Add optional branch information to VCS tag

### DIFF
--- a/docs/man/rpm-spec.5.scd
+++ b/docs/man/rpm-spec.5.scd
@@ -507,7 +507,14 @@ An example is shown in an indented block where applicable.
 	```
 
 *VCS:* _TEXT_
-	Upstream source code version control system location.
+	(Public) upstream source code VCS location. Two formats are
+	recommended. The traditional format is _<vcs>_:_<address>_ with
+	_<vcs>_ being the VCS command used (e.g. git, svn, hg, ...)
+	and _<address>_ being the location of the repository (e.g.
+	git:https://github.com/rpm-software-management/rpm.git). The
+	SPDX download location format is also recommended:
+	_<vcs>_+_<transport>_://_<host>_[/_<path>_][@_<revision\_tag\_or\_branch>_]
+	(e.g. git+https://github.com/rpm-software-management/rpm.git@main).
 
 	Properties: Ibs
 

--- a/docs/manual/tags.md
+++ b/docs/manual/tags.md
@@ -79,7 +79,7 @@ Sourcerpm          | 1044 | string       | Package source rpm file name.
 Translationurl     | 5100 | string       | URL of upstream translation service/repository
 UpstreamReleases   | 5101 | string       | URL to check for newer releases from upstream e.g. for build systems to check for newer upstream releases and then to notify the packager.
 Url                | 1020 | string       | Package URL, typically project upstream website.
-Vcs                | 5034 | string       | (Public) upstream source code VCS location. Format `<vcs>:<address>` with `<vcs>` being the VCS command used (e.g. `git`, `svn`, `hg`, ...) and `<address>` being the location of the repository as used by the VCS tool to clone/checkout the repository (e.g. `https://github.com/rpm-software-management/rpm.git`).
+Vcs                | 5034 | string       | (Public) upstream source code VCS location. See rpm-spec(5).
 Vendor             | 1011 | string       | Package vendor contact information.
 Sourcenevr         | 5120 | string       | Source RPM NEVR
 


### PR DESCRIPTION
The VCS tag defines the location of the repository, however, many packages also require specific branch information.  Fedora, for example, includes versioned packages for python (python3.14, python3.13, etc.), nodejs (nodejs26, nodejs25, etc.) and others including ruby and go.

These repositories also require a branch name to uniquely identify the upstream location of the repository.

Add an optional branch tag, starting with a hash '#', to the VCS tag.

Additional fix: I noticed that the VCS description in docs/manual/spec.md was empty.  I have updated it to reflect the same description.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>