### PR TITLE
Introduce new READINS dir & move debuginfo manifests there

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,17 @@ mark_as_advanced(AWK)
 
 find_program(FIND_DEBUGINFO find-debuginfo)
 mark_as_advanced(FIND_DEBUGINFO)
+if (FIND_DEBUGINFO AND AWK)
+	execute_process(COMMAND ${FIND_DEBUGINFO} --version
+			COMMAND ${AWK} "{print \$2}"
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			OUTPUT_VARIABLE FIND_DEBUGINFO_VERSION)
+endif()
+if (FIND_DEBUGINFO_VERSION VERSION_GREATER_EQUAL 5.3)
+	set(FIND_DEBUGINFO_OPTS "--output-dir \"%{_debuginfo_manifests_dir}\"")
+else()
+	set(FIND_DEBUGINFO_OPTS "")
+endif()
 
 find_program(PODMAN podman)
 mark_as_advanced(PODMAN)

--- a/build/build.cc
+++ b/build/build.cc
@@ -333,6 +333,7 @@ static rpmRC doBuildDir(rpmSpec spec, int test, int inPlace, StringBuf *sbp)
 			       "%{__rm} -rf '", spec->buildDir, "'\n",
 			       "%{__mkdir_p} '", spec->buildDir, "'\n",
 			       "%{__mkdir_p} '%{specpartsdir}'\n",
+			       "%{__mkdir_p} '%{readinsdir}'\n",
 			   });
 
     if (inPlace) {

--- a/build/files.cc
+++ b/build/files.cc
@@ -2209,6 +2209,29 @@ exit:
     return rc;
 }
 
