### PR TITLE
push qmsxtsxmnypw

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ insert_final_newline = true
 # XXX: Too common in existing source
 # trim_trailing_whitespace = true
 
-[*.{c,h,h.in,pc,pc.in}]
+[*.{c,cc,h,hh,h.in,pc,pc.in}]
 indent_size = 4
 indent_style = tab
 tab_width = 8

--- a/build/pack.cc
+++ b/build/pack.cc
@@ -18,6 +18,7 @@
 #include <rpm/rpmsign.h>
 
 #include "rpmio_internal.hh"	/* fdInitDigest, fdFiniDigest */
+#include "rpmalign.hh"		/* rpmAlignIsValid */
 #include "signature.hh"
 #include "rpmlead.hh"
 #include "rpmbuild_internal.hh"
@@ -27,11 +28,14 @@
 #include "debug.h"
 
 static int rpmPackageFilesArchive(rpmfiles fi, int isSrc,
-				  FD_t cfd, ARGV_t dpaths,
+				  FD_t cfd, ARGV_t dpaths, size_t align, off_t base,
 				  rpm_loff_t * archiveSize, char ** failedFile)
 {
     int rc = 0;
     rpmfi archive = rpmfiNewArchiveWriter(cfd, fi);
+
+    /* Enable block-aligned regular file content if requested */
+    rpmfiArchiveSetWriteAlign(archive, align, base);
 
     while (!rc && (rc = rpmfiNext(archive)) >= 0) {
         /* Copy file into archive. */
@@ -79,22 +83,41 @@ static rpmRC cpio_doio(FD_t fdo, Package pkg, const char * fmodeMacro,
     char *failedFile = NULL;
     FD_t cfd;
     int fsmrc;
+    size_t align = 0;
+    int uncompressed;
+    off_t base;
 
     (void) Fflush(fdo);
+    base = Ftell(fdo);
     cfd = Fdopen(fdDup(Fileno(fdo)), fmodeMacro);
     if (cfd == NULL)
 	return RPMRC_FAIL;
 
-    /* Calculate alternative (uncompressed) payload digest while writing */
-    fdInitDigestID(cfd, RPM_HASH_SHA256, RPMTAG_PAYLOADSHA256ALT, 0);
-    fdInitDigestID(cfd, RPM_HASH_SHA512, RPMTAG_PAYLOADSHA512ALT, 0);
-    fdInitDigestID(cfd, RPM_HASH_SHA3_256, RPMTAG_PAYLOADSHA3_256ALT, 0);
+    align = rpmExpandNumeric("%{?_payload_alignment}");
+    if (!rpmAlignIsValid(align))
+	align = 0;
+    uncompressed = (strstr(fmodeMacro, "ufdio") != NULL);
+
+    /*
+     * Alt (uncompressed) payload digest, computed while writing. For an
+     * uncompressed payload it equals the primary digest (taken from writeRPM's
+     * re-read pass), so skip it and leave *pld NULL; only a compressed payload
+     * needs it computed here.
+     */
+    *pld = *pld512 = *pld3 = NULL;
+    if (!uncompressed) {
+	fdInitDigestID(cfd, RPM_HASH_SHA256, RPMTAG_PAYLOADSHA256ALT, 0);
+	fdInitDigestID(cfd, RPM_HASH_SHA512, RPMTAG_PAYLOADSHA512ALT, 0);
+	fdInitDigestID(cfd, RPM_HASH_SHA3_256, RPMTAG_PAYLOADSHA3_256ALT, 0);
+    }
     fsmrc = rpmPackageFilesArchive(pkg->cpioList, headerIsSource(pkg->header),
-				   cfd, pkg->dpaths,
+				   cfd, pkg->dpaths, align, base,
 				   archiveSize, &failedFile);
-    fdFiniDigest(cfd, RPMTAG_PAYLOADSHA256ALT, (void **)pld, NULL, 1);
-    fdFiniDigest(cfd, RPMTAG_PAYLOADSHA512ALT, (void **)pld512, NULL, 1);
-    fdFiniDigest(cfd, RPMTAG_PAYLOADSHA3_256ALT, (void **)pld3, NULL, 1);
+    if (!uncompressed) {
+	fdFiniDigest(cfd, RPMTAG_PAYLOADSHA256ALT, (void **)pld, NULL, 1);
+	fdFiniDigest(cfd, RPMTAG_PAYLOADSHA512ALT, (void **)pld512, NULL, 1);
+	fdFiniDigest(cfd, RPMTAG_PAYLOADSHA3_256ALT, (void **)pld3, NULL, 1);
+    }
 
     if (fsmrc) {
 	char *emsg = rpmfileStrerror(fsmrc);
@@ -467,7 +490,10 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
     rpmRC rc = RPMRC_FAIL; /* assume failure */
     rpm_loff_t archiveSize = 0; /* uncompressed */
     rpm_loff_t payloadSize = 0; /* compressed */
-    off_t sigStart, hdrStart, payloadStart, payloadEnd;
+    off_t sigStart, hdrStart, hdrEnd, payloadStart, payloadEnd;
+    size_t payload_align = 0;
+    int payload_pad = 0;
+    int uncompressed;
 
     if (pkgidp)
 	*pkgidp = NULL;
@@ -475,6 +501,24 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
     rpmio_flags = getIOFlags(pkg);
     if (!rpmio_flags)
 	goto exit;
+
+    uncompressed = (strstr(rpmio_flags, "ufdio") != NULL);
+
+    /*
+     * Block-align regular file content and record the alignment for readers.
+     * An uncompressed payload also pads the payload start (payload_pad) so
+     * content lands on absolute block offsets; a compressed payload keeps the
+     * alignment inside the uncompressed stream.
+     */
+    {
+	size_t a = rpmExpandNumeric("%{?_payload_alignment}");
+	if (rpmAlignIsValid(a)) {
+	    uint32_t av = a;
+	    payload_align = a;
+	    payload_pad = uncompressed;
+	    headerPutUint32(pkg->header, RPMTAG_PAYLOADALIGNMENT, &av, 1);
+	}
+    }
 
     finalizeDeps(pkg);
 
@@ -555,6 +599,25 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
 
     /* Write payload section (cpio archive) */
     payloadStart = Ftell(fd);
+    /*
+     * For an uncompressed aligned payload, pad so the cpio content starts on a
+     * block boundary (cpio_doio picks up the aligned position itself). The
+     * padding is part of the payload for size and digest purposes (payloadStart
+     * stays at the payload start) and is skipped by readers via
+     * RPMTAG_PAYLOADALIGNMENT. Compressed payloads don't need this: their
+     * alignment is recovered from the decompressed stream instead.
+     */
+    if (payload_pad) {
+	off_t aligned = (payloadStart + payload_align - 1) & ~((off_t)payload_align - 1);
+	if (aligned > payloadStart) {
+	    size_t padn = aligned - payloadStart;
+	    char *zeros = (char *)xcalloc(1, padn);
+	    int ok = (Fwrite(zeros, padn, 1, fd) == padn);
+	    free(zeros);
+	    if (!ok)
+		goto exit;
+	}
+    }
     if (cpio_doio(fd, pkg, rpmio_flags, &archiveSize, &upld, &upld512, &upld3))
 	goto exit;
     payloadEnd = Ftell(fd);
@@ -582,7 +645,14 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
     fdFiniDigest(fd, RPMTAG_PAYLOADSHA512, (void **)&pld512, NULL, 1);
     fdFiniDigest(fd, RPMTAG_PAYLOADSHA3_256, (void **)&pld3, NULL, 1);
 
-    /* Insert the payload digests + size in main header */
+    /*
+     * Insert the payload digests + size in main header. For an uncompressed
+     * payload the alternative uncompressed digests were not computed while
+     * writing, so they equal the compressed ones.
+     */
+    if (upld == NULL) upld = xstrdup(pld);
+    if (upld512 == NULL && pld512) upld512 = xstrdup(pld512);
+    if (upld3 == NULL && pld3) upld3 = xstrdup(pld3);
     headerPutString(pkg->header, RPMTAG_PAYLOADSHA256, pld);
     headerPutString(pkg->header, RPMTAG_PAYLOADSHA256ALT, upld);
 
@@ -603,6 +673,8 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
 	goto exit;
     if (writeHdr(fd, pkg->header))
 	goto exit;
+    /* End of the header proper (any payload alignment padding follows). */
+    hdrEnd = Ftell(fd);
 
     /* Calculate the digests */
     if (rpmformat < 6) {
@@ -613,7 +685,7 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
 	fdInitDigestID(fd, RPM_HASH_SHA3_256, RPMTAG_SHA3_256HEADER, 0);
     }
     fdInitDigestID(fd, RPM_HASH_SHA256, RPMTAG_SHA256HEADER, 0);
-    if (fdConsume(fd, hdrStart, payloadStart - hdrStart))
+    if (fdConsume(fd, hdrStart, hdrEnd - hdrStart))
 	goto exit;
     fdFiniDigest(fd, RPMTAG_SHA1HEADER, (void **)&SHA1, NULL, 1);
     fdFiniDigest(fd, RPMTAG_SHA256HEADER, (void **)&SHA256, NULL, 1);

--- a/docs/manual/format_v6.md
+++ b/docs/manual/format_v6.md
@@ -120,6 +120,8 @@ for v6:
 - File type information is stored as MIME types instead of libmagic
   strings in RPMTAG_MIMEDICT and RPMTAG_FILEMIMEINDEX, retrievable
   with RPMTAG_FILEMIMES extension.
+- The optional RPMTAG_PAYLOADALIGNMENT records the payload content alignment,
+  see the Payload section.
 
 The Payload hashes in a signed Header are sufficient to establish
 cryptographic provenance of the package, without having to separately
@@ -133,6 +135,24 @@ The file header only contains the index number of the file in the RPM
 header as an 8 byte hex string. The payload may be compressed.
 
 Note: This is the format v4 uses for handling > 4GB files.
+
+### Aligned payloads
+
+When RPMTAG_PAYLOADALIGNMENT is present and non-zero, the payload is laid out
+so that regular file content starts on an alignment boundary:
+
+- The tag value is the alignment in bytes, a power of two, normally the
+  filesystem block size (4096).
+- For an uncompressed payload the payload itself starts on an alignment
+  boundary. The gap between the Header and the aligned payload start is zero
+  padding that is part of the payload for size and digest purposes and is
+  skipped by readers.
+- Within the payload, the content of every regular file at least as large as
+  the alignment starts on an alignment boundary. Smaller files, symlinks,
+  directories and other members keep the ordinary 4-byte cpio alignment.
+
+Readers that are unaware of the alignment can still process the payload as a
+plain (uncompressed) cpio archive after skipping the padding.
 
 ## Differences to V4
 

--- a/include/rpm/rpmarchive.h
+++ b/include/rpm/rpmarchive.h
@@ -121,6 +121,16 @@ size_t rpmfiArchiveWrite(rpmfi fi, const void * buf, size_t size);
 int rpmfiArchiveWriteFile(rpmfi fi, FD_t fd);
 
 /** \ingroup payload
+ * Enable content alignment on a write archive. When enabled, regular file
+ * content is padded to start on an @a align -aligned absolute offset in the
+ * underlying file. The payload remains a valid cpio archive.
+ * @param fi		archive writer (from rpmfiNewArchiveWriter)
+ * @param align		content alignment in bytes (0 disables), a power of two
+ * @param base		absolute file offset of the payload start
+ */
+void rpmfiArchiveSetWriteAlign(rpmfi fi, size_t align, rpm_loff_t base);
+
+/** \ingroup payload
  * Read content from current file in archive
  * @param fi		file info
  * @param buf		pointer to buffer

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -403,6 +403,7 @@ typedef enum rpmTag_e {
     RPMTAG_PAYLOADSHA512ALT	= 5122, /* s */
     RPMTAG_PAYLOADSHA3_256	= 5123, /* s */
     RPMTAG_PAYLOADSHA3_256ALT	= 5124, /* s */
+    RPMTAG_PAYLOADALIGNMENT	= 5125, /* i */
 
     RPMTAG_FIRSTFREE_TAG	/*!< internal */
 } rpmTag;

--- a/lib/cpio.cc
+++ b/lib/cpio.cc
@@ -36,6 +36,8 @@ struct rpmcpio_s {
     char mode;
     off_t offset;
     off_t fileend;
+    off_t base;		/*!< absolute file offset of the payload start */
+    size_t align;	/*!< content alignment, 0 if disabled */
 };
 
 /*
@@ -98,6 +100,17 @@ off_t rpmcpioTell(rpmcpio_t cpio)
     return cpio->offset;
 }
 
+void rpmcpioSetWriteAlign(rpmcpio_t cpio, size_t align, off_t base)
+{
+    cpio->align = align;
+    cpio->base = base;
+}
+
+void rpmcpioSetReadAlign(rpmcpio_t cpio, size_t align)
+{
+    cpio->align = align;
+}
+
 
 /**
  * Convert string to unsigned integer (with buffer size check).
@@ -123,37 +136,61 @@ static unsigned long strntoul(const char *str,char **endptr, int base, size_t nu
 }
 
 
-static int rpmcpioWritePad(rpmcpio_t cpio)
+/* Zero-fill the write stream up to the next @a modulo boundary. */
+static int rpmcpioPadWrite(rpmcpio_t cpio, size_t modulo)
 {
-    const ssize_t modulo = 4;
-    char buf[modulo];
-    ssize_t left, written;
-    memset(buf, 0, modulo);
-    left = (modulo - ((cpio->offset) % modulo)) % modulo;
+    off_t left = (off_t)((modulo - (cpio->offset % modulo)) % modulo);
+    char zeros[BUFSIZ];
+
     if (left <= 0)
-        return 0;
-    written = Fwrite(&buf, left, 1, cpio->fd);
-    if (written != left) {
-        return RPMERR_WRITE_FAILED;
+	return 0;
+    memset(zeros, 0, sizeof(zeros));
+    while (left > 0) {
+	size_t n = left > (off_t)sizeof(zeros) ? sizeof(zeros) : (size_t)left;
+	if (Fwrite(zeros, n, 1, cpio->fd) != n)
+	    return RPMERR_WRITE_FAILED;
+	cpio->offset += n;
+	left -= n;
     }
-    cpio->offset += written;
     return 0;
 }
 
-static int rpmcpioReadPad(rpmcpio_t cpio)
+/* Skip the read stream up to the next @a modulo boundary. */
+static int rpmcpioPadRead(rpmcpio_t cpio, size_t modulo)
 {
-    const ssize_t modulo = 4;
-    char buf[modulo];
-    ssize_t left, read;
-    left = (modulo - (cpio->offset % modulo)) % modulo;
-    if (left <= 0)
-        return 0;
-    read = Fread(&buf, left, 1, cpio->fd);
-    cpio->offset += read;
-    if (read != left) {
-        return RPMERR_READ_FAILED;
+    off_t left = (off_t)((modulo - (cpio->offset % modulo)) % modulo);
+    char buf[BUFSIZ];
+
+    while (left > 0) {
+	size_t n = left > (off_t)sizeof(buf) ? sizeof(buf) : (size_t)left;
+	if (Fread(buf, n, 1, cpio->fd) != n)
+	    return RPMERR_READ_FAILED;
+	cpio->offset += n;
+	left -= n;
     }
     return 0;
+}
+
+/* Content padding modulo. Regular files at least as large as the configured
+ * alignment are padded to it; everything else keeps 4-byte cpio padding.
+ * Non-regular content (a symlink target) is read inline before its size is
+ * known, so aligning it would leave padding the reader cannot skip and desync
+ * the stream. */
+static size_t rpmcpioContentModulo(rpmcpio_t cpio, int isreg, off_t fsize)
+{
+    if (isreg && cpio->align >= 4 && fsize >= (off_t)cpio->align)
+	return cpio->align;
+    return 4;
+}
+
+static int rpmcpioWriteContentPad(rpmcpio_t cpio, int isreg, off_t fsize)
+{
+    return rpmcpioPadWrite(cpio, rpmcpioContentModulo(cpio, isreg, fsize));
+}
+
+static int rpmcpioReadContentPad(rpmcpio_t cpio, int isreg, off_t fsize)
+{
+    return rpmcpioPadRead(cpio, rpmcpioContentModulo(cpio, isreg, fsize));
 }
 
 #define GET_NUM_FIELD(phys, log) \
@@ -176,7 +213,7 @@ static int rpmcpioTrailerWrite(rpmcpio_t cpio)
         return RPMERR_WRITE_FAILED;
     }
 
-    rc = rpmcpioWritePad(cpio);
+    rc = rpmcpioPadWrite(cpio, 4);
     if (rc)
         return rc;
 
@@ -206,7 +243,7 @@ static int rpmcpioTrailerWrite(rpmcpio_t cpio)
      * tape device(s) and/or concatenated cpio archives.
      */
 
-    rc = rpmcpioWritePad(cpio);
+    rc = rpmcpioPadWrite(cpio, 4);
 
     return rc;
 }
@@ -232,7 +269,7 @@ int rpmcpioHeaderWrite(rpmcpio_t cpio, char * path, struct stat * st)
 	return RPMERR_FILE_SIZE;
     }
 
-    rc = rpmcpioWritePad(cpio);
+    rc = rpmcpioPadWrite(cpio, 4);
     if (rc) {
         return rc;
     }
@@ -273,14 +310,15 @@ int rpmcpioHeaderWrite(rpmcpio_t cpio, char * path, struct stat * st)
         return RPMERR_WRITE_FAILED;
     }
 
-    rc = rpmcpioWritePad(cpio);
+    /* Align the content when it is a regular file large enough to benefit. */
+    rc = rpmcpioWriteContentPad(cpio, S_ISREG(st->st_mode), st->st_size);
 
     cpio->fileend = cpio->offset + st->st_size;
 
     return rc;
 }
 
