### PR TITLE
Hopefully silence scanners about a can't happen situation

### DIFF
--- a/lib/depends.cc
+++ b/lib/depends.cc
@@ -863,6 +863,9 @@ static void checkInstDeps(rpmts ts, depCache *dcache, rpmte te,
 
     if (depds)
 	dep = rpmdsN(depds);
+    /* Shut up scanners, this would be a bug somewhere else */
+    assert(dep != NULL);
+
     if (neg) {
 	ndep = (char *)xmalloc(strlen(dep) + 2);
 	ndep[0] = '!';


### PR DESCRIPTION
OpenScanHub and a related AI analysis think they found a scandalous NULL pointer reference in checkInstDeps() because they don't understand the big picture in which this executes. This is an alleged can't happen situation and checking for NULL would only make it seem otherwise. Add an assert() to hopefully document this situation to the scanners which only obsess here because think strlen() can be passed NULL.