### PR TITLE
scripts: add /usr/local/lib{64} to bare-dir standard-RPATH patterns

### DIFF
--- a/scripts/check-rpaths-worker
+++ b/scripts/check-rpaths-worker
@@ -131,9 +131,9 @@ function check_rpath() {
 		(/*\$PLATFORM*|/*\$\{PLATFORM\}*|/*\$LIB*|/*\$\{LIB\}*)
 		    badness=0;;
 	    	
-	        (/lib|/usr/lib|/usr/X11R6/lib)
+	        (/lib|/usr/lib|/usr/X11R6/lib|/usr/local/lib)
 		    badness=1;;
-	        (/lib64|/usr/lib64|/usr/X11R6/lib64)
+	        (/lib64|/usr/lib64|/usr/X11R6/lib64|/usr/local/lib64)
 		    badness=1;;
 	    	
 	        (.*)


### PR DESCRIPTION
Fix check-rpaths-worker: add missing /usr/local/lib and /usr/local/lib64 to bare-directory patterns

### Problem
 When a binary's RPATH contains /usr/local/lib or /usr/local/lib64 (without a trailing slash), check-rpaths-worker misclassifies it as badness=2 ("invalid RPATH — neither absolute nor relative — SECURITY risk", 
 error code 0x0002). This is misleading because:

 1. The path is absolute — the error message is factually wrong.
 2. The same directory with a trailing slash (/usr/local/lib/) or subdirectory (/usr/local/lib/foo) is correctly classified as badness=0 (approved) since the wildcard pattern /* matches them.
 3. The analogous bare directories /usr/lib, /usr/lib64, /usr/X11R6/lib, /usr/X11R6/lib64 are already correctly classified as badness=1 (standard RPATH, minor issue 0x0001).

### Root Cause
 The case statement in check_rpath() has two sets of patterns for standard library directories:

 - With /* (approved / badness=0): includes /usr/local/lib/* and /usr/local/lib64/*
 - Bare (standard / badness=1): was missing /usr/local/lib and /usr/local/lib64

 A bare /usr/local/lib therefore fell through to the catch-all (*) badness=2.

### Fix
 Add /usr/local/lib and /usr/local/lib64 to the bare badness=1 patterns, consistent with /usr/lib and /usr/lib64.

Fixes: #4266