### PR TITLE
rpmrc: Fix missing declaration of personality() on sparc*-linux

### DIFF
--- a/lib/rpmrc.cc
+++ b/lib/rpmrc.cc
@@ -45,6 +45,10 @@
 
 #include "debug.h"
 
+#if defined(__linux__) && defined(__sparc__)
+#include <sys/personality.h>
+#endif
+
 using wrlock = std::unique_lock<std::shared_mutex>;
 using rdlock = std::shared_lock<std::shared_mutex>;
 
@@ -1225,7 +1229,6 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 	    #define PERS_LINUX_32BIT	0x00800000
 	    #define PERS_LINUX32	0x00000008
 
-	    extern int personality(unsigned long);
 	    int oldpers;
 	    
 	    oldpers = personality(PERS_LINUX_32BIT);


### PR DESCRIPTION
Fixes the following link failure on sparc*-linux which occurs due to name mangling of the personality() symbol name when mixing C and C++:

/usr/bin/sparc64-linux-gnu-ld.bfd: ../lib/librpm.so.10.8.0: undefined reference to `personality(unsigned long)'
collect2: error: ld returned 1 exit status

To fix the failure, remove the external declaration of personality() and include <sys/personality.h> instead which properly wrap C symbols with 'extern "C"' to prevent symbol name mangling.