### PR TITLE
Remove host dependency from debuginfo tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,9 +311,6 @@ endif()
 find_program(AWK gawk mawk nawk awk REQUIRED)
 mark_as_advanced(AWK)
 
-find_program(FIND_DEBUGINFO find-debuginfo)
-mark_as_advanced(FIND_DEBUGINFO)
-
 find_program(PODMAN podman)
 mark_as_advanced(PODMAN)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,9 +312,6 @@ endif()
 find_program(AWK gawk mawk nawk awk REQUIRED)
 mark_as_advanced(AWK)
 
-find_program(FIND_DEBUGINFO find-debuginfo)
-mark_as_advanced(FIND_DEBUGINFO)
-
 find_program(PODMAN podman)
 mark_as_advanced(PODMAN)
 

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -30,11 +30,6 @@ export TZ
 unset SOURCE_DATE_EPOCH
 
 RPM_XFAIL=${RPM_XFAIL-1}
-if test -x "@FIND_DEBUGINFO@"; then
-    DEBUGINFO_DISABLED=false;
-else
-    DEBUGINFO_DISABLED=true;
-fi
 if test "${PYTHON}"; then
     PYTHON_DISABLED=false;
 else

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2027,7 +2027,6 @@ RPMTEST_CLEANUP
 # Check if rpmbuild creates the minisymtab section in the main hello binary
 RPMTEST_SETUP_RW([rpmbuild debuginfo minisymtab])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Use macros.debug to generate a debuginfo package.
@@ -2064,7 +2063,6 @@ RPMTEST_CLEANUP
 # but the debug symbols/info in the debuginfo package.
 RPMTEST_SETUP_RW([rpmbuild debuginfo minisymtab strip -g])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Use macros.debug to generate a debuginfo package.
