### PR TITLE
Avoid undefined behavior from signed integer shift wraparound

### DIFF
--- a/include/rpm/rpmbuild.h
+++ b/include/rpm/rpmbuild.h
@@ -40,7 +40,7 @@ enum rpmBuildFlags_e {
     RPMBUILD_CONF	= (1 << 22),	/*!< Execute %%conf. */
     RPMBUILD_MKBUILDDIR	= (1 << 23),	/*!< Internal use only */
 
-    RPMBUILD_NOBUILD	= (1 << 31)	/*!< Don't execute or package. */
+    RPMBUILD_NOBUILD	= (1U << 31)	/*!< Don't execute or package. */
 };
 
 typedef rpmFlags rpmBuildFlags;

--- a/include/rpm/rpmfc.h
+++ b/include/rpm/rpmfc.h
@@ -37,7 +37,7 @@ enum FCOLOR_e {
 
     RPMFC_WHITE			= (1 << 29),
     RPMFC_INCLUDE		= (1 << 30),
-    RPMFC_ERROR			= (1 << 31)
+    RPMFC_ERROR			= (1U << 31)
 };
 
 /** \ingroup rpmfc

--- a/include/rpm/rpmfiles.h
+++ b/include/rpm/rpmfiles.h
@@ -88,7 +88,7 @@ enum rpmVerifyAttrs_e {
     RPMVERIFY_READLINKFAIL= (1 << 28),	/*!< readlink failed */
     RPMVERIFY_READFAIL	= (1 << 29),	/*!< file read failed */
     RPMVERIFY_LSTATFAIL	= (1 << 30),	/*!< lstat failed */
-    RPMVERIFY_LGETFILECONFAIL	= (1 << 31)	/*!< lgetfilecon failed */
+    RPMVERIFY_LGETFILECONFAIL	= (1U << 31)	/*!< lgetfilecon failed */
 };
 
 typedef rpmFlags rpmVerifyAttrs;

--- a/include/rpm/rpmplugin.h
+++ b/include/rpm/rpmplugin.h
@@ -22,7 +22,7 @@ typedef enum rpmScriptletExecutionFlow_e {
  */
 enum rpmFileActionFlags_e {
     /* bits 0-15 reserved for actions */
-    FAF_UNOWNED		= (1 << 31)
+    FAF_UNOWNED		= (1U << 31)
 };
 typedef rpmFlags rpmFileActionFlags;
 

--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -57,7 +57,7 @@ enum rpmtransFlags_e {
     /* bit 28 unused */
     RPMTRANS_FLAG_NOARTIFACTS	= (1 << 29),	/*!< from --noartifacts */
     RPMTRANS_FLAG_NOCONFIGS	= (1 << 30),	/*!< from --noconfigs */
-    RPMTRANS_FLAG_DEPLOOPS	= (1 << 31)	/*!< from --deploops */
+    RPMTRANS_FLAG_DEPLOOPS	= (1U << 31)	/*!< from --deploops */
 };
 
 typedef rpmFlags rpmtransFlags;

--- a/lib/poptI.cc
+++ b/lib/poptI.cc
@@ -129,7 +129,7 @@ struct poptOption rpmInstallPoptTable[] = {
 	N_("relocate files in non-relocatable package"), NULL},
 
  { "deploops", '\0', POPT_BIT_SET|POPT_ARGFLAG_DOC_HIDDEN,
- 	&rpmIArgs.transFlags, RPMTRANS_FLAG_DEPLOOPS,
+	&rpmIArgs.transFlags, (int)RPMTRANS_FLAG_DEPLOOPS,
 	N_("print dependency loops as warning"), NULL},
 
  { "erase", 'e', POPT_BIT_SET,


### PR DESCRIPTION
Use an explicitly unsigned type where needed, but this may cause issues elsewhere. Like here, the popt struct member whose type we have no means to change is a signed integer. But we can't really just leave undefined behavior in our public headers forever. So just in case this does break something: thank the compiler committees.

Originally reported by Demi Marie Obenour in the form of a PR and now again in OpenScanHub Fedora scan.