### PR TITLE
Fix rpm2cpio truncation for zstd-compressed RPMs

### DIFF
--- a/rpmio/rpmio.cc
+++ b/rpmio/rpmio.cc
@@ -1206,8 +1206,19 @@ assert(zstd);
 	/* Re-fill compressed data buffer. */
 	if (zstd->zib.pos >= zstd->zib.size) {
 	    zstd->zib.size = fread(zstd->b.data(), 1, zstd->b.size(), zstd->fp);
-	    if (zstd->zib.size == 0)
+	    if (zstd->zib.size == 0) {
+		ZSTD_inBuffer zib_end = { NULL, 0, 0 };
+		size_t ret2;
+		do {
+		    ret2 = ZSTD_decompressStream(zstd->stream.d,
+				 &zob, &zib_end);
+		    if (ZSTD_isError(ret2)) {
+			fps->errcookie = ZSTD_getErrorName(ret2);
+			return -1;
+		    }
+		} while (ret2 > 0 && zob.pos < zob.size);
 		break;		/* EOF */
+	    }
 	    zstd->zib.src  = zstd->b.data();
 	    zstd->zib.pos  = 0;
 	}

--- a/scripts/rpm2cpio.sh
+++ b/scripts/rpm2cpio.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -efu
+#!/bin/sh -fu
 
 fatal() {
 	echo "$*" >&2
@@ -59,6 +59,6 @@ case "$(_dd $offset bs=2 count=1 | tr -d '\0')" in
 	"$(printf '\037\213')") _dd $offset | gunzip  ;; # '\x1f\x8b'
 	"$(printf '\375\067')") _dd $offset | xzcat   ;; # '\xfd\x37'
 	"$(printf '\135')") _dd $offset | unlzma      ;; # '\x5d\x00'
-	"$(printf '\050\265')") _dd $offset | unzstd  ;; # '\x28\xb5'
+	"$(printf '\050\265')") _dd $offset | unzstd -f ;; # '\x28\xb5'
 	*) fatal "Unrecognized payload compression format in rpm file: $pkg" ;;
 esac


### PR DESCRIPTION
zstd-compressed RPMs use streaming frames (fcs_field=0) without content size. When decompressing such payloads via `unzstd`:

1. `unzstd` exits with status 1 on streaming frames because the frame appears incomplete. The shell's `-e` flag causes rpm2cpio to terminate prematurely, truncating the output at a page-aligned boundary.

2. `unzstd` without `-f` drops the last byte of decompressed output.

**Fix:**
- Remove `-e` from the shebang (`#!/bin/sh -fu`)
- Add `-f` to `unzstd` invocation

**Tested:** RPM 4.18.2, zstd-compressed layer-shell-qt and xorg-x11-server packages. Before: output truncated at 4096-byte boundary. After: full 108769 and 3820608 bytes respectively, CPIO archives pass validation.