### PR TITLE
Restore file trigger priority ordering

### DIFF
--- a/lib/rpmtriggers.hh
+++ b/lib/rpmtriggers.hh
@@ -16,8 +16,9 @@ struct triggerInfo {
 
     bool operator < (const triggerInfo & o) const
     {
-	return std::tie(priority, hdrNum, tix) <
-	       std::tie(o.priority, o.hdrNum, o.tix);
+	if (priority != o.priority)
+	    return priority > o.priority;
+	return std::tie(hdrNum, tix) < std::tie(o.hdrNum, o.tix);
     }
     triggerInfo(unsigned int _hnum, unsigned int _tix, unsigned int _prio) :
 		hdrNum(_hnum), tix(_tix), priority(_prio)

--- a/tests/data/SPECS/filetrigger-priority.spec
+++ b/tests/data/SPECS/filetrigger-priority.spec
@@ -1,0 +1,30 @@
+Name:           filetrigger-priority
+Version:        1.0
+Release:        1
+Summary:        Testing file trigger priority ordering
+License:        GPL
+BuildArch:      noarch
+
+%description
+%{summary}
+
+%package data
+Summary:        Data for testing file trigger priority ordering
+
+%description data
+%{summary}
+
+%install
+mkdir -p %{buildroot}/opt/filetrigger-priority
+touch %{buildroot}/opt/filetrigger-priority/data
+
+%transfiletriggerin -n filetrigger-priority -P 100 -- /opt/filetrigger-priority
+echo "priority 100"
+
+%transfiletriggerin -n filetrigger-priority -P 200 -- /opt/filetrigger-priority
+echo "priority 200"
+
+%files
+
+%files data
+/opt/filetrigger-priority/data

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -650,6 +650,26 @@ transfiletriggerpostun(/foo*):
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([transaction file trigger priority order])
+AT_KEYWORDS([filetrigger script priority])
+
+runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
+runroot rpmbuild --quiet -bb /data/SPECS/filetrigger-priority.spec
+runroot rpm -U /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm
+
+RPMTEST_CHECK([
+runroot rpm -U \
+    /build/RPMS/noarch/filetrigger-priority-1.0-1.noarch.rpm \
+    /build/RPMS/noarch/filetrigger-priority-data-1.0-1.noarch.rpm
+],
+[0],
+[priority 200
+priority 100
+],
+[])
+
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP_RW([basic file triggers: failures])
 AT_KEYWORDS([filetrigger script])
 


### PR DESCRIPTION
The STL conversion changed file trigger ordering from descending to ascending
priority even though larger priority values are documented to execute first.
This changes ordering-dependent transaction results and can make the intended
final trigger result disappear.

Restore the original descending priority comparison while retaining ascending
header and trigger-index tie breakers. Add regression coverage that installs a
trigger owner and matching data package in one transaction and verifies that
both immediate transaction file triggers run in priority order.

Fixes: #4254

Signed-off-by: Daan De Meyer <daan@amutable.com>
