### PR TITLE
Enable updates in the test-suite image

### DIFF
--- a/tests/Containerfile.fedora
+++ b/tests/Containerfile.fedora
@@ -5,10 +5,6 @@ MAINTAINER rpm-maint@lists.rpm.org
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
 RUN rpm --quiet -q fedora-repos-modular && rpm -e fedora-repos-modular ||:
 RUN sed -i -e "s:^enabled=.$:enabled=0:g" /etc/yum.repos.d/*openh264.repo
-# updates disabled for a stable environment
-RUN sed -i -e "s:^enabled=.$:enabled=0:g" /etc/yum.repos.d/*updates*.repo
-# dummy for controlling per-repo gpgcheck via Semaphore setup
-RUN sed -i -e "s:^gpgcheck=.$:gpgcheck=1:g" /etc/yum.repos.d/*.repo
 RUN dnf -y install \
   autoconf \
   bubblewrap \


### PR DESCRIPTION
Update repositories have been disabled in the test-suite image to have a stable base against which tests run, but this is based on the false assumption that the base image (currently fedora:44) never changes. It does get updated from time to time, and then we end up *downgrading* a whole bunch of stuff when we install our own dependencies with updates disable.  So we end up with this bizarre mixture that nobody is expected to use or test, and if it breaks we can't even complain to anybody because this mixture is just boinkers.

The most recent breakage is test-suite blowing up with messages like:

    ImportError: /usr/local/lib64/librpm.so.10: undefined symbol: _ZNSt8__format15__do_vformat_toIcLj1EEENS_10_Sink_iterIT_EES3_St17basic_string_viewIS2_St11char_traitsIS2_EERSt20basic_format_contextIS3_S2_E, version GLIBCXX_3.4.35

The only surprise here is that breakages like these haven't been more common.

While at it, drop the Semaphore CI remnant as well. We haven't been there for years.