### PR TITLE
macros: default to systemd-sysusers binary

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -142,8 +142,8 @@
 %_sysusersdir		@sysusersdir@
 
 # sysusers helper binary (or a replacement script), comment out to disable
-#%__systemd_sysusers	@__SYSTEMD_SYSUSERS@
-%__systemd_sysusers	%{_rpmconfigdir}/sysusers.sh
+%__systemd_sysusers	@__SYSTEMD_SYSUSERS@
+#%__systemd_sysusers	%{_rpmconfigdir}/sysusers.sh
 
 #
 #	Path to script that creates debug symbols in a /usr/lib/debug


### PR DESCRIPTION
Nowadays the sd-sysusers binary is available everywhere and should be the preferred implementation. Fedora has been patching this in for a long time now:

https://src.fedoraproject.org/rpms/rpm/blob/rawhide/f/rpm-4.20-sysusers.patch

Switch the default around. If some downstream doesn't want to use sd-sysusers for any reason, they can be the ones to carry a patch for it.