### PR TITLE
Fix long file-signing password input

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -26,7 +26,7 @@ RUN dnf -y install \
   libzstd-devel \
   elfutils-libelf-devel \
   elfutils-devel \
-  openssl-devel \
+  openssl openssl-devel \
   libgcrypt-devel \
   rpm-sequoia-devel \
   file-devel \
@@ -47,6 +47,7 @@ RUN dnf -y install \
   which \
   elfutils binutils \
   findutils sed grep gawk diffutils file patch \
+  util-linux-script \
   tar unzip gzip bzip2 cpio xz 7zip 7zip-standalone \
   pkgconfig \
   /usr/bin/systemd-sysusers \

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -2513,6 +2513,20 @@ gpg2 --import /data/keys/rpm.org-rsa-2048-test.secret
 rpmsign --key-id 4344591E1964C5FC --addsign --signfiles --fskpath=/data/keys/privkey.pem /tmp/hello-2.0-1.x86_64.rpm
 
 RPMTEST_CHECK([[
+fskpass=0123456789012345678901234567890123456789012345678901234567890123456789
+openssl pkey -in /data/keys/privkey.pem -aes-256-cbc \
+	-passout pass:"$fskpass" -out /tmp/privkey-encrypted.pem
+cp /data/RPMS/hello-2.0-1.x86_64.rpm /tmp/hello-encrypted-key.rpm
+printf '%s\n' "$fskpass" | \
+    script -qec "rpmsign --key-id 4344591E1964C5FC --addsign --signfiles \
+	--fskpass --fskpath=/tmp/privkey-encrypted.pem \
+	/tmp/hello-encrypted-key.rpm" /dev/null >/dev/null
+]],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([[
 rpmsign --key-id 4344591E1964C5FC --addsign --signfiles --fskpath=/data/keys/privkey.pem --define "_file_signing_key_id 9000000000" /tmp/hello-2.0-1.x86_64.rpm
 ]],
 [1],

--- a/tools/rpmsign.cc
+++ b/tools/rpmsign.cc
@@ -97,8 +97,9 @@ static int flags_sign_files(int flags)
 static char *get_fskpass(void)
 {
     struct termios flags, tmp_flags;
-    int passlen = 64;
-    char *password = (char *)xmalloc(passlen);
+    size_t passlen = 0;
+    ssize_t nread = -1;
+    char *password = NULL;
     char *pwd = NULL;
 
     tcgetattr(fileno(stdin), &flags);
@@ -112,7 +113,8 @@ static char *get_fskpass(void)
     }
 
     printf("PEM password: ");
-    pwd = fgets(password, passlen, stdin);
+    if ((nread = getline(&password, &passlen, stdin)) >= 0)
+	pwd = password;
 
     if (tcsetattr(fileno(stdin), TCSANOW, &flags) != 0) {
 	perror("tcsetattr");
@@ -121,10 +123,12 @@ static char *get_fskpass(void)
     }
 
 exit:
-    if (pwd)
-	pwd[strlen(pwd) - 1] = '\0';  /* remove newline */
-    else
+    if (pwd) {
+	if (nread && pwd[nread - 1] == '\n')
+	    pwd[nread - 1] = '\0';
+    } else {
 	free(password);
+    }
     return pwd;
 }
 #endif


### PR DESCRIPTION
File-signing password input used a fixed 64-byte fgets() buffer and
unconditionally removed its final byte. Passwords that filled the buffer
therefore lost a real character, while longer passwords were silently
truncated and could not unlock their key.

Read the complete line with getline() and remove the trailing newline only
when one is present. Add an IMA signing regression test using an encrypted
key with a password longer than the old buffer, and install the
pseudo-terminal helper required by the Fedora test image.

Signed-off-by: Daan De Meyer <daan@amutable.com>