+static char *lookupReadinFile(rpmSpec spec, const char *path)
+{
+    char *filename = NULL;
+    ARGV_t dirs;
+
+    if (*path == '/')
+	return rpmGetPath(path, NULL);
+
+    dirs = argvSplitString(spec->readinPath, ":", ARGV_SKIPEMPTY);
+    for (ARGV_t d = dirs; *d; d++) {
+	char *fn = rpmGetPath(*d, "/", path, NULL);
+	struct stat sb;
+	if (stat(fn, &sb) == 0 && S_ISREG(sb.st_mode)) {
+	    filename = fn;
+	    break;
+	}
+	free(fn);
+    }
+    argvFree(dirs);
+
+    return filename;
+}
+
 int readManifest(rpmSpec spec, const char *path, const char *descr, int flags,
 		ARGV_t *avp, StringBuf *sbp)
 {
@@ -2217,15 +2240,12 @@ int readManifest(rpmSpec spec, const char *path, const char *descr, int flags,
     int lineno = 0;
     int nlines = -1;
 
-    if (*path == '/') {
-	fn = rpmGetPath(path, NULL);
-    } else {
-	fn = rpmGenPath("%{builddir}", "%{?buildsubdir}", path);
-    }
-    fd = fopen(fn, "r");
-
+    fn = lookupReadinFile(spec, path);
+    if (fn)
+	fd = fopen(fn, "r");
     if (fd == NULL) {
-	rpmlog(RPMLOG_ERR, _("Could not open %s file %s: %m\n"), descr, fn);
+	rpmlog(RPMLOG_ERR, _("Could not open %s file %s: %m\n"),
+		descr, fn ? fn : path);
 	goto exit;
     }
 

--- a/build/parsePreamble.cc
+++ b/build/parsePreamble.cc
@@ -1323,6 +1323,13 @@ int parsePreamble(rpmSpec spec, int initialPackage, enum parseStages stage)
 	    rpmPushMacroFlags(spec->macros, "specpartsdir", NULL, specparts,
 				RMIL_SPEC, RPMMACRO_LITERAL);
 	    free(specparts);
+
+	    char *readinsdir = rpmGetPath(spec->buildDir, "/READINS", NULL);
+	    spec->readinPath = rstrscat(NULL, readinsdir,
+				":%{builddir}/%{?buildsubdir}", NULL);
+	    rpmPushMacroFlags(spec->macros, "readinsdir", NULL, readinsdir,
+				RMIL_SPEC, RPMMACRO_LITERAL);
+	    free(readinsdir);
 	}
 
 	if (!spec->buildRoot) {

--- a/build/rpmbuild_internal.hh
+++ b/build/rpmbuild_internal.hh
@@ -133,6 +133,7 @@ struct rpmSpec_s {
     char * specFile;	/*!< Name of the spec file. */
     char * buildRoot;
     char * buildDir;
+    char * readinPath;
     const char * rootDir;
 
     struct OpenFileInfo * fileStack;

--- a/build/spec.cc
+++ b/build/spec.cc
@@ -223,6 +223,7 @@ rpmSpec newSpec(void)
     
     spec->buildRoot = NULL;
     spec->buildDir = NULL;
+    spec->readinPath = NULL;
 
     spec->buildRestrictions = headerNew();
     spec->BANames = NULL;
@@ -251,6 +252,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     spec->buildRoot = _free(spec->buildRoot);
     spec->buildDir = _free(spec->buildDir);
     spec->specFile = _free(spec->specFile);
+    spec->readinPath = _free(spec->readinPath);
 
     closeSpec(spec);
 

--- a/docs/man/rpm-scriptlets.7.scd
+++ b/docs/man/rpm-scriptlets.7.scd
@@ -64,8 +64,9 @@ _PATHPREFIX_
 	Note that macros intended to be runtime expanded generally need
 	to be escaped in specs to avoid buildtime expansion.
 
-*-f* _PATH_
-	Read the scriptlet body from the file at _PATH_ (during build).
+*-f* _FILE_
+	Read the scriptlet body from the file at _FILE_ (during build).
+	See *READ-IN FILES* in *rpm-spec*(5) for details.
 
 *-n*
 	Interpret _NAME_ as a full package name.

--- a/docs/man/rpm-spec.5.scd
+++ b/docs/man/rpm-spec.5.scd
@@ -581,6 +581,7 @@ An example is shown in an indented block where applicable.
 		Additional files manifest to be read from disk after
 		the build scripts have completed.
 		May be supplied multiple times.
+		See *READ-IN FILES* for details.
 
 	*-n*
 		Interpret _SUBNAME_ as the full package name.
@@ -863,6 +864,7 @@ RPM-specific environment variables are set:
 - *RPM_PACKAGE_RELEASE*: Rpm release of the source package
 - *RPM_SOURCE_DIR*: The source directory of the package
 - *RPM_SPECPARTS_DIR*: The directory of dynamically generated spec parts
+- *RPM_READINS_DIR*: The directory of *READ-IN FILES*
 
 Note: many of these have macro counterparts which may seem more convenient
 and consistent with the rest of the spec, but one should always use the
@@ -948,6 +950,21 @@ script.
 
 	Properties: Ot
 
+# READ-IN FILES
+Some sections, such as *%files* manifests or transaction scriptlets, can have (a
+part of) their contents generated on-the-fly during the build, written to a file
+on disk and finally read in using the *-f* _FILE_ option.
+
+The file(s) should be written into the *$RPM_READINS_DIR* directory (created at
+the start of the build automatically) by a build scriptlet and referred to by a
+_FILE_ relative to that directory.
+
+For backwards compatibility, _FILE_ can also be absolute (with the leading */*).
+If a relative _FILE_ is not found, the *%{builddir}/%{?buildsubdir}* directory
+is used in place of *$RPM_READINS_DIR* for the lookup.
+
+Added: 6.2.0
+
 # CONDITIONALS
 The spec supports several conditionals which can appear anywhere in the
 spec, and can nest.
@@ -1007,7 +1024,8 @@ _EXPRESSION_
 	See *Expression expansion* in *rpm-macros*(7).
 
 _FILE_
-	A relative filename, typically just the basename component.
+	A relative filename, typically just the basename component, unless
+	stated otherwise.
 
 _LANG_
 	*locale*(7) language name.

--- a/macros.in
+++ b/macros.in
@@ -780,7 +780,8 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
   RPM_OS=\"%{_os}\"\
   RPM_BUILD_NCPUS=\"%{_smp_build_ncpus}\"\
   RPM_SPECPARTS_DIR=\"%{specpartsdir}\"\
-  export RPM_SOURCE_DIR RPM_BUILD_DIR RPM_OPT_FLAGS RPM_ARCH RPM_OS RPM_BUILD_NCPUS RPM_SPECPARTS_DIR RPM_LD_FLAGS\
+  RPM_READINS_DIR=\"%{readinsdir}\"\
+  export RPM_SOURCE_DIR RPM_BUILD_DIR RPM_OPT_FLAGS RPM_ARCH RPM_OS RPM_BUILD_NCPUS RPM_SPECPARTS_DIR RPM_READINS_DIR RPM_LD_FLAGS\
   RPM_DOC_DIR=\"%{_docdir}\"\
   export RPM_DOC_DIR\
   RPM_PACKAGE_NAME=\"%{NAME}\"\

--- a/macros.in
+++ b/macros.in
@@ -145,6 +145,10 @@
 %__systemd_sysusers	@__SYSTEMD_SYSUSERS@
 #%__systemd_sysusers	%{_rpmconfigdir}/sysusers.sh
 
+# location of debuginfo manifest files, comment out to revert to original path
+#%_debuginfo_manifests_dir  %{builddir}/%{?buildsubdir}
+%_debuginfo_manifests_dir   %{readinsdir}
+
 #
 #	Path to script that creates debug symbols in a /usr/lib/debug
 #	shadow tree.
@@ -168,6 +172,7 @@
     %{?_find_debuginfo_dwz_opts} \\\
     %{?_find_debuginfo_opts} \\\
     %{?_find_debuginfo_vendor_opts} \\\
+    @FIND_DEBUGINFO_OPTS@ \\\
     %{?_debugsource_packages:-S debugsourcefiles.list} \\\
     "%{builddir}/%{?buildsubdir}"\
 %{nil}

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -57,8 +57,11 @@ RUN dnf -y install \
   scd2html \
   sequoia-sq \
   nss-altfiles
+
 # If updates to specific packages are needed, do it here
-RUN dnf -y --enablerepo=updates install "rpm-sequoia-devel >= 1.10.2-4"
+RUN dnf -y --enablerepo=updates install \
+    "debugedit >= 5.3" \
+    "rpm-sequoia-devel >= 1.10.2-4"
 
 # Install some development tools
 RUN dnf -y install \

--- a/tests/data/SPECS/readin.spec
+++ b/tests/data/SPECS/readin.spec
@@ -1,0 +1,49 @@
+%bcond setup 0
+
+Name:           readin
+Version:        1.0
+Release:        1
+Summary:        Simple read-in test package
+Group:		Testing
+License:        GPL
+BuildArch:	noarch
+Source:		source-noroot.tar.gz
+
+%description
+%{summary}
+
+%if %{with setup}
+%prep
+%setup -C
+%endif
+
+%build
+cat << EOF > file1
+#!/bin/sh
+echo yay
+EOF
+chmod a+x file1
+cp file1 file2
+
+cat << EOF > $RPM_READINS_DIR/manifest1.list
+/opt/bin/file1
+EOF
+
+cat << EOF > manifest2.list
+/opt/bin/file2
+EOF
+
+cat << EOF > %{readinsdir}/post.sh
+#!/bin/sh
+echo post
+EOF
+chmod a+x $RPM_READINS_DIR/post.sh
+
+%install
+mkdir -p $RPM_BUILD_ROOT/opt/bin
+cp file1 file2 $RPM_BUILD_ROOT/opt/bin/
+
+%post -f post.sh
+
+%files -f manifest1.list -f manifest2.list
+%defattr(-,root,root,-)

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -489,6 +489,7 @@ runroot find /build/BUILD|sort
 /build/BUILD/simple-1.0-build/BUILDROOT/opt
 /build/BUILD/simple-1.0-build/BUILDROOT/opt/bin
 /build/BUILD/simple-1.0-build/BUILDROOT/opt/bin/simple
+/build/BUILD/simple-1.0-build/READINS
 /build/BUILD/simple-1.0-build/SPECPARTS
 /build/BUILD/simple-1.0-build/rpmbuild.env
 /build/BUILD/simple-1.0-build/simple
@@ -509,6 +510,7 @@ runroot find /build/BUILD|sort
 /build/BUILD/simple-1.0-build/BUILDROOT/opt
 /build/BUILD/simple-1.0-build/BUILDROOT/opt/bin
 /build/BUILD/simple-1.0-build/BUILDROOT/opt/bin/simple
+/build/BUILD/simple-1.0-build/READINS
 /build/BUILD/simple-1.0-build/SPECPARTS
 /build/BUILD/simple-1.0-build/rpmbuild.env
 /build/BUILD/simple-1.0-build/simple-1.0
@@ -4185,4 +4187,15 @@ runroot rpmbuild -bb --quiet --target x86_64 --with hello32 \
 [warning: Binaries not matching package arch (hello-1.0-1.x86_64):
     /usr/local/bin/hello (ELF 32-bit)
 ])
+RPMTEST_CLEANUP
+
+RPMTEST_SETUP_RW([rpmbuild read-in files])
+AT_KEYWORDS([build])
+RPMTEST_CHECK([
+rpmbuild -bb --quiet ${RPMDATA}/SPECS/readin.spec
+rpmbuild -bb --quiet --with setup ${RPMDATA}/SPECS/readin.spec
+],
+[0],
+[],
+[ignore])
 RPMTEST_CLEANUP

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -626,6 +626,44 @@ hello-2.0/COPYING
 hello-2.0/FAQ
 hello-2.0/Makefile
 hello-2.0/README
+hello-2.0/hello
+hello-2.0/hello.c
+],
+[])
+
+# check that read-in files are in the expected location
+RPMTEST_CHECK([
+runroot find /build/BUILD/hello-2.0-build/READINS | sort
+],
+[0],
+[/build/BUILD/hello-2.0-build/READINS
+/build/BUILD/hello-2.0-build/READINS/debugfiles.list
+/build/BUILD/hello-2.0-build/READINS/debuglinks.list
+/build/BUILD/hello-2.0-build/READINS/debugsources.list
+/build/BUILD/hello-2.0-build/READINS/elfbins.list
+],
+[])
+
+# revert to the original debuginfo manifest location
+RPMTEST_CHECK([
+runroot --chdir hello-2.0 rpmbuild -bb --build-in-place \
+    --define "_debuginfo_manifests_dir %{builddir}/%{?buildsubdir}" \
+    ../hello.spec
+],
+[0],
+[ignore],
+[ignore])
+
+# check that read-in files are in the expected location
+RPMTEST_CHECK([
+runroot find hello-2.0 | sort
+],
+[0],
+[hello-2.0
+hello-2.0/COPYING
+hello-2.0/FAQ
+hello-2.0/Makefile
+hello-2.0/README
 hello-2.0/debugfiles.list
 hello-2.0/debuglinks.list
 hello-2.0/debugsources.list


### PR DESCRIPTION
Please see the commit messages for details.

Fixes: #4268, #3658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generated read-in manifest files during package builds.
  * Manifest files can be resolved from build directories, configured search paths, or absolute paths.
  * Added the `RPM_READINS_DIR` environment variable and `%{readinsdir}` macro.
  * Improved compatibility with newer `find-debuginfo` versions.

* **Documentation**
  * Documented read-in file locations, lookup behavior, and configuration options.

* **Tests**
  * Added coverage for generated manifests, alternate locations, and builds with or without setup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->