-int rpmcpioStrippedHeaderWrite(rpmcpio_t cpio, int fx, off_t fsize)
+int rpmcpioStrippedHeaderWrite(rpmcpio_t cpio, int fx, int isreg, off_t fsize)
 {
     struct cpioStrippedPhysicalHeader hdr_s;
     struct cpioStrippedPhysicalHeader * hdr = &hdr_s;
@@ -296,7 +334,7 @@ int rpmcpioStrippedHeaderWrite(rpmcpio_t cpio, int fx, off_t fsize)
         return RPMERR_WRITE_FAILED;
     }
 
-    rc = rpmcpioWritePad(cpio);
+    rc = rpmcpioPadWrite(cpio, 4);
     if (rc) {
         return rc;
     }
@@ -315,7 +353,8 @@ int rpmcpioStrippedHeaderWrite(rpmcpio_t cpio, int fx, off_t fsize)
         return RPMERR_WRITE_FAILED;
     }
 
-    rc = rpmcpioWritePad(cpio);
+    /* Align the content when it is a regular file large enough to benefit. */
+    rc = rpmcpioWriteContentPad(cpio, isreg, fsize);
 
     cpio->fileend = cpio->offset + fsize;
 
@@ -348,6 +387,7 @@ int rpmcpioHeaderRead(rpmcpio_t cpio, char ** path, int * fx)
     ssize_t read;
     char magic[6];
     rpm_loff_t fsize;
