### PR TITLE
Fix macro undefining through Lua macros table bypassing sanity checks

### DIFF
--- a/rpmio/rpmlua.cc
+++ b/rpmio/rpmlua.cc
@@ -1323,7 +1323,7 @@ static int mc_newindex(lua_State *L)
     rpmMacroContext *mc = checkmc(L, 1);
     const char *name = luaL_checkstring(L, 2);
     if (lua_isnil(L, 3)) {
-	if (rpmPopMacro(*mc, name))
+	if (rpmUndefineMacro(*mc, name))
 	    luaL_error(L, "error undefining macro %s", name);
     } else {
 	const char *body = luaL_checkstring(L, 3);

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1170,6 +1170,15 @@ rpm --eval '%{lua: rpm.undefine("define")}'
 [[error: Macro %define is a built-in (%undefine)
 error: lua script failed: [string "<lua>"]:1: error undefining macro
 ]])
+
+RPMTEST_CHECK([
+rpm --eval '%{lua: macros.define = nil}'
+],
+[1],
+[],
+[[error: Macro %define is a built-in (%undefine)
+error: lua script failed: [string "<lua>"]:1: error undefining macro define
+]])
 RPMTEST_CLEANUP
 
 RPMTEST_SETUP([lua rpm extensions 2])


### PR DESCRIPTION
Commit 47b005e67ab9e00539d03bf53de837f0613e7130 fixed two such cases but missed the Lua macros table access. Add a test as well.

Reported and initial patch by Dan Andersson.

Fixes: #4133
Fixes: #4203