### PR TITLE
Construct rpmstrPool with new instead of xcalloc

### DIFF
--- a/rpmio/rpmstrpool.cc
+++ b/rpmio/rpmstrpool.cc
@@ -237,7 +237,7 @@ static void rpmstrPoolRehash(rpmstrPool pool)
 
 rpmstrPool rpmstrPoolCreate(void)
 {
-    rpmstrPool pool = (rpmstrPool)xcalloc(1, sizeof(*pool));
+    rpmstrPool pool = new rpmstrPool_s{};
 
     pool->offs_alloced = STROFFS_CHUNK;
     pool->offs = (const char **)xcalloc(pool->offs_alloced, sizeof(*pool->offs));
@@ -267,7 +267,7 @@ rpmstrPool rpmstrPoolFree(rpmstrPool pool)
 	pool->chunks[i] = _free(pool->chunks[i]);
     }
     free(pool->chunks);
-    free(pool);
+    delete pool;
 
     return NULL;
 }


### PR DESCRIPTION
Construct rpmstrPool with new instead of xcalloc

`rpmstrPool_s` embeds a `std::shared_mutex`, but `rpmstrPoolCreate()` allocates it with `xcalloc()`, so the mutex is never constructed. On Linux this works by accident (`PTHREAD_MUTEX_INITIALIZER` is all-zero); on macOS/libc++ the zeroed `pthread_mutex_t` has an invalid signature, so the first lock fails with `EINVAL` and `rpmbuild` aborts while parsing a spec:

    libc++abi: terminating due to uncaught exception of type
    std::__1::system_error: mutex lock failed: Invalid argument

Use `new`/`delete` so the mutex is constructed, matching `rpmkeyring.cc` and `macro.cc`. Still reproduces on master.