+    unsigned long fmode = 0;
 
     if ((cpio->mode & O_ACCMODE) != O_RDONLY) {
         return RPMERR_READ_FAILED;
@@ -365,7 +405,7 @@ int rpmcpioHeaderRead(rpmcpio_t cpio, char ** path, int * fx)
         }
     }
 
-    rc = rpmcpioReadPad(cpio);
+    rc = rpmcpioPadRead(cpio, 4);
     if (rc) return rc;
 
     read = Fread(&magic, 6, 1, cpio->fd);
@@ -383,7 +423,7 @@ int rpmcpioHeaderRead(rpmcpio_t cpio, char ** path, int * fx)
 	    return RPMERR_BAD_HEADER;
 
         GET_NUM_FIELD(shdr.fx, *fx);
-        rc = rpmcpioReadPad(cpio);
+        rc = rpmcpioPadRead(cpio, 4);
 
         if (!rc && *fx == -1)
             rc = RPMERR_ITER_END;
@@ -401,6 +441,7 @@ int rpmcpioHeaderRead(rpmcpio_t cpio, char ** path, int * fx)
         return RPMERR_BAD_HEADER;
 
     GET_NUM_FIELD(hdr.filesize, fsize);
+    GET_NUM_FIELD(hdr.mode, fmode);
     GET_NUM_FIELD(hdr.namesize, nameSize);
     if (nameSize <= 0 || nameSize > CPIO_NAMESIZE_MAX) {
         return RPMERR_BAD_HEADER;
@@ -414,7 +455,7 @@ int rpmcpioHeaderRead(rpmcpio_t cpio, char ** path, int * fx)
         return RPMERR_BAD_HEADER;
     }
 
