### PR TITLE
Fix an ancient and embarrassing thinko in rasprintf()

### DIFF
--- a/rpmio/rpmstring.cc
+++ b/rpmio/rpmstring.cc
@@ -79,8 +79,8 @@ int rvasprintf(char **strp, const char *fmt, va_list ap)
     n = vsnprintf(NULL, 0, fmt, aq);
     va_end(aq);
 
-    if (n >= -1) {
-	size_t nb = n + 1;
+    if (n >= 0) {
+	size_t nb = (size_t)n + 1;
 	p = (char *)xmalloc(nb);
 	va_copy(aq, ap);
         n = vsnprintf(p, nb, fmt, aq);


### PR DESCRIPTION
vsnprintf() returns -1 on error, so that's kinda our cue to not proceed further.

This buggy asprintf() variant was added in 2008. I guess vsnprintf() doesn't return errors too often.

While we're here, fix a (rather theoretical) overflow of the signed int if output size is INT_MAX-1.
