### PR TITLE
Prevent command injection via rpmbuild -t

### DIFF
--- a/build/parseSpec.cc
+++ b/build/parseSpec.cc
@@ -1311,7 +1311,7 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
     /* Set up a new Spec structure with no packages. */
     spec = newSpec();
 
-    spec->specFile = rpmGetPath(specFile, NULL);
+    spec->specFile = rpmCleanPath(xstrdup(specFile));
     pushOFI(spec, spec->specFile);
     /* If explicit --buildroot was passed, grab hold of it */
     if (buildRoot)

--- a/tests/data/misc/CVE-2026-78367.py
+++ b/tests/data/misc/CVE-2026-78367.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+# Generate a PoC archive for CVE-2026-78367
+# Adapted from https://github.com/rpm-software-management/rpm/pull/4317
+
+import os, tarfile, io
+
+spec_content = b"""\
+Name: poc
+Version: 1.0
+Release: 1
+Summary: PoC for getTarSpec member-name injection
+License: MIT
+BuildArch: noarch
+
+%description
+%{summary}.
+
+%files
+"""
+
+member_name = (
+    "%{lua:io.open(os.getenv('RPM_POC_PATH'),'w')"
+    ":write('gotcha'):close()}"
+    ".spec"
+)
+
+with tarfile.open("evil.tar.gz", "w:gz") as tf:
+    info = tarfile.TarInfo(name=member_name)
+    info.size = len(spec_content)
+    tf.addfile(info, io.BytesIO(spec_content))

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -885,6 +885,27 @@ runroot rpm -q --qf "%{packager}\n" /build/SRPMS/hello-2.0-1.src.rpm
 [])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP_RW([rpmbuild -ts <spec> (evil)])
+AT_KEYWORDS([build])
+
+runroot /data/misc/CVE-2026-78367.py
+
+RPMTEST_CHECK([
+runroot --setenv RPM_POC_PATH /tmp/gotcha \
+	rpmbuild --quiet -ts evil.tar.gz
+],
+[0],
+[],
+[])
+
+RPMTEST_CHECK([
+test -f $RPMTEST/tmp/gotcha
+],
+[1],
+[],
+[])
+RPMTEST_CLEANUP
+
 # weird filename survival test
 RPMTEST_SETUP_RW([rpmbuild package with weird filenames])
 AT_KEYWORDS([build])

--- a/tools/rpmbuild.cc
+++ b/tools/rpmbuild.cc
@@ -369,6 +369,8 @@ static int isSpecFile(const char * specfile)
 static char * getTarSpec(const char *arg)
 {
     char *specFile = NULL;
+    char *specDir = NULL;
+    char *specBase = NULL;
     char *specFinal = NULL;
     const char **spec;
     char tarbuf[BUFSIZ];
@@ -418,9 +420,11 @@ static char * getTarSpec(const char *arg)
     if (!gotspec) {
     	rpmlog(RPMLOG_ERR, _("Failed to read spec file from %s\n"), arg);
     } else {
+	specDir = rpmExpand("%{_specdir}", NULL);
+	specBase = basename(tarbuf);
 	/* remove trailing \n */
-	tarbuf[strlen(tarbuf)-1] = '\0';
-	specFinal = rpmExpand("%{_specdir}/%{basename:", tarbuf, "}", NULL);
+	specBase[strlen(specBase)-1] = '\0';
+	rasprintf(&specFinal, "%s/%s", specDir, specBase);
 	if (rename(specFile, specFinal)) {
 	    rpmlog(RPMLOG_ERR, _("Failed to rename %s to %s: %m\n"),
 		    specFile, specFinal);
@@ -431,6 +435,7 @@ static char * getTarSpec(const char *arg)
 
 exit:
     free(specFile);
+    free(specDir);
     Fclose(fd);
     return specFinal;
 }


### PR DESCRIPTION
When running in -t mode, the spec member name in the passed tarball will get macro-expanded twice: first when constructing the target filename in getTarSpec() and then in parseSpec(). This allows a crafted tarball to execute arbitrary code when the user just runs rpmbuild -ts or similar.

Luckily, neither of these expansions is necessary, they are only done as a convenience and/or historical artifact. The former in getTarSpec() was only added recently via commit dfffedb5ebe46e039c0313b3d2fb939dfc63efd6 and can easily be split into a basename(3) call so that the member name is not included in the expansion, effectively reverting that part of the original commit. The latter seems to be only used as a way to normalize the spec filename stored in the rpmSpec struct and can be replaced by a mere rpmCleanPath().

Make both changes and add a corresponding test. The included archive was generated with the following Python 3 code, adapted from the original report #4314:

    import os, tarfile, io

    spec_content = b"""\
    Name: poc
    Version: 1.0
    Release: 1
    Summary: PoC for getTarSpec member-name injection
    License: MIT
    BuildArch: noarch

    %description
    %{summary}.

    %files
    """

    member_name = (
        "%{lua:io.open(os.getenv('RPM_POC_PATH'),'w')"
        ":write('gotcha'):close()}"
        ".spec"
    )

    with tarfile.open("CVE-2026-78367.tar.gz", "w:gz") as tf:
        info = tarfile.TarInfo(name=member_name)
        info.size = len(spec_content)
        tf.addfile(info, io.BytesIO(spec_content))

Fixes: CVE-2026-78367, #4314