-    rc = rpmcpioReadPad(cpio);
+    rc = rpmcpioReadContentPad(cpio, S_ISREG(fmode), fsize);
     cpio->fileend = cpio->offset + fsize;
 
     if (!rc && rstreq(name, CPIO_TRAILER))
@@ -426,9 +467,15 @@ int rpmcpioHeaderRead(rpmcpio_t cpio, char ** path, int * fx)
     return rc;
 }
 
-void rpmcpioSetExpectedFileSize(rpmcpio_t cpio, off_t fsize)
+int rpmcpioSetExpectedFileSize(rpmcpio_t cpio, int isreg, off_t fsize)
 {
+    int rc = 0;
+    /* Stripped headers carry no size, so the content alignment padding could not
+     * be skipped at header-read time; skip it now that the size is known. */
+    if (isreg && cpio->align && fsize >= (off_t)cpio->align)
+	rc = rpmcpioReadContentPad(cpio, isreg, fsize);
     cpio->fileend = cpio->offset + fsize;
+    return rc;
 }
 
 ssize_t rpmcpioRead(rpmcpio_t cpio, void * buf, size_t size)

--- a/lib/cpio.hh
+++ b/lib/cpio.hh
@@ -29,6 +29,27 @@ int rpmcpioClose(rpmcpio_t cpio);
 RPM_GNUC_INTERNAL
 off_t rpmcpioTell(rpmcpio_t cpio);
 