@@ -2103,7 +2101,6 @@ RPMTEST_CLEANUP
 # Test the case without unique debug file names.
 RPMTEST_SETUP_RW([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2189,7 +2186,6 @@ RPMTEST_CLEANUP
 # Check that rpmbuild creates no debuginfo when --nodebuginfo is passed
 RPMTEST_SETUP_RW([rpmbuild no debuginfo])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Use macros.debug to generate a debuginfo package,
@@ -2222,7 +2218,6 @@ RPMTEST_CLEANUP
 # Test with unique debug file names.
 RPMTEST_SETUP_RW([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2308,7 +2303,6 @@ RPMTEST_CLEANUP
 # We explicitly build with all debug.macros to test those helpers.
 RPMTEST_SETUP_RW([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2339,7 +2333,6 @@ RPMTEST_CLEANUP
 # Check that a GDB index is included when requested.
 RPMTEST_SETUP_RW([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2365,7 +2358,6 @@ RPMTEST_CLEANUP
 # Check that a GDB index is NOT included when not requested.
 RPMTEST_SETUP_RW([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2390,7 +2382,6 @@ RPMTEST_CLEANUP
 # Check that a -g3 (macros) build creates a valid .debug file.
 RPMTEST_SETUP_RW([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo generated with -g3.
@@ -2421,7 +2412,6 @@ RPMTEST_CLEANUP
 # Check that a debug source is in a "unique" directory when requested.
 RPMTEST_SETUP_RW([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2457,7 +2447,6 @@ RPMTEST_CLEANUP
 # It will be in the "build directory" name under /usr/src/debug.
 RPMTEST_SETUP_RW([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2490,7 +2479,6 @@ RPMTEST_CLEANUP
 # Check that defining _debugsource_packages creates -debugsource package
 RPMTEST_SETUP_RW([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2521,7 +2509,6 @@ RPMTEST_CLEANUP
 # should be in expected build dir).
 RPMTEST_SETUP_RW([rpmbuild debugsource debugsourcefiles.list path])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2545,7 +2532,6 @@ RPMTEST_CLEANUP
 # Check that undefining _debuginfo_subpackages creates one single -debuginfo.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages single])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2583,7 +2569,6 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2663,7 +2648,6 @@ RPMTEST_CLEANUP
 # With unique debug and source names
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple unique])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2743,7 +2727,6 @@ RPMTEST_CLEANUP
 # Unique with debugsources.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple unique debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2826,7 +2809,6 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages works with excluded files.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2886,7 +2868,6 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages works with RemovePathPostfixes.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2022,7 +2022,6 @@ RPMTEST_CLEANUP
 # Check if rpmbuild creates the minisymtab section in the main hello binary
 RPMTEST_SETUP_RW([rpmbuild debuginfo minisymtab])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Use macros.debug to generate a debuginfo package.
@@ -2059,7 +2058,6 @@ RPMTEST_CLEANUP
 # but the debug symbols/info in the debuginfo package.
 RPMTEST_SETUP_RW([rpmbuild debuginfo minisymtab strip -g])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Use macros.debug to generate a debuginfo package.
@@ -2098,7 +2096,6 @@ RPMTEST_CLEANUP
 # Test the case without unique debug file names.
 RPMTEST_SETUP_RW([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2184,7 +2181,6 @@ RPMTEST_CLEANUP
 # Check that rpmbuild creates no debuginfo when --nodebuginfo is passed
 RPMTEST_SETUP_RW([rpmbuild no debuginfo])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Use macros.debug to generate a debuginfo package,
@@ -2217,7 +2213,6 @@ RPMTEST_CLEANUP
 # Test with unique debug file names.
 RPMTEST_SETUP_RW([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2303,7 +2298,6 @@ RPMTEST_CLEANUP
 # We explicitly build with all debug.macros to test those helpers.
 RPMTEST_SETUP_RW([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2334,7 +2328,6 @@ RPMTEST_CLEANUP
 # Check that a GDB index is included when requested.
 RPMTEST_SETUP_RW([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2360,7 +2353,6 @@ RPMTEST_CLEANUP
 # Check that a GDB index is NOT included when not requested.
 RPMTEST_SETUP_RW([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2385,7 +2377,6 @@ RPMTEST_CLEANUP
 # Check that a -g3 (macros) build creates a valid .debug file.
 RPMTEST_SETUP_RW([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo generated with -g3.
@@ -2416,7 +2407,6 @@ RPMTEST_CLEANUP
 # Check that a debug source is in a "unique" directory when requested.
 RPMTEST_SETUP_RW([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2452,7 +2442,6 @@ RPMTEST_CLEANUP
 # It will be in the "build directory" name under /usr/src/debug.
 RPMTEST_SETUP_RW([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build a package that has some debuginfo
@@ -2485,7 +2474,6 @@ RPMTEST_CLEANUP
 # Check that defining _debugsource_packages creates -debugsource package
 RPMTEST_SETUP_RW([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2516,7 +2504,6 @@ RPMTEST_CLEANUP
 # should be in expected build dir).
 RPMTEST_SETUP_RW([rpmbuild debugsource debugsourcefiles.list path])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2540,7 +2527,6 @@ RPMTEST_CLEANUP
 # Check that undefining _debuginfo_subpackages creates one single -debuginfo.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages single])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2578,7 +2564,6 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages creates multiple -debuginfos.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2658,7 +2643,6 @@ RPMTEST_CLEANUP
 # With unique debug and source names
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple unique])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2738,7 +2722,6 @@ RPMTEST_CLEANUP
 # Unique with debugsources.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple unique debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2821,7 +2804,6 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages works with excluded files.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \
@@ -2881,7 +2863,6 @@ RPMTEST_CLEANUP
 # Check that defining _debuginfo_subpackages works with RemovePathPostfixes.
 RPMTEST_SETUP_RW([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 rundebug rpmbuild --quiet \

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -22,7 +22,6 @@ AT_BANNER([RPM buildid tests])
 # Check if rpmbuild "none" doesn't generates buildid symlinks for hello program
 RPMTEST_SETUP_RW([rpmbuild buildid none])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.
@@ -52,7 +51,6 @@ RPMTEST_CLEANUP
 # Without unique debug file names.
 RPMTEST_SETUP_RW([rpmbuild buildid alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.
@@ -140,7 +138,6 @@ RPMTEST_CLEANUP
 # With unique debug file names.
 RPMTEST_SETUP_RW([rpmbuild buildid alldebug unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.
@@ -227,7 +224,6 @@ RPMTEST_CLEANUP
 # Without unique debug file names
 RPMTEST_SETUP_RW([rpmbuild buildid separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.
@@ -314,7 +310,6 @@ RPMTEST_CLEANUP
 # With unique debug file names
 RPMTEST_SETUP_RW([rpmbuild buildid separate unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.
@@ -400,7 +395,6 @@ RPMTEST_CLEANUP
 # Without unique debug file names
 RPMTEST_SETUP_RW([rpmbuild buildid compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.
@@ -500,7 +494,6 @@ RPMTEST_CLEANUP
 # With unique debug file names
 RPMTEST_SETUP_RW([rpmbuild buildid compat unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.
@@ -600,7 +593,6 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary copied.
 RPMTEST_SETUP_RW([rpmbuild buildid duplicate alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # Should create two warnings
 rundebug rpmbuild --quiet \
@@ -664,7 +656,6 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary hard linked.
 RPMTEST_SETUP_RW([rpmbuild buildid hardlink alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # No warnings for hard links
 rundebug rpmbuild --quiet \
@@ -725,7 +716,6 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary copied.
 RPMTEST_SETUP_RW([rpmbuild buildid duplicate separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # Should create two warnings
 rundebug rpmbuild --quiet \
@@ -786,7 +776,6 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary hard linked.
 RPMTEST_SETUP_RW([rpmbuild buildid hardlink separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # No warnings for hard links
 rundebug rpmbuild --quiet \
@@ -844,7 +833,6 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary copied.
 RPMTEST_SETUP_RW([rpmbuild buildid duplicate compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # Should create two warnings
 rundebug rpmbuild --quiet \
@@ -917,7 +905,6 @@ RPMTEST_CLEANUP
 # This is simply the hello example with one binary hard linked.
 RPMTEST_SETUP_RW([rpmbuild buildid hardlink compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # No warnings for hard links
 rundebug rpmbuild --quiet \
@@ -986,7 +973,6 @@ RPMTEST_CLEANUP
 # but not with _no_recompute_build_ids
 RPMTEST_SETUP_RW([rpmbuild buildid recompute])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # Make sure we get debuginfo
 export CFLAGS="-g"
@@ -1096,7 +1082,6 @@ RPMTEST_CLEANUP
 # with _unique_build_ids defined.
 RPMTEST_SETUP_RW([rpmbuild buildid unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # No warnings for hard links
 rundebug rpmbuild --quiet \
@@ -1140,7 +1125,6 @@ RPMTEST_CLEANUP
 # with _unique_build_ids undefined (and exact same sources).
 RPMTEST_SETUP_RW([rpmbuild buildid non-unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 # No warnings for hard links
 rundebug rpmbuild --quiet \
@@ -1188,7 +1172,6 @@ RPMTEST_CLEANUP
 # even if the spec file sets attrs explicitly.
 RPMTEST_SETUP_RW([rpmbuild buildid attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.
@@ -1218,7 +1201,6 @@ RPMTEST_CLEANUP
 # even if the spec file sets config explicitly.
 RPMTEST_SETUP_RW([rpmbuild buildid config attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
-RPMTEST_SKIP_IF([$DEBUGINFO_DISABLED])
 RPMTEST_CHECK([
 
 # Build, contains one ELF which should have a buildid.


### PR DESCRIPTION
The testsuite runs in a controlled container that provides find-debuginfo, but configuration still looked for the helper on the host and skipped all debuginfo coverage when it was absent. This made test selection depend on an unrelated host package and hid 37 existing tests from otherwise complete runs.

Remove the host-side CMake probe, the derived DEBUGINFO_DISABLED variable, and the obsolete skip guards. The build-time __FIND_DEBUGINFO lookup remains in place so RPM still locates the helper inside the test environment. The existing debuginfo and build-id cases now provide regression coverage on every test run.

Fixes: #4259
Signed-off-by: Daan De Meyer <daan@amutable.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration consistency by removing obsolete debuginfo tool detection.
  * Debuginfo-related build and build-ID validation tests now run consistently, including when debuginfo support is disabled.

* **Tests**
  * Updated test setup to remove outdated debuginfo availability checks.
  * Preserved existing test logic and expected results while broadening test coverage across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->