### PR TITLE
Add statvfs(3) support to the Lua posix module

### DIFF
--- a/docs/man/rpm-lua.7.scd
+++ b/docs/man/rpm-lua.7.scd
@@ -831,6 +831,39 @@ calls refer to the system manual, eg *access*(3) for *posix.access()*.
 	end
 	```
 
+*statvfs(*_PATH_ [, _SELECTOR_]*)*
+	Get filesystem *statvfs*(3) information about the filesystem at _PATH_.
+	_PATH_ can be either a mount point or a file within the filesystem.
+	The optional _SELECTOR_ may be one of
+	- *bsize*
+	- *blocks*
+	- *bfree*
+	- *bavail*
+	- *favail*
+	- *ffree*
+	- *files*
+	- *flag*
+	- *frsize*
+	- *fsid*
+	- *namemax*
+
+	If omitted, a table with all these fields is returned.
+
+	*flag* is a table with the following mount flag names as keys,
+	and booleans as values:
+	- *rdonly*
+	- *nosuid*
+
+	Example:
+	```
+	print(posix.statvfs('/', 'bavail'))
+
+	st = posix.statvfs('/srv')
+	if st.flag.rdonly == true then
+	    ...
+	end
+	```
+
 *symlink(*_OLDPATH_, _NEWPATH_*)*
 	Create a symbolic link at _NEWPATH_ to _OLDPATH_.
 	See also *symlink*(2).

--- a/rpmio/lposix.cc
+++ b/rpmio/lposix.cc
@@ -22,6 +22,7 @@
 #include <sys/times.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
+#include <sys/statvfs.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
@@ -709,6 +710,64 @@ static int Pstat(lua_State *L)			/** stat(path,[selector]) */
 	return doselection(L, 2, Sstat, Fstat, &s);
 }
 
+struct flagname {
+    int flag;
+    const char *name;
+};
+
+static const struct flagname statvfsFlags[] = {
+    { ST_RDONLY,	"rdonly" },
+    { ST_NOSUID,	"nosuid" },
+    { 0,		NULL },
+};
+
+static int Fstatvfs(lua_State *L, int i, const void *data)
+{
+    const struct statvfs *buf=(const struct statvfs *)data;
+    switch (i) {
+    case 0: lua_pushinteger(L, (lua_Integer)buf->f_bsize); break;
+    case 1: lua_pushinteger(L, (lua_Integer)buf->f_frsize); break;
+    case 2: lua_pushinteger(L, (lua_Integer)buf->f_blocks); break;
+    case 3: lua_pushinteger(L, (lua_Integer)buf->f_bfree); break;
+    case 4: lua_pushinteger(L, (lua_Integer)buf->f_bavail); break;
+    case 5: lua_pushinteger(L, (lua_Integer)buf->f_files); break;
+    case 6: lua_pushinteger(L, (lua_Integer)buf->f_ffree); break;
+    case 7: lua_pushinteger(L, (lua_Integer)buf->f_favail); break;
+    case 8: lua_pushinteger(L, (lua_Integer)buf->f_fsid); break;
+    case 9:
+	    const struct flagname *fl;
+	    lua_newtable(L);
+	    for (fl = statvfsFlags; fl->name != NULL; fl++) {
+		lua_pushstring(L, fl->name);
+		lua_pushboolean(L, (buf->f_flag & fl->flag));
+		lua_settable(L, -3);
+	    }
+	    break;
+    case 10:lua_pushinteger(L, (lua_Integer)buf->f_namemax); break;
+    default: return 0;
+    }
+    return 1;
+}
+
+static const char *const Sstatvfs[] =
+{
+    "bsize",   "frsize", "blocks", "bfree", "bavail",
+    "files",   "ffree",  "favail", "fsid",  "flag",
+    "namemax", NULL
+};
+
+static int Pstatvfs(lua_State *L)		/** statvfs(path,[selector]) */
+{
+	const char *path = luaL_checkstring(L, 1);
+	struct statvfs buf;
+
+	if (statvfs(path, &buf) == -1) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	return doselection(L, 2, Sstatvfs, Fstatvfs, &buf);
+}
 
 static int Puname(lua_State *L)			/** uname([string]) */
 {
@@ -851,6 +910,7 @@ static const luaL_Reg R[] =
 	{"setuid",		Psetuid},
 	{"sleep",		Psleep},
 	{"stat",		Pstat},
+	{"statvfs",		Pstatvfs},
 	{"symlink",		Psymlink},
 	{"sysconf",		Psysconf},
 	{"times",		Ptimes},

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1341,6 +1341,29 @@ rpm.call("test", "foo", 6, 29 / 4)
 ])
 RPMTEST_CLEANUP
 
+RPMTEST_SETUP([lua statvfs])
+AT_KEYWORDS([macros lua])
+RPMTEST_CHECK([
+rpm --eval '%{lua:st=posix.statvfs("/"); print(st.bsize == math.tointeger(rpm.expand("%(stat -f -c%s /)")))}' \
+    --eval '%{lua:print(posix.statvfs("/", "namemax") == math.tointeger(posix.pathconf("/", "name_max")))}'
+],
+[0],
+[true
+true
+],
+[])
+
+RPMTEST_CHECK([
+# These appear to be fs/environment specific, but we know these for the
+# test-suite: root is mounted read-only and suid is not restricted.
+rpm --eval '%{lua:fl=posix.statvfs("/", "flag"); print(fl.nosuid, fl.rdonly)}'
+],
+[0],
+[false	true
+],
+[])
+RPMTEST_CLEANUP
+
 RPMTEST_SETUP([%define + %undefine in nested levels 1])
 AT_KEYWORDS([macros define undefine])
 RPMTEST_CHECK([


### PR DESCRIPTION
Based on initial patch by Bernhard Rosenkränzer, return the "flag" value in a meaningfully testable form instead of a raw integer and add documentation and tests.

glibc supports many more flags than the two specified by POSIX but they'd need to be individually conditionalized, and these seem the most important from RPM POV...