+/**
+ * Enable content alignment on a write archive. When align is non-zero, regular
+ * file content is padded to start on an @a align-aligned absolute offset in the
+ * underlying file (base is the file offset at which the payload/cpio stream
+ * begins). Has no effect on stripped headers.
+ * @param cpio		cpio archive (opened for writing)
+ * @param align		content alignment in bytes (0 disables)
+ * @param base		absolute file offset of the payload start
+ */
+RPM_GNUC_INTERNAL
+void rpmcpioSetWriteAlign(rpmcpio_t cpio, size_t align, off_t base);
+
+/**
+ * Set the content alignment on a read archive so the alignment padding before
+ * aligned file content is skipped. Read from RPMTAG_PAYLOADALIGNMENT.
+ * @param cpio		cpio archive (opened for reading)
+ * @param align		content alignment in bytes (0 = none)
+ */
+RPM_GNUC_INTERNAL
+void rpmcpioSetReadAlign(rpmcpio_t cpio, size_t align);
+
 RPM_GNUC_INTERNAL
 rpmcpio_t rpmcpioFree(rpmcpio_t cpio);
 
@@ -42,7 +63,7 @@ rpmcpio_t rpmcpioFree(rpmcpio_t cpio);
 RPM_GNUC_INTERNAL
 int rpmcpioHeaderWrite(rpmcpio_t cpio, char * path, struct stat * st);
 RPM_GNUC_INTERNAL
-int rpmcpioStrippedHeaderWrite(rpmcpio_t cpio, int fx, off_t fsize);
+int rpmcpioStrippedHeaderWrite(rpmcpio_t cpio, int fx, int isreg, off_t fsize);
 
 RPM_GNUC_INTERNAL
 ssize_t rpmcpioWrite(rpmcpio_t cpio, const void * buf, size_t size);
@@ -69,7 +90,7 @@ int rpmcpioHeaderRead(rpmcpio_t cpio, char ** path, int * fx);
  * This is needed after reading a stripped cpio header! See above.
  */
 RPM_GNUC_INTERNAL
-void rpmcpioSetExpectedFileSize(rpmcpio_t cpio, off_t fsize);
+int rpmcpioSetExpectedFileSize(rpmcpio_t cpio, int isreg, off_t fsize);
 
 RPM_GNUC_INTERNAL
 ssize_t rpmcpioRead(rpmcpio_t cpio, void * buf, size_t size);

--- a/lib/rpmalign.hh
+++ b/lib/rpmalign.hh
@@ -1,0 +1,27 @@
+#ifndef H_RPMALIGN
+#define H_RPMALIGN
+
+#include <sys/types.h>		/* off_t */
+#include <stdint.h>
+
+/** \ingroup payload
+ * \file Shared helpers for block-aligned payloads.
+ *
+ * A content alignment is stored in RPMTAG_PAYLOADALIGNMENT and must be a
+ * positive power of two. These helpers centralize the validity check and the
+ * round-up arithmetic so the masking is defined in exactly one place.
+ */
+
+/** True when @a align is a usable content alignment (a positive power of two). */
+static inline int rpmAlignIsValid(uint64_t align)
+{
+    return align > 0 && (align & (align - 1)) == 0;
+}
+
+/** Round @a pos up to the next multiple of @a align (a power of two). */
+static inline off_t rpmAlignUp(off_t pos, uint64_t align)
+{
+    return (off_t)((pos + (off_t)align - 1) & ~((off_t)align - 1));
+}
+
+#endif	/* H_RPMALIGN */

--- a/lib/rpmfi.cc
+++ b/lib/rpmfi.cc
@@ -27,6 +27,7 @@
 #include "fsm.hh"	/* rpmpsm stuff for now */
 #include "rpmug.hh"
 #include "rpmio_internal.hh"   /* fdInit/FiniDigest */
+#include "rpmalign.hh"	/* rpmAlignIsValid */
 
 #include "debug.h"
 
