### PR TITLE
Fix argvSplitString() dropping a trailing empty field

### DIFF
--- a/include/rpm/argv.h
+++ b/include/rpm/argv.h
@@ -175,10 +175,14 @@ typedef rpmFlags argvFlags;
 
 /** \ingroup rpmargv
  * Split a string into an argv array.
+ * The result has one field per separator occurrence plus one, ie empty
+ * fields are preserved, leading and trailing ones alike, and an empty
+ * string splits into a single empty field. Pass ARGV_SKIPEMPTY to omit
+ * empty fields instead.
  * @param str		string arg to split
  * @param seps		separator characters
  * @param flags		flags to control behavior
- * @return		argv array
+ * @return		argv array, NULL on NULL str or seps
  */
 RPM_PUBLIC_API
 ARGV_t argvSplitString(const char * str, const char * seps, argvFlags flags);

--- a/lib/transaction.cc
+++ b/lib/transaction.cc
@@ -1233,7 +1233,7 @@ static ARGI_t initPkgDigests(FD_t fd)
 {
     ARGI_t ids = NULL;
     char *digests = rpmExpand("%{?_pkgverify_digests}", NULL);
-    ARGV_t vals = argvSplitString(digests, ":", 0);
+    ARGV_t vals = argvSplitString(digests, ":", ARGV_NONE);
 
     for (ARGV_t v = vals; v && *v; v++) {
 	uint32_t alg = atoi(*v);

--- a/rpmio/argv.cc
+++ b/rpmio/argv.cc
@@ -198,7 +198,8 @@ ARGV_t argvSplitString(const char * str, const char * seps, argvFlags flags)
 
     argv = (ARGV_t)xmalloc( (argc + 1) * sizeof(*argv));
 
-    for (c = 0, s = dest; s < t; s+= strlen(s) + 1) {
+    /* Final field starts at t when empty: str empty or ends with a separator */
+    for (c = 0, s = dest; s <= t; s+= strlen(s) + 1) {
 	if (*s == '\0' && (flags & ARGV_SKIPEMPTY))
 	    continue;
 	argv[c] = xstrdup(s);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,7 +63,7 @@ foreach(at ${TESTSUITE_AT})
 endforeach()
 
 set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint readpkgnullts rpmdig
-	      importkey oldtxn)
+	      importkey oldtxn argvcheck)
 foreach(prg ${TESTPROGS})
 	add_executable(${prg} EXCLUDE_FROM_ALL ${prg}.c)
 	target_link_libraries(${prg} PRIVATE librpm)

--- a/tests/argvcheck.c
+++ b/tests/argvcheck.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <rpm/argv.h>
+
+static const char *flagname(argvFlags flags)
+{
+    return (flags & ARGV_SKIPEMPTY) ? "ARGV_SKIPEMPTY" : "ARGV_NONE";
+}
+
+static void dump(const char *label, const char **av, int n)
+{
+    fprintf(stderr, "  %s (%d):", label, n);
+    for (int i = 0; i < n; i++)
+	fprintf(stderr, " \"%s\"", av[i]);
+    fprintf(stderr, "\n");
+}
+
+static int check(const char *str, argvFlags flags,
+		 const char **want, int nwant)
+{
+    ARGV_t argv = argvSplitString(str, ",", flags);
+    int n = argvCount(argv);
+    int rc = (n != nwant);
+
+    for (int i = 0; !rc && i < n; i++)
+	rc = (strcmp(argv[i], want[i]) != 0);
+
+    if (rc) {
+	fprintf(stderr, "argvSplitString(\"%s\", \",\", %s) mismatch:\n",
+		str, flagname(flags));
+	dump("got ", (const char **)argv, n);
+	dump("want", want, nwant);
+    }
+    argvFree(argv);
+    return rc;
+}
+
+int main(void)
+{
+    const char *none[] = { NULL };
+    const char *empty[] = { "" };
+    const char *emptyx2[] = { "", "" };
+    const char *a_empty[] = { "a", "" };
+    const char *ab[] = { "a", "b" };
+    const char *a_b[] = { "a", "", "b" };
+    const char *a[] = { "a" };
+    int rc = 0;
+
+    /* ARGV_NONE preserves empty fields, trailing ones included */
+    rc |= check("",     ARGV_NONE, empty,	1);
+    rc |= check(",",    ARGV_NONE, emptyx2,	2);
+    rc |= check("a,",   ARGV_NONE, a_empty,	2);
+    rc |= check("a,b",  ARGV_NONE, ab,		2);
+    rc |= check("a,,b", ARGV_NONE, a_b,		3);
+
+    /* ARGV_SKIPEMPTY drops them all, unchanged by the above */
+    rc |= check("",     ARGV_SKIPEMPTY, none,	0);
+    rc |= check(",",    ARGV_SKIPEMPTY, none,	0);
+    rc |= check("a,",   ARGV_SKIPEMPTY, a,	1);
+    rc |= check("a,,b", ARGV_SKIPEMPTY, ab,	2);
+
+    return rc;
+}

--- a/tests/rpmio.at
+++ b/tests/rpmio.at
@@ -2,6 +2,16 @@
 
 AT_BANNER([I/O])
 
+RPMTEST_SETUP([argvSplitString empty field handling])
+AT_KEYWORDS([api argv])
+RPMTEST_CHECK([
+argvcheck
+],
+[0],
+[],
+[])
+RPMTEST_CLEANUP
+
 # test too unstable for production
 #RPMTEST_SETUP_RW([SIGPIPE from --pipe])
 #AT_KEYWORDS([signals])


### PR DESCRIPTION
`argvSplitString()` with `ARGV_NONE` drops a trailing empty field:

    argvSplitString("",   ",", ARGV_NONE)  ->  []      expected [""]
    argvSplitString("a,", ",", ARGV_NONE)  ->  ["a"]   expected ["a", ""]
    argvSplitString(",",  ",", ARGV_NONE)  ->  [""]    expected ["", ""]

Interior empty fields are already preserved (`"a,,b"` -> `["a", "", "b"]`), so
this looks inconsistent rather than intentional.

### Origin

The emit loop bound has been `s < t` since argv.c was added in 6278739895
(2002), where empty fields were skipped unconditionally and the bound was
therefore unobservable. 35052b9623 (2010) made skipping conditional on
`ARGV_SKIPEMPTY`, with the stated intent that the default should

> make a "real" split, including empty strings

but left the bound alone, so the trailing field has been dropped ever since.

### Fix

`s < t` -> `s <= t`. The final field begins exactly at `t` when it is empty,
and `argc` (1 + separator count) already sizes the allocation for it, so no
other change is needed. `ARGV_SKIPEMPTY` output is unaffected.

### Blast radius

Only two in-tree callers pass `ARGV_NONE`:

- `initPkgDigests()` - an unset `%{?_pkgverify_digests}` now splits to one
  empty field rather than none, discarded by the existing `atoi()` guard.
- `lookup_field_in_file()` - unchanged for well-formed entries, whose fgets
  chunk ends in a newline rather than a separator. A malformed entry with
  exactly two colons ending in one ("name:x:", no gid) previously yielded too
  few fields and was skipped, and now matches with an empty result.

Everything else passes `ARGV_SKIPEMPTY`, the `argvSplit()` wrapper included.

### On API policy

CODING_STYLE.md says public API changes belong in major bumps, and this is
6.1.90. I have treated the trailing-field drop as a bug against 35052b9623's
stated intent rather than as contract, but that call is yours - happy to rework
it behind a new flag, or hold it for the next major, if you would rather the
existing behaviour stay put.

Also adds an `argvcheck` testprog pinning both flag modes, and documents the
empty-field contract in the public header, which never stated it.

### Status

Further work needed before inclusion: I have not yet run `make ci` locally, so
I am watching the PR checks. Will update once it is green.
