### PR TITLE
Disable automatic git maintenance, too

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1249,6 +1249,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %{__git} config user.name "%{__scm_username}"\
 %{__git} config user.email "%{__scm_usermail}"\
 %{__git} config gc.auto 0\
+%{__git} config maintenance.auto false\
 %{__git} add --force .\
 GIT_COMMITTER_DATE=%{__scm_source_timestamp} GIT_AUTHOR_DATE=%{__scm_source_timestamp}\\\
 	%{__git} commit %{-q} --no-gpg-sign --allow-empty -a\\\


### PR DESCRIPTION
Git 2.30 (released in 2020) introduced the new maintenance.auto config option that avoids [1] extra process invocation that would previously happen even with gc.auto disabled (which we already disable).

This has recently [2] been changed so that disabling gc.auto has the same effect, but to let the users of older Git versions benefit from this feature, disable maintenance.auto explicitly as well. Git versions that don't know about the maintenance.auto option (< 2.30) will not mind if we set this option since it will simply be ignored.

Original patch by fundawang <fundawang@yeah.net>.

[1] Commit 1942d48380fec53f76361e9adebef15b5db9628a in Git
[2] Commit 29364f16242abd490160f66d2d239ac45e1d45fb in Git