@@ -113,6 +114,7 @@ struct rpmfiles_s {
     struct fingerPrint * fps;	/*!< File fingerprint(s). */
 
     int digestalgo;		/*!< File digest algorithm */
+    uint32_t align;		/*!< Payload content alignment (0 = none) */
     uint32_t *signatureoffs;	/*!< File signature offsets */
     int veritysiglength;	/*!< Verity signature length */
     uint16_t verityalgo;	/*!< Verity algorithm */
@@ -1676,6 +1678,10 @@ rpmfiles rpmfilesNew(rpmstrPool pool, Header h, rpmTagVal tagN, rpmfiFlags flags
 
     fi->magic = RPMFIMAGIC;
     fi->fiflags = flags;
+    /* alignment must be a power of two; ignore untrusted junk */
+    fi->align = headerGetNumber(h, RPMTAG_PAYLOADALIGNMENT);
+    if (!rpmAlignIsValid(fi->align))
+	fi->align = 0;
     /* private or shared pool? */
     fi->pool = (pool != NULL) ? rpmstrPoolLink(pool) : rpmstrPoolCreate();
 
@@ -1981,6 +1987,9 @@ rpmfi rpmfiNewArchiveReader(FD_t fd, rpmfiles files, int itype)
     }
     if (fi) {
 	fi->archive = archive;
+	/* skip content alignment padding */
+	if (files->align)
+	    rpmcpioSetReadAlign(archive, files->align);
     } else {
 	rpmcpioFree(archive);
     }
@@ -2000,6 +2009,12 @@ rpmfi rpmfiNewArchiveWriter(FD_t fd, rpmfiles files)
 	rpmcpioFree(archive);
     }
     return fi;
+}
+
+void rpmfiArchiveSetWriteAlign(rpmfi fi, size_t align, rpm_loff_t base)
+{
+    if (fi && fi->archive)
+	rpmcpioSetWriteAlign(fi->archive, align, (off_t)base);
 }
 
 int rpmfiArchiveClose(rpmfi fi)
@@ -2028,7 +2043,8 @@ static int rpmfiArchiveWriteHeader(rpmfi fi)
     rpmfiles files = fi->files;
 
     if (files->lfsizes) {
-	return rpmcpioStrippedHeaderWrite(fi->archive, rpmfiFX(fi), st.st_size);
+	return rpmcpioStrippedHeaderWrite(fi->archive, rpmfiFX(fi),
+					 S_ISREG(st.st_mode), st.st_size);
     } else {
 	const char * dn = rpmfiDN(fi);
 	char * path = rstrscat(NULL, (dn[0] == '/' && !rpmExpandNumeric("%{_noPayloadPrefix}")) ? "." : "",
@@ -2232,7 +2248,8 @@ static int iterReadArchiveNext(rpmfi fi)
 	    /* XXX should we validate the payload matches? */
 	    free(buf);
 	}
-	rpmcpioSetExpectedFileSize(fi->archive, fsize);
+	if (rc == 0)
+	    rc = rpmcpioSetExpectedFileSize(fi->archive, S_ISREG(mode), fsize);
 	rpmfiSetFound(fi, fx);
     } else {
 	/* Mapping error */

--- a/lib/rpmte.cc
+++ b/lib/rpmte.cc
@@ -19,6 +19,7 @@
 
 #include "misc.hh"
 #include "rpmplugins.hh"
+#include "rpmalign.hh"		/* rpmAlignIsValid, rpmAlignUp */
 #include "rpmte_internal.hh"
 /* strpool-related interfaces */
 #include "rpmfi_internal.hh"
@@ -636,10 +637,49 @@ static int rpmteClose(rpmte te, int reset_fi)
     return 1;
 }
 
