### PR TITLE
Document the SHA3-256 header digest

### DIFF
--- a/docs/manual/signatures_digests.md
+++ b/docs/manual/signatures_digests.md
@@ -16,6 +16,7 @@ contents:
 |       RSA      |    RSAHEADER      |   4.0   | OpenPGP/RSA    |    S     |   H     |
 |       DSA      |    DSAHEADER      |   4.0   | OpenPGP/DSA    |    S     |   H     |
 |      SHA256    |  SHA256HEADER     |  4.14   | SHA256         |    S     |   H     |
+|    SHA3_256    | SHA3_256HEADER    |   6.0   | SHA3_256       |    S     |   H     |
 |      OPENPGP   |  OPENPGPHEADER    |   6.0   | any (***)      |    S     |   H     |
 |        -       |  PAYLOADSHA256    |  4.14   | SHA256 (*)     |    H     |   Pc    |
 |        -       |  PAYLOADSHA256ALT |  4.16   | SHA256 (*)     |    H     |   P     |


### PR DESCRIPTION
RPM v6 packages carry a SHA3-256 digest of the main header, but the signatures and digests reference omitted the corresponding signature and header tags. This left the verification table inconsistent with both the format documentation and the implementation.

Add the RPMSIGTAG_SHA3_256 and RPMTAG_SHA3_256HEADER entry with its version, location, and covered range. The documentation pages target verifies that the updated table is copied into the generated site.

Fixes: #4032
Signed-off-by: Daan De Meyer <daan@amutable.com>