+/*
+ * True if the payload at the descriptor's current position is a raw cpio
+ * stream. A missing compressor tag is ambiguous (a v3 package omits it but
+ * stores gzip), so check the cpio magic. Restores the position.
+ */
+static int rpmtePayloadUncompressed(FD_t fd)
+{
+    char magic[4];
+    off_t pos = Ftell(fd);
+    int israw = 0;
+
+    if (pos >= 0) {
+	if (Fread(magic, sizeof(magic), 1, fd) == (ssize_t)sizeof(magic))
+	    israw = (memcmp(magic, "0707", sizeof(magic)) == 0);
+	Fseek(fd, pos, SEEK_SET);
+    }
+    return israw;
+}
+
+/*
+ * Skip the alignment padding between the header and an aligned payload so the
+ * descriptor is positioned at the payload start. Only uncompressed payloads
+ * carry this gap; a compressed payload keeps its alignment inside the stream.
+ */
+static int rpmteSeekAlignedPayload(rpmte te)
+{
+    uint64_t align = headerGetNumber(te->h, RPMTAG_PAYLOADALIGNMENT);
+    const char *compr = headerGetString(te->h, RPMTAG_PAYLOADCOMPRESSOR);
+    if (rpmAlignIsValid(align) && (compr == NULL || compr[0] == '\0')) {
+	off_t pos = Ftell(te->fd);
+	off_t aligned = rpmAlignUp(pos, align);
+	if (aligned > pos && Fseek(te->fd, aligned, SEEK_SET) < 0)
+	    return -1;
+    }
+    return 0;
+}
+
 FD_t rpmtePayload(rpmte te)
 {
     FD_t payload = NULL;
     if (te->fd && te->h) {
+	if (rpmteSeekAlignedPayload(te))
+	    return NULL;
 	const char *compr = headerGetString(te->h, RPMTAG_PAYLOADCOMPRESSOR);
 	char *ioflags = rstrscat(NULL, "r.", compr ? compr : "gzip", NULL);
 	payload = Fdopen(fdDup(Fileno(te->fd)), ioflags);

--- a/macros.in
+++ b/macros.in
@@ -377,6 +377,15 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #%_source_payload	w9.gzdio
 %_binary_payload	%[ %_rpmformat >=6 ? "w19.zstdio" : "w9.gzdio" ]
 
+#	Payload content alignment, in bytes. When set (typically to a filesystem
+#	block size such as 4096), regular file content is block-aligned within the
+#	(uncompressed) payload. For an uncompressed payload (%_binary_payload
+#	w.ufdio) the payload start is aligned as well, so the content lands on
+#	absolute block boundaries; a compressed payload keeps the alignment inside
+#	the uncompressed stream, recovered on decompression. 0 disables (the
+#	default). Must be a power of two.
+%_payload_alignment	0
+
 #	Algorithm to use for generating file checksum digests on build.
 #	If not specified or 0, MD5 is used.
 #	WARNING: non-MD5 is backwards incompatible with rpm < 4.6!

--- a/scripts/rpm2cpio.sh
+++ b/scripts/rpm2cpio.sh
@@ -54,11 +54,22 @@ sigsize=$rsize
 calcsize $(($offset + (8 - ($sigsize % 8)) % 8))
 hdrsize=$rsize
 
+# An uncompressed aligned payload (RPMTAG_PAYLOADALIGNMENT) has NUL padding
+# between the header and the payload. Skip that padding so the payload starts at
+# its magic. No compression magic begins with a NUL byte, so this is a no-op for
+# compressed and unaligned payloads. Scan to the first non-NUL byte (awk exits
+# there, closing the pipe) so any alignment is handled, not just small ones.
+pad=$(_dd $offset |
+	od -An -v -tu1 |
+	awk '{for(i=1;i<=NF;i++){if($i!=0){print c+i-1; exit}} c+=NF}')
+offset=$(($offset + ${pad:-0}))
+
 case "$(_dd $offset bs=2 count=1 | tr -d '\0')" in
 	"$(printf '\102\132')") _dd $offset | bunzip2 ;; # '\x42\x5a'
 	"$(printf '\037\213')") _dd $offset | gunzip  ;; # '\x1f\x8b'
 	"$(printf '\375\067')") _dd $offset | xzcat   ;; # '\xfd\x37'
 	"$(printf '\135')") _dd $offset | unlzma      ;; # '\x5d\x00'
 	"$(printf '\050\265')") _dd $offset | unzstd  ;; # '\x28\xb5'
+	"$(printf '\060\067')") _dd $offset           ;; # '07' cpio (uncompressed)
 	*) fatal "Unrecognized payload compression format in rpm file: $pkg" ;;
 esac

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(TESTSUITE_AT
 	rpmconfig2.at
 	rpmconfig3.at
 	rpmbrp.at
+	rpmalign.at
 )
 
 FILE(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/rpmtests.at)

--- a/tests/data/SPECS/aligntest.spec
+++ b/tests/data/SPECS/aligntest.spec
@@ -1,0 +1,37 @@
+Name:           aligntest
+Version:        1.0
+Release:        1
+Summary:        Testing block-aligned payloads
+License:        GPL
+BuildArch:      noarch
+
+%description
+%{summary}
+
+%install
+mkdir -p %{buildroot}/opt/aligntest/sub
+# A file larger than a filesystem block, so its content can be block-aligned.
+seq 1 20000 > %{buildroot}/opt/aligntest/big.txt
+# A sub-block file and a nested one, which keep the ordinary cpio padding.
+echo hello > %{buildroot}/opt/aligntest/small.txt
+seq 1 5000 > %{buildroot}/opt/aligntest/sub/nested.txt
+# Non-regular payload members exercise the unaligned paths.
+: > %{buildroot}/opt/aligntest/empty.txt
+ln -s big.txt %{buildroot}/opt/aligntest/link
+# A symlink whose target is longer than a small alignment: symlink content is
+# never block-aligned (only regular files are), so this must survive a small
+# _payload_alignment on the v6 stripped read path.
+ln -s sub/nested.txt %{buildroot}/opt/aligntest/longlink
+# A hard link to a large (aligned) file exercises the hardlink write path
+# together with block-aligned content.
+ln %{buildroot}/opt/aligntest/big.txt %{buildroot}/opt/aligntest/big.hardlink
+
+%files
+%dir /opt/aligntest/sub
+/opt/aligntest/big.txt
+/opt/aligntest/big.hardlink
+/opt/aligntest/small.txt
+/opt/aligntest/sub/nested.txt
+/opt/aligntest/empty.txt
+/opt/aligntest/link
+/opt/aligntest/longlink

--- a/tests/rpmalign.at
+++ b/tests/rpmalign.at
@@ -1,0 +1,125 @@
+#    rpmalign.at: test block-aligned payloads
+#
+#    An aligned payload records RPMTAG_PAYLOADALIGNMENT and lays out regular
+#    file content on an alignment boundary, while remaining a plain cpio
+#    archive that builds, installs and verifies like any other package.
+
+AT_BANNER([RPM aligned payloads])
+
+# ------------------------------------------------------------------
+# An uncompressed aligned payload records RPMTAG_PAYLOADALIGNMENT, and because
+# its content is aligned in the payload itself the compressed and uncompressed
+# payload digests are equal.
+RPMTEST_SETUP_RW([aligned payload format])
+AT_KEYWORDS([align build payload])
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet \
+	--define "_binary_payload w.ufdio" \
+	--define "_payload_alignment 4096" \
+	/data/SPECS/aligntest.spec
+
+pkg=/build/RPMS/noarch/aligntest-1.0-1.noarch.rpm
+runroot rpm -qp --qf "%{payloadcompressor} %{payloadalignment}\n" ${pkg}
+c=$(runroot rpm -qp --qf "%{payloadsha256}" ${pkg})
+u=$(runroot rpm -qp --qf "%{payloadsha256alt}" ${pkg})
+test "$c" = "$u" && echo digests-equal || echo digests-differ
+],
+[0],
+[(none) 4096
+digests-equal
+],
+[])
+RPMTEST_CLEANUP
+
+# ------------------------------------------------------------------
+# An aligned payload installs correctly (v6, stripped headers). rpm -V
+# recomputes and compares every file digest, so this validates that readers
+# skip the alignment padding and reconstruct the content correctly.
+RPMTEST_SETUP_RW([aligned payload install v6])
+AT_KEYWORDS([align install])
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet \
+	--define "_binary_payload w.ufdio" \
+	--define "_payload_alignment 4096" \
+	--define "_rpmformat 6" \
+	/data/SPECS/aligntest.spec
+
+runroot rpm -U --nodeps --nosignature \
+	/build/RPMS/noarch/aligntest-1.0-1.noarch.rpm
+runroot rpm -V --nodeps --nouser --nogroup aligntest >/dev/null && echo verify-ok
+],
+[0],
+[verify-ok
+],
+[])
+RPMTEST_CLEANUP
+
+# ------------------------------------------------------------------
+# The same with the v4 format, which uses full cpio headers.
+RPMTEST_SETUP_RW([aligned payload install v4])
+AT_KEYWORDS([align install])
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet \
+	--define "_binary_payload w.ufdio" \
+	--define "_payload_alignment 4096" \
+	--define "_rpmformat 4" \
+	/data/SPECS/aligntest.spec
+
+runroot rpm -U --nodeps --nosignature \
+	/build/RPMS/noarch/aligntest-1.0-1.noarch.rpm
+runroot rpm -V --nodeps --nouser --nogroup aligntest >/dev/null && echo verify-ok
+],
+[0],
+[verify-ok
+],
+[])
+RPMTEST_CLEANUP
+
+# ------------------------------------------------------------------
+# Alignment is independent of compression: a compressed payload keeps the
+# alignment inside the uncompressed stream, recovered on decompression. It
+# still builds, installs and verifies like any package.
+RPMTEST_SETUP_RW([aligned compressed payload])
+AT_KEYWORDS([align build install])
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet \
+	--define "_binary_payload w3.zstdio" \
+	--define "_payload_alignment 4096" \
+	/data/SPECS/aligntest.spec
+
+pkg=/build/RPMS/noarch/aligntest-1.0-1.noarch.rpm
+runroot rpm -qp --qf "%{payloadcompressor} %{payloadalignment}\n" ${pkg}
+runroot rpm -U --nodeps --nosignature ${pkg}
+runroot rpm -V --nodeps --nouser --nogroup aligntest >/dev/null && echo verify-ok
+],
+[0],
+[zstd 4096
+verify-ok
+],
+[])
+RPMTEST_CLEANUP
+
+# ------------------------------------------------------------------
+# A small alignment (smaller than a symlink target) on the v6 stripped format.
+# Only regular file content is block-aligned; symlink targets and hardlink
+# stubs keep the ordinary cpio padding. If a symlink target were aligned, the
+# stripped read path would read the padding as target bytes and desync the
+# whole payload, so a successful install+verify here is the regression guard.
+RPMTEST_SETUP_RW([aligned payload small alignment v6])
+AT_KEYWORDS([align install])
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet \
+	--define "_binary_payload w.ufdio" \
+	--define "_payload_alignment 8" \
+	--define "_rpmformat 6" \
+	/data/SPECS/aligntest.spec
+
+runroot rpm -U --nodeps --nosignature \
+	/build/RPMS/noarch/aligntest-1.0-1.noarch.rpm
+runroot rpm -V --nodeps --nouser --nogroup aligntest >/dev/null && echo verify-ok
+],
+[0],
+[verify-ok
+],
+[])
+RPMTEST_CLEANUP

--- a/tools/rpm2archive.cc
+++ b/tools/rpm2archive.cc
@@ -158,9 +158,22 @@ static int process_package(rpmts ts, const char * filename)
 	break;
     }
 
-
     /* Retrieve payload size and compression type. */
     {	const char *compr = headerGetString(h, RPMTAG_PAYLOADCOMPRESSOR);
+	/* Skip alignment padding before an uncompressed payload (compressed
+	 * payloads have no such gap). */
+	uint64_t align = headerGetNumber(h, RPMTAG_PAYLOADALIGNMENT);
+	if (align & (align - 1))	/* only a power of two is valid */
+	    align = 0;
+	if (align > 0 && (compr == NULL || compr[0] == '\0')) {
+	    off_t pos = Ftell(fdi);
+	    off_t aligned = (pos + align - 1) & ~((off_t)align - 1);
+	    if (aligned > pos && Fseek(fdi, aligned, SEEK_SET) < 0) {
+		fprintf(stderr, _("cannot seek to payload start: %s\n"),
+			Fstrerror(fdi));
+		exit(EXIT_FAILURE);
+	    }
+	}
 	rpmio_flags = rstrscat(NULL, "r.", compr ? compr : "gzip", NULL);
     }
 


### PR DESCRIPTION
- **Fix the .editorconfig source file glob**
- **Support building and reading block-aligned payloads**
